### PR TITLE
Dev changes to allow outside access to dev urls

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,6 +43,7 @@ module.exports = function (grunt) {
       connect: {
         docs: {
           options: {
+            hostname: '0.0.0.0',
             base: 'dist/docs',
             livereload: true,
             open: true
@@ -216,7 +217,7 @@ module.exports = function (grunt) {
           files: ['Gruntfile.js', 'src/**/*.js', 'src/**/*.html', 'styles/**/*.css'],
           tasks: ['build'],
           options: {
-            livereload: true
+            livereload: 35722
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "grunt-contrib-jshint": "0.7.0",
     "grunt-contrib-uglify": "0.2.5",
     "grunt-contrib-watch": "0.5.3",
-    "grunt-eslint": "^17.1.0",
+    "grunt-eslint": "~17.1.0",
     "grunt-htmlhint": "0.4.1",
     "grunt-karma": "0.8.3",
     "grunt-ng-annotate": "^1.0.1",


### PR DESCRIPTION
- Changed livereload port to avoid conflicts with other servers.
- Changed versioning of eslint