### PR TITLE
Fix #37 - Adding support for angular 1.4.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,15 +31,13 @@
     "type": "git",
     "url": "git://github.com/patternfly/angular-patternfly.git"
   },
-  "dependencies": {
-    "angular": "1.3.*"
-  },
   "devDependencies": {
-    "angular-animate": "1.3.*",
-    "angular-mocks": "1.3.*",
-    "angular-sanitize": "1.3.*",
-    "angular-touch": "1.3.*",
-    "angular-route": "1.3.*",
+    "angular": "1.3.0 - 1.4.*",
+    "angular-animate": "1.3.0 - 1.4.*",
+    "angular-mocks": "1.3.0 - 1.4.*",
+    "angular-sanitize": "1.3.0 - 1.4.*",
+    "angular-touch": "1.3.0 - 1.4.*",
+    "angular-route": "1.3.0 - 1.4.*",
     "lodash": "3.x",
     "patternfly": "2.1.0"
   }


### PR DESCRIPTION
Adding support for angular 1.4.x and also changing angular to just be a devDependency since products seem the be specifying their own version anyway and having the listed dependency is causing problems with projects who are trying to consume angular-patternfly via rails-assets since they can't override the version like you can do with bower resolutions.