### PR TITLE
Fixes 151 - Set bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,15 +33,15 @@
     "type": "git",
     "url": "git://github.com/patternfly/angular-patternfly.git"
   },
-  "devDependencies": {
+  "dependencies": {
     "angular": "1.3.0 - 1.4.*",
     "angular-animate": "1.3.0 - 1.4.*",
-    "angular-mocks": "1.3.0 - 1.4.*",
     "angular-sanitize": "1.3.0 - 1.4.*",
-    "angular-touch": "1.3.0 - 1.4.*",
-    "angular-route": "1.3.0 - 1.4.*",
     "angular-bootstrap": "0.13.x",
     "lodash": "3.x",
     "patternfly": "~2.9.0"
+  },
+  "devDependencies": {
+    "angular-mocks": "1.3.0 - 1.4.*"
   }
 }


### PR DESCRIPTION
Move dependencies that are required by consumers from
devDependencies to dependencies in bower.json.