### PR TITLE
Tagging for 2.2.1. SimpleFilter bug fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-patternfly",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "authors": [
     "Red Hat"
   ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Red Hat",
   "name": "angular-patternfly",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Angular extension of the PatternFly project.",
   "homepage": "https://github.com/patternfly/angular-patternfly",
   "dependencies": {},


### PR DESCRIPTION
This is needed for manageIQ so they can consume the filter fix.