### PR TITLE
Update main to only include non minified version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,10 +23,7 @@
     "README.md",
     "bower.json"
   ],
-  "main": [
-    "dist/angular-patternfly.js",
-    "dist/angular-patternfly.min.js"
-  ],
+  "main": "dist/angular-patternfly.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/patternfly/angular-patternfly.git"


### PR DESCRIPTION
Resolves https://github.com/patternfly/angular-patternfly/issues/27

This is similar to how the angular repos and jquery etc are structured. They deliver minified and unminified versions but only the unminified version are listed in main:

Angular:
"main": "./angular.js",
jQuery:
"main": "dist/jquery.js",