### PR TITLE
Ng-Docs: Moved 'card' examples out of TrendChart and UtilizationBarChart...

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,7 +45,7 @@ module.exports = function (grunt) {
           options: {
             hostname: '0.0.0.0',
             base: 'dist/docs',
-            livereload: true,
+            livereload: 35722,
             open: true
           }
         }

--- a/dist/angular-patternfly.js
+++ b/dist/angular-patternfly.js
@@ -308,21 +308,38 @@ angular.module( 'patternfly.card' ).directive('pfAggregateStatusCard', function 
 
  <file name="index.html">
    <div ng-controller="ChartCtrl">
-     <div pf-card head-title="Card Title" sub-title="Card Subtitle" filter="filterConfigHeader" style="width: 50%">
-       [Card Contents] <button>Click Me</button> Timeframe filter in header
+     <label class="label-title">Timeframe filter in header</label>
+     <div pf-card head-title="Card Title" sub-title="Card Subtitle" show-top-border="true" filter="filterConfigHeader" style="width: 50%">
+       Card Contents
      </div>
 
+     <label class="label-title">Footer with Link & Timeframe filter</label>
      <div pf-card head-title="Card Title" sub-title="Card Subtitle" show-top-border="true"
           footer="footerConfig" filter="filterConfig" style="width: 50%">
-       [Card Contents] <button>Click Me</button> Footer with Link & Timeframe filter
+       Card Contents
      </div>
 
+     <label class="label-title">Card With Single Trend Chart</label>
+     <div pf-card head-title="Cluster Utilization" show-top-border="true" footer="footerConfig" filter="filterConfig" style="width: 50%">
+       <div pf-trends-chart config="configSingle" chart-data="dataSingle"></div>
+     </div>
+
+     <label class="label-title">Card With Multiple Trends</label>
      <div pf-card head-title="Performance" sub-title="Last 30 Days" show-top-border="false"
           show-titles-separator="false" style="width: 65%" footer="actionBarConfig">
        <div pf-trends-chart config="configVirtual" chart-data="dataVirtual"></div>
        <div pf-trends-chart config="configPhysical" chart-data="dataPhysical"></div>
        <div pf-trends-chart config="configMemory" chart-data="dataMemory"></div>
      </div>
+
+     <label class="label-title">Card With Multiple Utilization Bars</label>
+     <div pf-card head-title="System Resources" show-top-border="true" style="width: 65%">
+       <div pf-utilization-bar-chart chart-data=data2 chart-title=title2 layout=layoutInline units=units2 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data3 chart-title=title3 layout=layoutInline units=units3 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data4 chart-title=title4 layout=layoutInline units=units4 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data5 chart-title=title5 layout=layoutInline units=units5 threshold-error="85" threshold-warning="60"></div>
+     </div>
+
    </div>
  </file>
  <file name="script.js">
@@ -361,6 +378,21 @@ angular.module( 'patternfly.card' ).directive('pfAggregateStatusCard', function 
        for (var d = 20 - 1; d >= 0; d--) {
          dates.push(new Date(today.getTime() - (d * 24 * 60 * 60 * 1000)));
        }
+
+       $scope.configSingle = {
+         'chartId'      : 'example2TrendsChart',
+         'title'        : 'Storage Capacity',
+         'layout'       : 'compact',
+         'valueType'    : 'actual',
+         'units'        : 'TB',
+         'tooltipType'  : 'percentage'
+       };
+
+       $scope.dataSingle = {
+         'total': '250',
+         'xData': dates,
+         'yData': ['used', '90', '20', '30', '20', '20', '10', '14', '20', '25', '68', '44', '56', '78', '56', '67', '88', '76', '65', '87', '76']
+       };
 
        $scope.configVirtual = {
          'chartId'      : 'virtualTrendsChart',
@@ -411,6 +443,40 @@ angular.module( 'patternfly.card' ).directive('pfAggregateStatusCard', function 
             alert("Footer Callback Fn Called");
           }
        }
+
+       $scope.title2      = 'Memory';
+       $scope.units2      = 'GB';
+
+       $scope.data2 = {
+         'used': '25',
+         'total': '100'
+       };
+
+       $scope.title3 = 'CPU Usage';
+       $scope.units3 = 'MHz';
+
+       $scope.data3 = {
+         'used': '420',
+         'total': '500',
+       };
+
+       $scope.title4 = 'Disk Usage';
+       $scope.units4 = 'TB';
+       $scope.data4 = {
+         'used': '350',
+         'total': '500',
+       };
+
+       $scope.title5 = 'Disk I/O';
+       $scope.units5 = 'I/Ops';
+       $scope.data5 = {
+         'used': '450',
+         'total': '500',
+       };
+
+       $scope.layoutInline = {
+         'type': 'inline'
+       };
      });
  </file>
  </example>
