### PR TITLE
Updating patternfly reference impl to be a devDependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,15 +32,14 @@
     "url": "git://github.com/patternfly/angular-patternfly.git"
   },
   "dependencies": {
-    "angular": "1.2.25 - 1.3.*",
-    "patternfly": "~2.0.0",
-    "c3": "~0.4.10"
+    "angular": "1.2.25 - 1.3.*"
   },
   "devDependencies": {
     "angular-animate": "1.2.25 - 1.3.*",
     "angular-mocks": "1.2.25 - 1.3.*",
     "angular-sanitize": "1.2.25 - 1.3.*",
     "angular-touch": "1.2.25 - 1.3.*",
-    "angular-route": "1.2.25 - 1.3.*"
+    "angular-route": "1.2.25 - 1.3.*",
+    "patternfly": "~2.0.0"
   }
 }


### PR DESCRIPTION
Angular-Patternfly is now being used in a ruby based project where they use they use the SASS version (https://github.com/patternfly/patternfly-sass) of the reference impl not the LESS version. 

Listing the LESS version as a dependency causes the library to automatically get pulled into their code base which means therubyracer to gets pulled in causing their code base to be slow. They would like to exclude the less version from getting pulled in so I am suggesting changing the patternfly reference impl to be a devDependency instead and then the projects can explicitly specify whether they want the LESS or SASS version of PF.