### PR TITLE
Moving angular-patternfly to use patternfly 2.4.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,6 +40,6 @@
     "angular-route": "1.3.0 - 1.4.*",
     "angular-bootstrap": "0.13.x",
     "lodash": "3.x",
-    "patternfly": "~2.3.0"
+    "patternfly": "~2.4.0"
   }
 }


### PR DESCRIPTION
Moving angular-patternfly to use pf 2.4.0.
Needed for #123 

@erundle @jeff-phillips-18 please review and merge if ok with this. -thanks!