### PR TITLE
Example Pages: Charts & Cards

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,6 +62,12 @@ module.exports = function (grunt) {
           dest: 'dist/docs',
           expand: true
         },
+        examples: {
+          cwd: 'examples/',
+          src: ['*.html', '*.js'],
+          dest: 'dist/docs/examples',
+          expand: true
+        },
         styles: {
           cwd: 'styles/',
           src: ['*.css', '!*.min.css'],
@@ -213,7 +219,7 @@ module.exports = function (grunt) {
           tasks: ['eslint']
         },
         all: {
-          files: ['Gruntfile.js', 'src/**/*.js', 'src/**/*.html', 'styles/**/*.css'],
+          files: ['Gruntfile.js', 'src/**/*.js', 'src/**/*.html', 'styles/**/*.css', 'examples/**/*.html', 'examples/**/*.js'],
           tasks: ['build'],
           options: {
             livereload: true

--- a/examples/cards-controller.js
+++ b/examples/cards-controller.js
@@ -1,0 +1,122 @@
+angular.module( 'AngularPatternflyExamples').controller( 'ExampleCardsCtrl', function( $scope ) {
+
+  $scope.cardEventsFooterConfig = {
+    'iconClass' : 'fa fa-flag',
+    'text'      : 'View All Events',
+    'callBackFn': function () {
+      alert("Footer Callback Fn Called");
+    }
+  }
+
+  $scope.cardEventsFilterConfig = {
+    'filters' : [{label:'Last 30 Days', value:'30'},
+      {label:'Last 15 Days', value:'15'},
+      {label:'Today', value:'today'}],
+    'callBackFn': function (f) {
+      alert("Filter Callback Fn Called for '" + f.label + "' value = " + f.value);
+    },
+    'defaultFilter' : '1'
+  }
+
+  $scope.filterConfigHeader = {
+    'filters' : [{label:'Last 30 Days', value:'30'},
+      {label:'Last 15 Days', value:'15'},
+      {label:'Today', value:'today'}],
+    'callBackFn': function (f) {
+      alert("Header Filter Callback Fn Called for '" + f.label + "' value = " + f.value);
+    },
+    'position' : 'header'
+  }
+
+  $scope.actionBarConfig = {
+    'iconClass' : 'fa fa-plus-circle',
+    'text'      : 'Add New Cluster',
+    'callBackFn': function () {
+      alert("Footer Callback Fn Called");
+    }
+  }
+
+  var today = new Date();
+  var dates = ['dates'];
+  for (var d = 20 - 1; d >= 0; d--) {
+    dates.push(new Date(today.getTime() - (d * 24 * 60 * 60 * 1000)));
+  }
+
+  $scope.configVirtual = {
+    'chartId'      : 'virtualTrendsChart',
+    'layout'       : 'inline',
+    'trendLabel'   : 'Virtual Disk I/O',
+    'units'        : 'GB',
+    'tooltipType'  : 'percentage'
+  };
+
+  $scope.dataVirtual = {
+    'total': '250',
+    'xData': dates,
+    'yData': ['used', '90', '20', '30', '20', '20', '10', '14', '20', '25', '68', '44', '56', '78', '56', '67', '88', '76', '65', '87', '76']
+  };
+
+  $scope.configPhysical = {
+    'chartId'      : 'physicalTrendsChart',
+    'layout'       : 'inline',
+    'trendLabel'   : 'Physical Disk I/O',
+    'units'        : 'MHz',
+    'tooltipType'  : 'percentage'
+  };
+
+  $scope.dataPhysical = {
+    'total': '250',
+    'xData': dates,
+    'yData': ['used', '20', '20', '35', '20', '20', '87', '14', '20', '25', '28', '44', '56', '78', '56', '67', '88', '76', '65', '87', '16']
+  };
+
+  $scope.configMemory = {
+    'chartId'      : 'memoryTrendsChart',
+    'layout'       : 'inline',
+    'trendLabel'   : 'Memory Utilization',
+    'units'        : 'GB',
+    'tooltipType'  : 'percentage'
+  };
+
+  $scope.dataMemory = {
+    'total': '250',
+    'xData': dates,
+    'yData': ['used', '20', '20', '35', '70', '20', '87', '14', '95', '25', '28', '44', '56', '66', '16', '67', '88', '76', '65', '87', '56']
+  };
+
+  $scope.aggStatus = {
+    "title":"Nodes",
+    "count":793,
+    "href":"#",
+    "iconClass": "fa fa-shield",
+    "notifications":[
+      {
+        "iconClass":"pficon pficon-error-circle-o",
+        "count":4,
+        "href":"#"
+      },
+      {
+        "iconClass":"pficon pficon-warning-triangle-o",
+        "count":1
+      }
+    ]
+  };
+
+  $scope.aggTallStatus = {
+    "title":"Providers",
+    "count":2,
+    "notifications":[
+      {
+        "iconClass":"pficon pficon-error-circle-o",
+        "count":1,
+        "href":"#"
+      },
+      {
+        "iconClass":"pficon pficon-warning-triangle-o",
+        "count":1,
+        "href":"#"
+      }
+    ]
+  };
+});
+

--- a/examples/cards.html
+++ b/examples/cards.html
@@ -1,0 +1,127 @@
+<!doctype html>
+<html ng-app="AngularPatternflyExamples">
+<head>
+  <meta charset="utf-8"/>
+
+  <title>Angular-PatternFly Examples</title>
+
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="description" content=""/>
+  <meta name="viewport" content="width=device-width"/>
+
+  <!-- PatternFly Styles -->
+  <!-- Note: No other CSS files are needed regardless of what other JS packages located in patternfly/components that you decide to pull in -->
+  <link rel="stylesheet" href="/css/patternfly.css" />
+  <link rel="stylesheet" href="/css/patternfly-additions.css" />
+  <link rel="stylesheet" href="/css/angular-patternfly.css">
+
+  <link rel="stylesheet" href="/css/ng-docs.css">
+  <link rel="stylesheet" href="/css/examples.css">
+
+</head>
+
+<body>
+<!-- Javascript Libs -->
+<script src='/grunt-scripts/jquery.js'></script>
+<script src="/grunt-scripts/bootstrap.js"></script>
+<script src="/grunt-scripts/c3.js"></script>
+<script src="/grunt-scripts/d3.js"></script>
+
+<script src="/grunt-scripts/patternfly.js"></script>
+<script src="/grunt-scripts/bootstrap-combobox.js"></script>
+<script src="/grunt-scripts/bootstrap-datepicker.js"></script>
+<script src="/grunt-scripts/bootstrap-select.js"></script>
+<script src="/grunt-scripts/bootstrap-treeview.js"></script>
+
+<!-- Angular PatternFly -->
+<script src="/grunt-scripts/angular.js"></script>
+<script src="/grunt-scripts/angular-patternfly.js"></script>
+<script src="/grunt-scripts/ui-bootstrap-tpls.js"></script>
+
+<!-- Angular PatternFly Examples-->
+<script src="examples-module.js"></script>
+<script src="cards-controller.js"></script>
+
+
+<nav class="navbar navbar-default navbar-pf">
+  <div class="navbar-header">
+    <a class="navbar-brand" href="index.html">
+      <img class="pull-left" src="/img/logo-alt.svg" style="margin-top: 0px">
+      <span style="padding: 15px 20px 15px 0">ANGULAR PATTERNFLY EXAMPLES</span>
+    </a></div>
+  <div class="collapse navbar-collapse navbar-collapse-1">
+    <ul class="nav navbar-nav navbar-primary">
+      <li><a href="index.html">Charts</a></li>
+      <li class="active"><a href="cards.html">Cards</a></li>
+    </ul>
+  </div>
+</nav>
+
+<div ng-controller="ExampleCardsCtrl" class="examples-container">
+
+  <div class="row">
+    <div class="col-md-12">
+      <span class="examples-title-lg">Cards</span>
+      <span class="examples-title-sm">(pf-card)</span>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-3 text-center">
+      <h4>Events Card</h4>
+    </div>
+    <div class="col-md-6 text-center">
+      <h4>Multi-Trend Card</h4>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-3">
+      <div pf-card head-title="Events" sub-title="System Events" show-top-border="true"
+           footer="cardEventsFooterConfig" filter="cardEventsFilterConfig">
+        <ul style='list-style-type: none'>
+          <li>Info        - CPU chip installed
+          <li>Warning     - CPU chip is hot
+          <li>Error       - I should not be attracted to CPU chip
+          <li>Info        - CPU chip is dating Graphics Card
+        </ul>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div pf-card head-title="Performance" show-top-border="true"
+           filter="filterConfigHeader" footer="actionBarConfig">
+        <div pf-trends-chart config="configVirtual" chart-data="dataVirtual"></div>
+        <div pf-trends-chart config="configPhysical" chart-data="dataPhysical"></div>
+        <div pf-trends-chart config="configMemory" chart-data="dataMemory"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-12">
+      <span class="examples-title-lg">Aggregate Status Cards</span>
+      <span class="examples-title-sm">(pf-aggregate-status-card)</span>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-3 text-center">
+      <h4>Default</h4>
+    </div>
+    <div class="col-md-3 text-center">
+      <h4>Tall Layout</h4>
+    </div>
+    <div class="col-md-3 text-center">
+      <h4>Mini Layout</h4>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-3">
+      <div pf-aggregate-status-card status="aggStatus" show-top-border="true"></div>
+    </div>
+    <div class="col-md-3">
+      <div pf-aggregate-status-card status="aggTallStatus" show-top-border="true" alt-layout="true"></div>
+    </div>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/examples/charts-controller.js
+++ b/examples/charts-controller.js
@@ -1,0 +1,170 @@
+angular.module( 'AngularPatternflyExamples').controller( 'ExampleChartsCtrl', function( $scope ) {
+
+  $scope.donutErrConfig = {
+    'chartId': 'ChartErr',
+    'units': 'GB',
+    'thresholds':{'warning':'60','error':'90'},
+  };
+
+  $scope.donutErrData = {
+    'used': '950',
+    'total': '1000'
+  };
+
+  $scope.donutWarnConfig = {
+    'chartId': 'ChartWarn',
+    'units': 'GB',
+    'thresholds':{'warning':'60','error':'90'}
+  };
+
+  $scope.donutWarnData = {
+    'used': '650',
+    'total': '1000'
+  };
+
+  $scope.donutOkConfig = {
+    'chartId': 'ChartOk',
+    'units': 'GB',
+    'thresholds':{'warning':'60','error':'90'}
+  };
+
+  $scope.donutOkData = {
+    'used': '350',
+    'total': '1000'
+  };
+
+  $scope.donutConfig = {
+    'chartId': 'ChartDonut',
+    'units': 'GB',
+  };
+
+  $scope.donutData = {
+    'used': '750',
+    'total': '1000'
+  };
+
+  $scope.pctLabel = "percent";
+
+  $scope.sparkConfig = {
+    'chartId': 'exampleSparkline1',
+    'tooltipType': 'default'
+  };
+
+  $scope.sparkUsageConfig = {
+    'chartId': 'exampleSparkline2',
+    'tooltipType': 'usagePerDay'
+  };
+
+  $scope.sparkValueConfig = {
+    'chartId': 'exampleSparkline3',
+    'tooltipType': 'valuePerDay'
+  };
+
+  $scope.sparkPctConfig = {
+    'chartId': 'exampleSparkline4',
+    'tooltipType': 'percentage'
+  };
+
+  var today = new Date();
+  var dates = ['dates'];
+  for (var d = 20 - 1; d >= 0; d--) {
+    dates.push(new Date(today.getTime() - (d * 24 * 60 * 60 * 1000)));
+  }
+
+  $scope.sparkData = {
+    'total': '100',
+    'xData': dates,
+    'yData': ['used', '10', '20', '30', '20', '30', '10', '14', '20', '25', '68', '54', '56', '78', '56', '67', '88', '76', '65', '87', '76']
+  };
+  $scope.custChartHeight = 60;
+
+
+  $scope.trendsLgConfig = {
+    'chartId'      : 'exampleTrendsLgChart',
+    'title'        : 'Network Utilization Trends',
+    'layout'       : 'large',
+    'trendLabel'   : 'Virtual Disk I/O',
+    'valueType'    : 'actual',
+    'timeFrame'    : 'Last 15 Minutes',
+    'units'        : 'MHz',
+    'tooltipType'  : 'percentage'
+  };
+
+  $scope.trendsSmConfig = {
+    'chartId'      : 'exampleTrendsSmChart',
+    'title'        : 'Network Utilization Trends',
+    'layout'       : 'small',
+    'valueType'    : 'actual',
+    'timeFrame'    : 'Last 15 Minutes',
+    'units'        : 'MHz',
+    'tooltipType'  : 'percentage'
+  };
+
+  $scope.trendsCompactConfig = {
+    'chartId'      : 'exampleTrendsCompactChart',
+    'title'        : 'Disk I/O',
+    'layout'       : 'compact',
+    'valueType'    : 'actual',
+    'timeFrame'    : 'Last 15 Minutes',
+    'units'        : 'GB',
+    'tooltipType'  : 'percentage'
+  };
+
+  $scope.trendsInlineConfig = {
+    'chartId'      : 'exampleTrendsInlineChart',
+    'title'        : 'Disk I/O',
+    'layout'       : 'inline',
+    'trendLabel'   : 'Virtual Disk I/O',
+    'valueType'    : 'actual',
+    'timeFrame'    : 'Last 15 Minutes',
+    'units'        : 'GB',
+    'tooltipType'  : 'percentage'
+  };
+
+  $scope.utilCpuConfig = {
+    title: 'CPU',
+    units: 'Cores'
+  };
+
+  $scope.utilCpuDonutConfig = {
+    'chartId': 'UtilCpuChartDonut',
+    'units': 'Cores',
+    'thresholds':{'warning':'60','error':'90'}
+  };
+
+  $scope.utilCpuSparkConfig = {
+    'chartId': 'UtilCpuSparkline',
+    'tooltipType': 'default'
+  };
+
+  $scope.utilCpuData = {
+    used: 19,
+    total: 20,
+    xData: dates,
+    yData: ['used', '87', '20', '30', '20', '30', '2', '14', '20', '45', '68', '54', '56', '78', '56', '67', '88', '76', '65', '87', '76']
+  };
+
+  $scope.utilMemConfig = {
+    title: 'Memory',
+    units: 'GB'
+  };
+
+  $scope.utilMemDonutConfig = {
+    'chartId': 'UtilMemChartDonut',
+    'units': 'GB',
+    'thresholds':{'warning':'60','error':'90'}
+  };
+
+  $scope.utilMemSparkConfig = {
+    'chartId': 'UtilMemSparkline',
+    'tooltipType': 'default'
+  };
+
+  $scope.utilMemData = {
+    used: 76,
+    total: 100,
+    xData: dates,
+    yData: ['used', '10', '20', '30', '20', '30', '10', '14', '20', '25', '68', '54', '56', '78', '56', '67', '88', '76', '65', '87', '76']
+  };
+});
+

--- a/examples/examples-module.js
+++ b/examples/examples-module.js
@@ -1,0 +1,6 @@
+angular.module( 'AngularPatternflyExamples', [
+  'ui.bootstrap',
+  'patternfly',
+  'patternfly.charts']
+);
+

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html ng-app="AngularPatternflyExamples">
+<head>
+  <meta charset="utf-8"/>
+
+  <title>Angular-PatternFly Examples</title>
+
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <meta name="description" content=""/>
+  <meta name="viewport" content="width=device-width"/>
+
+  <!-- PatternFly Styles -->
+  <!-- Note: No other CSS files are needed regardless of what other JS packages located in patternfly/components that you decide to pull in -->
+  <link rel="stylesheet" href="/css/patternfly.css" />
+  <link rel="stylesheet" href="/css/patternfly-additions.css" />
+  <link rel="stylesheet" href="/css/angular-patternfly.css">
+
+  <link rel="stylesheet" href="/css/ng-docs.css">
+  <link rel="stylesheet" href="/css/examples.css">
+
+</head>
+
+<body>
+<!-- Javascript Libs -->
+<script src='/grunt-scripts/jquery.js'></script>
+<script src="/grunt-scripts/bootstrap.js"></script>
+<script src="/grunt-scripts/c3.js"></script>
+<script src="/grunt-scripts/d3.js"></script>
+
+<script src="/grunt-scripts/patternfly.js"></script>
+<script src="/grunt-scripts/bootstrap-combobox.js"></script>
+<script src="/grunt-scripts/bootstrap-datepicker.js"></script>
+<script src="/grunt-scripts/bootstrap-select.js"></script>
+<script src="/grunt-scripts/bootstrap-treeview.js"></script>
+
+<!-- Angular PatternFly -->
+<script src="/grunt-scripts/angular.js"></script>
+<script src="/grunt-scripts/angular-patternfly.js"></script>
+<script src="/grunt-scripts/ui-bootstrap-tpls.js"></script>
+
+<!-- Angular PatternFly Examples-->
+<script src="examples-module.js"></script>
+<script src="charts-controller.js"></script>
+
+
+<nav class="navbar navbar-default navbar-pf">
+  <div class="navbar-header">
+    <a class="navbar-brand" href="index.html">
+      <img class="pull-left" src="/img/logo-alt.svg" style="margin-top: 0px">
+      <span style="padding: 15px 20px 15px 0">ANGULAR PATTERNFLY EXAMPLES</span>
+    </a></div>
+  <div class="collapse navbar-collapse navbar-collapse-1">
+    <ul class="nav navbar-nav navbar-primary">
+      <li class="active"><a href="index.html">Charts</a></li>
+      <li><a href="cards.html">Cards</a></li>
+    </ul>
+  </div>
+</nav>
+
+<div ng-controller="ExampleChartsCtrl" class="examples-container">
+
+  <div class="row">
+    <div class="col-md-6">
+      <span class="examples-title-lg">Utilization Charts</span>
+      <span class="examples-title-sm">(pf-utilization-chart)</span>
+    </div>
+    <div class="col-md-6">
+      <span class="examples-title-lg">Trend Charts</span>
+      <span class="examples-title-sm">(pf-trends-chart)</span>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-3">
+      <div pf-utilization-chart config="utilCpuConfig"
+           donut-config="utilCpuDonutConfig" sparkline-config="utilCpuSparkConfig"
+           chart-data="utilCpuData" sparkline-chart-height="custChartHeight">
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div pf-utilization-chart config="utilMemConfig"
+           donut-config="utilMemDonutConfig" sparkline-config="utilMemSparkConfig"
+           chart-data="utilMemData" sparkline-chart-height="custChartHeight">
+      </div>
+    </div>
+    <div class="col-md-6">
+      <h4>Large Layout</h4>
+      <div pf-trends-chart config="trendsLgConfig" chart-data="sparkData"></div>
+      <hr/>
+      <h4>Small Layout</h4>
+      <div pf-trends-chart config="trendsSmConfig" chart-data="sparkData"></div>
+      <hr/>
+      <h4>Compact Layout</h4>
+      <div pf-trends-chart config="trendsCompactConfig" chart-data="sparkData"></div>
+      <hr/>
+      <h4>Inline Layout</h4>
+      <div pf-trends-chart config="trendsInlineConfig" chart-data="sparkData"></div>
+      <hr/>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-12">
+      <span class="examples-title-lg">Donut Charts</span>
+      <span class="examples-title-sm">(pf-donut-pct-chart)</span>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-3 text-center">
+      <h4>Error Threshold</h4>
+    </div>
+    <div class="col-md-3 text-center">
+      <h4>Warning Threshold</h4>
+    </div>
+    <div class="col-md-3 text-center">
+      <h4>Ok</h4>
+    </div>
+    <div class="col-md-3 text-center">
+      <h4>No Threshold<br>Center-Label is 'percentage'</h4>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-3">
+      <div pf-donut-pct-chart config="donutErrConfig" data="donutErrData"></div>
+    </div>
+    <div class="col-md-3">
+      <div pf-donut-pct-chart config="donutWarnConfig" data="donutWarnData"></div>
+    </div>
+    <div class="col-md-3">
+      <div pf-donut-pct-chart config="donutOkConfig" data="donutOkData"></div>
+    </div>
+    <div class="col-md-3">
+      <div pf-donut-pct-chart config="donutConfig" data="donutData" center-label="pctLabel"></div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-12">
+      <span class="examples-title-lg">Sparkline Charts</span>
+      <span class="examples-title-sm">(pf-sparkline-chart)</span>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-3 text-center">
+      <h4>Default Tooltip</h4>
+    </div>
+    <div class="col-md-3 text-center">
+      <h4>Usage Per Day Tooltip</h4>
+    </div>
+    <div class="col-md-3 text-center">
+      <h4>Value Per Day Tooltip</h4>
+    </div>
+    <div class="col-md-3 text-center">
+      <h4>Percentage Tooltip</h4>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-3">
+      <div pf-sparkline-chart config="sparkConfig" chart-data="sparkData" chart-height="custChartHeight"></div>
+    </div>
+    <div class="col-md-3">
+      <div pf-sparkline-chart config="sparkUsageConfig" chart-data="sparkData" chart-height="custChartHeight"></div>
+    </div>
+    <div class="col-md-3">
+      <div pf-sparkline-chart config="sparkValueConfig" chart-data="sparkData" chart-height="custChartHeight"></div>
+    </div>
+    <div class="col-md-3">
+      <div pf-sparkline-chart config="sparkPctConfig" chart-data="sparkData" chart-height="custChartHeight"></div>
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/misc/examples.css
+++ b/misc/examples.css
@@ -87,3 +87,38 @@ hr {
 .actions-label {
   margin-top: 5px;
 }
+
+.examples-container {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+.examples-container .row {
+  margin-top: 10px;
+}
+
+.examples-title-lg {
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.examples-title-sm {
+  margin-left: 10px;
+  font-size: 16px;
+  font-weight: 400;
+}
+
+.examples-container .row h4{
+  font-size: 18px;
+  font-weight: 400;
+  font-style: italic;
+}
+
+.examples-container hr {
+  display: block;
+  height: 10px;
+  border: 0;
+  border-top: 1px solid #525252;
+  margin: 1em 0;
+  padding: 0;
+}


### PR DESCRIPTION
Angular-PatternFly Examples, similar to the test pages in PatternFly Ref. Impl.:

![image](https://cloud.githubusercontent.com/assets/12733153/10316403/24409602-6c2d-11e5-9fc5-755567db022d.png)

'grunt ngdocs:view'

Change url to:
http://127.0.0.1:8000/examples

- Good place to test and demo components and widgets
- Better place to develop than ng-docs commented out code
- Not cross-referencing or publicizing yet until flushed out some more
- Next steps would be to add Data List, Data Toolbar, Filtering, Sorting, etc..
