### PR TITLE
pfnotification service does not make data available to html template

### DIFF
--- a/src/notification/notification.js
+++ b/src/notification/notification.js
@@ -325,6 +325,11 @@ angular.module( 'patternfly.notification' ).directive('pfNotificationList', func
 
   return {
     restrict: 'E',
+    controller: NotificationListController,
     templateUrl: 'notification/notification-list.html'
   };
+
+  function NotificationListController ($scope, $rootScope) {
+    $scope.notifications = $rootScope.notifications;
+  }
 });


### PR DESCRIPTION
The related provider should be rewritten, no question about that. Until that time, this fix makes $rootScope.notification available to the pfNotificationList directive.

Previous behavior, where <pf-notification-list></pf-notification-list> was declared, notifications would not appear when the Notification (Notification.error for example) provider was invoked.

Present behavior (with this commit) <pf-notification-list></pf-notification-list> will now display the list of cued notifications no matter where it's declared.