@@ -1475,13 +1541,6 @@ angular.module('patternfly.charts').directive('pfSparklineChart', ["c3ChartDefau
          <button ng-click="addDataPoint()">Add Data Point</button>
        </div>
      </div>
-     <hr class="col-md-12">
-     <div class="col-md-12">
-       <div pf-card head-title="Cluster Utilization" show-top-border="true"
-            footer="footerConfig" filter="filterConfig">
-         <div pf-trends-chart config="config2" chart-data="data"></div>
-       </div>
-     </div>
     </div>
  </file>
  <file name="script.js">
@@ -1495,15 +1554,6 @@ angular.module('patternfly.charts').directive('pfSparklineChart', ["c3ChartDefau
          'valueType'    : 'actual',
          'timeFrame'    : 'Last 15 Minutes',
          'units'        : 'MHz',
-         'tooltipType'  : 'percentage'
-       };
-
-       $scope.config2 = {
-         'chartId'      : 'example2TrendsChart',
-         'title'        : 'Storage Capacity',
-         'layout'       : 'compact',
-         'valueType'    : 'actual',
-         'units'        : 'TB',
          'tooltipType'  : 'percentage'
        };
 
@@ -1643,32 +1693,20 @@ angular.module('patternfly.charts').directive('pfTrendsChart', function () {
  <example module="patternfly.example">
    <file name="index.html">
      <div ng-controller="ChartCtrl">
+
+       <label class="label-title">Default Layout, no Thresholds</label>
        <div pf-utilization-bar-chart chart-data=data1 chart-title=title1 units=units1></div>
-       <hr>
-       <div pf-card head-title="Utilization Bar Chart">
-         <div pf-utilization-bar-chart chart-data=data2 chart-title=title2 units=units2 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data3 chart-title=title3 units=units3 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data4 chart-title=title4 units=units4 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data5 chart-title=title5 units=units5 threshold-error="85" threshold-warning="60"></div>
-       </div>
-
-       <hr>
-       <label><strong>layout='inline'</strong></label>
-       <div pf-card head-title="Utilization Bar Chart">
-         <div pf-utilization-bar-chart chart-data=data2 chart-title=title2short layout=layoutInline units=units2 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data3 chart-title=title3 layout=layoutInline units=units3 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data4 chart-title=title4 layout=layoutInline units=units4 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data5 chart-title=title5 layout=layoutInline units=units5 threshold-error="85" threshold-warning="60"></div>
-       </div>
-
-       <hr>
-       <label><strong>layout='inline', footer-label-format='percent', and custom chart-footer labels</strong></label>
-       <div pf-card head-title="Utilization Bar Chart">
-         <div pf-utilization-bar-chart chart-data=data2 chart-title=title2short layout=layoutInline footer-label-format='percent' units=units2 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data3 chart-title=title3 layout=layoutInline footer-label-format='percent' units=units3 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data4 chart-title=title4 chart-footer=footer1 layout=layoutInline units=units4 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data5 chart-title=title5 chart-footer=footer2 layout=layoutInline units=units5 threshold-error="85" threshold-warning="60"></div>
-       </div>
+       <br>
+       <label class="label-title">Inline Layouts with Error, Warning, and Ok Thresholds</label>
+       <div pf-utilization-bar-chart chart-data=data5 chart-title=title5 layout=layoutInline units=units5 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data3 chart-title=title3 layout=layoutInline units=units3 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data2 chart-title=title2 layout=layoutInline units=units2 threshold-error="85" threshold-warning="60"></div>
+       <br>
+       <label class="label-title">layout='inline', footer-label-format='percent', and custom chart-footer labels</label>
+       <div pf-utilization-bar-chart chart-data=data2 chart-title=title2 layout=layoutInline footer-label-format='percent' units=units2 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data3 chart-title=title3 layout=layoutInline footer-label-format='percent' units=units3 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data4 chart-title=title4 chart-footer=footer1 layout=layoutInline units=units4 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data5 chart-title=title5 chart-footer=footer2 layout=layoutInline units=units5 threshold-error="85" threshold-warning="60"></div>
      </div>
    </file>
 
@@ -1685,8 +1723,7 @@ angular.module('patternfly.charts').directive('pfTrendsChart', function () {
       'total': '24'
     };
 
-    $scope.title2      = 'Memory Utilization';
-    $scope.title2short = 'Memory';
+    $scope.title2      = 'Memory';
     $scope.units2      = 'GB';
 
     $scope.data2 = {

--- a/misc/examples.css
+++ b/misc/examples.css
@@ -87,3 +87,9 @@ hr {
 .actions-label {
   margin-top: 5px;
 }
+
+.label-title {
+  font-size: 16px;
+  font-weight: 600;
+  padding-bottom: 10px;
+}

--- a/src/card/basic/card.directive.js
+++ b/src/card/basic/card.directive.js
@@ -34,21 +34,38 @@
 
  <file name="index.html">
    <div ng-controller="ChartCtrl">
-     <div pf-card head-title="Card Title" sub-title="Card Subtitle" filter="filterConfigHeader" style="width: 50%">
-       [Card Contents] <button>Click Me</button> Timeframe filter in header
+     <label class="label-title">Timeframe filter in header</label>
+     <div pf-card head-title="Card Title" sub-title="Card Subtitle" show-top-border="true" filter="filterConfigHeader" style="width: 50%">
+       Card Contents
      </div>
 
+     <label class="label-title">Footer with Link & Timeframe filter</label>
      <div pf-card head-title="Card Title" sub-title="Card Subtitle" show-top-border="true"
           footer="footerConfig" filter="filterConfig" style="width: 50%">
-       [Card Contents] <button>Click Me</button> Footer with Link & Timeframe filter
+       Card Contents
      </div>
 
+     <label class="label-title">Card With Single Trend Chart</label>
+     <div pf-card head-title="Cluster Utilization" show-top-border="true" footer="footerConfig" filter="filterConfig" style="width: 50%">
+       <div pf-trends-chart config="configSingle" chart-data="dataSingle"></div>
+     </div>
+
+     <label class="label-title">Card With Multiple Trends</label>
      <div pf-card head-title="Performance" sub-title="Last 30 Days" show-top-border="false"
           show-titles-separator="false" style="width: 65%" footer="actionBarConfig">
        <div pf-trends-chart config="configVirtual" chart-data="dataVirtual"></div>
        <div pf-trends-chart config="configPhysical" chart-data="dataPhysical"></div>
        <div pf-trends-chart config="configMemory" chart-data="dataMemory"></div>
      </div>
+
+     <label class="label-title">Card With Multiple Utilization Bars</label>
+     <div pf-card head-title="System Resources" show-top-border="true" style="width: 65%">
+       <div pf-utilization-bar-chart chart-data=data2 chart-title=title2 layout=layoutInline units=units2 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data3 chart-title=title3 layout=layoutInline units=units3 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data4 chart-title=title4 layout=layoutInline units=units4 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data5 chart-title=title5 layout=layoutInline units=units5 threshold-error="85" threshold-warning="60"></div>
+     </div>
+
    </div>
  </file>
  <file name="script.js">
@@ -87,6 +104,21 @@
        for (var d = 20 - 1; d >= 0; d--) {
          dates.push(new Date(today.getTime() - (d * 24 * 60 * 60 * 1000)));
        }
+
+       $scope.configSingle = {
+         'chartId'      : 'example2TrendsChart',
+         'title'        : 'Storage Capacity',
+         'layout'       : 'compact',
+         'valueType'    : 'actual',
+         'units'        : 'TB',
+         'tooltipType'  : 'percentage'
+       };
+
+       $scope.dataSingle = {
+         'total': '250',
+         'xData': dates,
+         'yData': ['used', '90', '20', '30', '20', '20', '10', '14', '20', '25', '68', '44', '56', '78', '56', '67', '88', '76', '65', '87', '76']
+       };
 
        $scope.configVirtual = {
          'chartId'      : 'virtualTrendsChart',
@@ -137,6 +169,40 @@
             alert("Footer Callback Fn Called");
           }
        }
+
+       $scope.title2      = 'Memory';
+       $scope.units2      = 'GB';
+
+       $scope.data2 = {
+         'used': '25',
+         'total': '100'
+       };
+
+       $scope.title3 = 'CPU Usage';
+       $scope.units3 = 'MHz';
+
+       $scope.data3 = {
+         'used': '420',
+         'total': '500',
+       };
+
+       $scope.title4 = 'Disk Usage';
+       $scope.units4 = 'TB';
+       $scope.data4 = {
+         'used': '350',
+         'total': '500',
+       };
+
+       $scope.title5 = 'Disk I/O';
+       $scope.units5 = 'I/Ops';
+       $scope.data5 = {
+         'used': '450',
+         'total': '500',
+       };
+
+       $scope.layoutInline = {
+         'type': 'inline'
+       };
      });
  </file>
  </example>

--- a/src/charts/trends/trends-chart.directive.js
+++ b/src/charts/trends/trends-chart.directive.js
@@ -82,13 +82,6 @@
          <button ng-click="addDataPoint()">Add Data Point</button>
        </div>
      </div>
-     <hr class="col-md-12">
-     <div class="col-md-12">
-       <div pf-card head-title="Cluster Utilization" show-top-border="true"
-            footer="footerConfig" filter="filterConfig">
-         <div pf-trends-chart config="config2" chart-data="data"></div>
-       </div>
-     </div>
     </div>
  </file>
  <file name="script.js">
@@ -102,15 +95,6 @@
          'valueType'    : 'actual',
          'timeFrame'    : 'Last 15 Minutes',
          'units'        : 'MHz',
-         'tooltipType'  : 'percentage'
-       };
-
-       $scope.config2 = {
-         'chartId'      : 'example2TrendsChart',
-         'title'        : 'Storage Capacity',
-         'layout'       : 'compact',
-         'valueType'    : 'actual',
-         'units'        : 'TB',
          'tooltipType'  : 'percentage'
        };
 

--- a/src/charts/utilization-bar/utilization-bar-chart.directive.js
+++ b/src/charts/utilization-bar/utilization-bar-chart.directive.js
@@ -43,32 +43,20 @@
  <example module="patternfly.example">
    <file name="index.html">
      <div ng-controller="ChartCtrl">
+
+       <label class="label-title">Default Layout, no Thresholds</label>
        <div pf-utilization-bar-chart chart-data=data1 chart-title=title1 units=units1></div>
-       <hr>
-       <div pf-card head-title="Utilization Bar Chart">
-         <div pf-utilization-bar-chart chart-data=data2 chart-title=title2 units=units2 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data3 chart-title=title3 units=units3 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data4 chart-title=title4 units=units4 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data5 chart-title=title5 units=units5 threshold-error="85" threshold-warning="60"></div>
-       </div>
-
-       <hr>
-       <label><strong>layout='inline'</strong></label>
-       <div pf-card head-title="Utilization Bar Chart">
-         <div pf-utilization-bar-chart chart-data=data2 chart-title=title2short layout=layoutInline units=units2 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data3 chart-title=title3 layout=layoutInline units=units3 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data4 chart-title=title4 layout=layoutInline units=units4 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data5 chart-title=title5 layout=layoutInline units=units5 threshold-error="85" threshold-warning="60"></div>
-       </div>
-
-       <hr>
-       <label><strong>layout='inline', footer-label-format='percent', and custom chart-footer labels</strong></label>
-       <div pf-card head-title="Utilization Bar Chart">
-         <div pf-utilization-bar-chart chart-data=data2 chart-title=title2short layout=layoutInline footer-label-format='percent' units=units2 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data3 chart-title=title3 layout=layoutInline footer-label-format='percent' units=units3 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data4 chart-title=title4 chart-footer=footer1 layout=layoutInline units=units4 threshold-error="85" threshold-warning="60"></div>
-         <div pf-utilization-bar-chart chart-data=data5 chart-title=title5 chart-footer=footer2 layout=layoutInline units=units5 threshold-error="85" threshold-warning="60"></div>
-       </div>
+       <br>
+       <label class="label-title">Inline Layouts with Error, Warning, and Ok Thresholds</label>
+       <div pf-utilization-bar-chart chart-data=data5 chart-title=title5 layout=layoutInline units=units5 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data3 chart-title=title3 layout=layoutInline units=units3 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data2 chart-title=title2 layout=layoutInline units=units2 threshold-error="85" threshold-warning="60"></div>
+       <br>
+       <label class="label-title">layout='inline', footer-label-format='percent', and custom chart-footer labels</label>
+       <div pf-utilization-bar-chart chart-data=data2 chart-title=title2 layout=layoutInline footer-label-format='percent' units=units2 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data3 chart-title=title3 layout=layoutInline footer-label-format='percent' units=units3 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data4 chart-title=title4 chart-footer=footer1 layout=layoutInline units=units4 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data5 chart-title=title5 chart-footer=footer2 layout=layoutInline units=units5 threshold-error="85" threshold-warning="60"></div>
      </div>
    </file>
 
@@ -85,8 +73,7 @@
       'total': '24'
     };
 
-    $scope.title2      = 'Memory Utilization';
-    $scope.title2short = 'Memory';
+    $scope.title2      = 'Memory';
     $scope.units2      = 'GB';
 
     $scope.data2 = {


### PR DESCRIPTION
…and into base Card.  
- updated ng-doc example labels
- fixed livereload param

**Updated pfCard examples:**

![image](https://cloud.githubusercontent.com/assets/12733153/10974402/f167413c-83af-11e5-81c4-c3d46335133c.png)


**Updated Utilization Bar Chart examples:**

![image](https://cloud.githubusercontent.com/assets/12733153/10974429/17f84da0-83b0-11e5-9bed-31b76ab53c7c.png)

