### PR TITLE
Update build such that dist/docs is not updated every time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ dist/docs/img
 dist/docs/index.html
 
 
+docs
 node_modules
 lib
 .bower

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "grunt-karma": "0.8.3",
     "grunt-ng-annotate": "^1.0.1",
     "grunt-ngdocs": "0.2.9",
+    "grunt-remove": "^0.1.0",
     "karma": "0.12.23",
     "karma-chrome-launcher": "0.1.4",
     "karma-firefox-launcher": "0.1.3",


### PR DESCRIPTION
This will require that when a release is done, the grunt task ngdocs:publish is run and the doc changes are pushed at that point.