### PR TITLE
pfSelect - fixed blank choice in select

### DIFF
--- a/dist/angular-patternfly.js
+++ b/dist/angular-patternfly.js
@@ -3254,6 +3254,7 @@ angular.module( 'patternfly.notification' ).directive('pfNotificationList', func
        $scope.drinks = ['tea', 'coffee', 'water'];
        $scope.pets = ['Dog', 'Cat', 'Chicken'];
        $scope.pet = $scope.pets[0];
+       $scope.fruit = 'orange';
      });
    </file>
 

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -57,6 +57,7 @@
        $scope.drinks = ['tea', 'coffee', 'water'];
        $scope.pets = ['Dog', 'Cat', 'Chicken'];
        $scope.pet = $scope.pets[0];
+       $scope.fruit = 'orange';
      });
    </file>
 


### PR DESCRIPTION
If the ng-model does not contain a recognized value a blank entry will be displayed in the choices. I set the value to "orange" to be different than the hard-coded value of "apple".