### PR TITLE
tooltip placement changed to top for sort menu

### DIFF
--- a/src/sort/sort.html
+++ b/src/sort/sort.html
@@ -2,7 +2,7 @@
   <form>
     <div class="form-group">
       <div class="dropdown btn-group">
-        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tooltip="Sort by" tooltip-placement="bottom">
+        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tooltip="Sort by" tooltip-placement="top">
           {{config.currentField.title}}
           <span class="caret"></span>
         </button>


### PR DESCRIPTION
For `sort` drop down menu tooltip showing on `bottom`. looks bit uneasy to read sort options. Changed tooltip placement to `top`