### PR TITLE
Split pfCard examples to be included separately in patternfly-toolkit

### DIFF
--- a/dist/angular-patternfly.js
+++ b/dist/angular-patternfly.js
@@ -295,7 +295,7 @@ angular.module( 'patternfly.card' ).directive('pfAggregateStatusCard', function 
 });
 ;/**
  * @ngdoc directive
- * @name patternfly.card.directive:pfCard
+ * @name patternfly.examples.card:pfCard - Timeframe Filters
  * @restrict A
  * @element ANY
  * @param {string} headTitle Title for the card
@@ -330,37 +330,14 @@ angular.module( 'patternfly.card' ).directive('pfAggregateStatusCard', function 
  <file name="index.html">
    <div ng-controller="ChartCtrl">
      <label class="label-title">Timeframe filter in header</label>
-     <div pf-card head-title="Card Title" sub-title="Card Subtitle" show-top-border="true" filter="filterConfigHeader" style="width: 50%">
-       Card Contents
-     </div>
-
+       <div pf-card head-title="Card Title" sub-title="Card Subtitle" show-top-border="true" filter="filterConfigHeader" style="width: 50%">
+         Card Contents
+       </div>
      <label class="label-title">Footer with Link & Timeframe filter</label>
      <div pf-card head-title="Card Title" sub-title="Card Subtitle" show-top-border="true"
           footer="footerConfig" filter="filterConfig" style="width: 50%">
-       Card Contents
+        Card Contents
      </div>
-
-     <label class="label-title">Card With Single Trend Chart</label>
-     <div pf-card head-title="Cluster Utilization" show-top-border="true" footer="footerConfig" filter="filterConfig" style="width: 50%">
-       <div pf-trends-chart config="configSingle" chart-data="dataSingle"></div>
-     </div>
-
-     <label class="label-title">Card With Multiple Trends</label>
-     <div pf-card head-title="Performance" sub-title="Last 30 Days" show-top-border="false"
-          show-titles-separator="false" style="width: 65%" footer="actionBarConfig">
-       <div pf-trends-chart config="configVirtual" chart-data="dataVirtual"></div>
-       <div pf-trends-chart config="configPhysical" chart-data="dataPhysical"></div>
-       <div pf-trends-chart config="configMemory" chart-data="dataMemory"></div>
-     </div>
-
-     <label class="label-title">Card With Multiple Utilization Bars</label>
-     <div pf-card head-title="System Resources" show-top-border="true" style="width: 65%">
-       <div pf-utilization-bar-chart chart-data=data2 chart-title=title2 layout=layoutInline units=units2 threshold-error="85" threshold-warning="60"></div>
-       <div pf-utilization-bar-chart chart-data=data3 chart-title=title3 layout=layoutInline units=units3 threshold-error="85" threshold-warning="60"></div>
-       <div pf-utilization-bar-chart chart-data=data4 chart-title=title4 layout=layoutInline units=units4 threshold-error="85" threshold-warning="60"></div>
-       <div pf-utilization-bar-chart chart-data=data5 chart-title=title5 layout=layoutInline units=units5 threshold-error="85" threshold-warning="60"></div>
-     </div>
-
    </div>
  </file>
  <file name="script.js">
@@ -382,6 +359,80 @@ angular.module( 'patternfly.card' ).directive('pfAggregateStatusCard', function 
             alert("Header Filter Callback Fn Called for '" + f.label + "' value = " + f.value);
           },
         'position' : 'header'
+       }
+
+       $scope.filterConfig = {
+         'filters' : [{label:'Last 30 Days', value:'30'},
+                      {label:'Last 15 Days', value:'15'},
+                      {label:'Today', value:'today'}],
+         'callBackFn': function (f) {
+            alert("Filter Callback Fn Called for '" + f.label + "' value = " + f.value);
+          },
+        'defaultFilter' : '1'
+       }
+     });
+ </file>
+ </example>
+ */
+;/**
+ * @ngdoc directive
+ * @name patternfly.examples.card:pfCard - Trends
+ * @restrict A
+ * @element ANY
+ * @param {string} headTitle Title for the card
+ * @param {string=} subTitle Sub-Title for the card
+ * @param {boolean=} showTopBorder Show/Hide the blue top border. True shows top border, false (default) hides top border
+ * @param {boolean=} showTitlesSeparator Show/Hide the grey line between the title and sub-title.
+ * True (default) shows the line, false hides the line
+ * @param {object=} footer footer configuration properties:<br/>
+ * <ul style='list-style-type: none'>
+ * <li>.iconClass  - (optional) the icon to show on the bottom left of the footer panel
+ * <li>.text       - (optional) the text to show on the bottom left of the footer panel, to the right of the icon
+ * <li>.href       - (optional) the href link to navigate to when the footer href is clicked
+ * <li>.callBackFn - (optional) user defined function to call when the footer href is clicked
+ * </ul>
+ * *Note: If a href link and a callBackFn are specified, the href link will be called
+ * @param {object=} filter filter configuration properties:<br/>
+ * <ul style='list-style-type: none'>
+ * <li>.filters    - drop down items for the filter.
+ *<pre class=''>
+ *  Ex:  'filters' : [{label:'Last 30 Days', value:'30'},
+ *                    {label:'Last 15 Days', value:'15'},
+ *                    {label:'Today', value:'today'}]</pre>
+ * <li>.defaultFilter - integer, 0 based index into the filters array
+ * <li>.callBackFn - user defined function to call when a filter is selected
+ * </ul>
+ * @description
+ * Directive for easily displaying a card with html content
+ *
+ * @example
+ <example module="demo">
+
+ <file name="index.html">
+   <div ng-controller="ChartCtrl">
+     <label class="label-title">Card With Single Trend Chart</label>
+     <div pf-card head-title="Cluster Utilization" show-top-border="true" footer="footerConfig" filter="filterConfig" style="width: 50%">
+       <div pf-trends-chart config="configSingle" chart-data="dataSingle"></div>
+     </div>
+     <label class="label-title">Card With Multiple Trends</label>
+     <div pf-card head-title="Performance" sub-title="Last 30 Days" show-top-border="false"
+          show-titles-separator="false" style="width: 65%" footer="actionBarConfig">
+       <div pf-trends-chart config="configVirtual" chart-data="dataVirtual"></div>
+       <div pf-trends-chart config="configPhysical" chart-data="dataPhysical"></div>
+       <div pf-trends-chart config="configMemory" chart-data="dataMemory"></div>
+     </div>
+    </div>
+   </div>
+ </file>
+ <file name="script.js">
+ angular.module( 'demo', ['patternfly.charts', 'patternfly.card'] ).controller( 'ChartCtrl', function( $scope ) {
+
+       $scope.footerConfig = {
+         'iconClass' : 'fa fa-flag',
+         'text'      : 'View All Events',
+         'callBackFn': function () {
+            alert("Footer Callback Fn Called");
+          }
        }
 
        $scope.filterConfig = {
@@ -464,9 +515,60 @@ angular.module( 'patternfly.card' ).directive('pfAggregateStatusCard', function 
             alert("Footer Callback Fn Called");
           }
        }
+     });
+ </file>
+ </example>
+ */
+;/**
+ * @ngdoc directive
+ * @name patternfly.card.directive:pfCard
+ * @restrict A
+ * @element ANY
+ * @param {string} headTitle Title for the card
+ * @param {string=} subTitle Sub-Title for the card
+ * @param {boolean=} showTopBorder Show/Hide the blue top border. True shows top border, false (default) hides top border
+ * @param {boolean=} showTitlesSeparator Show/Hide the grey line between the title and sub-title.
+ * True (default) shows the line, false hides the line
+ * @param {object=} footer footer configuration properties:<br/>
+ * <ul style='list-style-type: none'>
+ * <li>.iconClass  - (optional) the icon to show on the bottom left of the footer panel
+ * <li>.text       - (optional) the text to show on the bottom left of the footer panel, to the right of the icon
+ * <li>.href       - (optional) the href link to navigate to when the footer href is clicked
+ * <li>.callBackFn - (optional) user defined function to call when the footer href is clicked
+ * </ul>
+ * *Note: If a href link and a callBackFn are specified, the href link will be called
+ * @param {object=} filter filter configuration properties:<br/>
+ * <ul style='list-style-type: none'>
+ * <li>.filters    - drop down items for the filter.
+ *<pre class=''>
+ *  Ex:  'filters' : [{label:'Last 30 Days', value:'30'},
+ *                    {label:'Last 15 Days', value:'15'},
+ *                    {label:'Today', value:'today'}]</pre>
+ * <li>.defaultFilter - integer, 0 based index into the filters array
+ * <li>.callBackFn - user defined function to call when a filter is selected
+ * </ul>
+ * @description
+ * Directive for easily displaying a card with html content
+ *
+ * @example
+ <example module="demo">
 
-       $scope.title2      = 'Memory';
-       $scope.units2      = 'GB';
+ <file name="index.html">
+   <div ng-controller="ChartCtrl">
+     <label class="label-title">Card With Multiple Utilization Bars</label>
+     <div pf-card head-title="System Resources" show-top-border="true" style="width: 65%">
+       <div pf-utilization-bar-chart chart-data=data2 chart-title=title2 layout=layoutInline units=units2 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data3 chart-title=title3 layout=layoutInline units=units3 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data4 chart-title=title4 layout=layoutInline units=units4 threshold-error="85" threshold-warning="60"></div>
+       <div pf-utilization-bar-chart chart-data=data5 chart-title=title5 layout=layoutInline units=units5 threshold-error="85" threshold-warning="60"></div>
+     </div>
+   </div>
+ </file>
+ <file name="script.js">
+ angular.module( 'demo', ['patternfly.charts', 'patternfly.card'] ).controller( 'ChartCtrl', function( $scope ) {
+
+       $scope.title2 = 'Memory';
+       $scope.units2 = 'GB';
 
        $scope.data2 = {
          'used': '25',

--- a/src/card/basic/card-timeframe.js
+++ b/src/card/basic/card-timeframe.js
@@ -1,0 +1,81 @@
+/**
+ * @ngdoc directive
+ * @name patternfly.examples.card:pfCard - Timeframe Filters
+ * @restrict A
+ * @element ANY
+ * @param {string} headTitle Title for the card
+ * @param {string=} subTitle Sub-Title for the card
+ * @param {boolean=} showTopBorder Show/Hide the blue top border. True shows top border, false (default) hides top border
+ * @param {boolean=} showTitlesSeparator Show/Hide the grey line between the title and sub-title.
+ * True (default) shows the line, false hides the line
+ * @param {object=} footer footer configuration properties:<br/>
+ * <ul style='list-style-type: none'>
+ * <li>.iconClass  - (optional) the icon to show on the bottom left of the footer panel
+ * <li>.text       - (optional) the text to show on the bottom left of the footer panel, to the right of the icon
+ * <li>.href       - (optional) the href link to navigate to when the footer href is clicked
+ * <li>.callBackFn - (optional) user defined function to call when the footer href is clicked
+ * </ul>
+ * *Note: If a href link and a callBackFn are specified, the href link will be called
+ * @param {object=} filter filter configuration properties:<br/>
+ * <ul style='list-style-type: none'>
+ * <li>.filters    - drop down items for the filter.
+ *<pre class=''>
+ *  Ex:  'filters' : [{label:'Last 30 Days', value:'30'},
+ *                    {label:'Last 15 Days', value:'15'},
+ *                    {label:'Today', value:'today'}]</pre>
+ * <li>.defaultFilter - integer, 0 based index into the filters array
+ * <li>.callBackFn - user defined function to call when a filter is selected
+ * </ul>
+ * @description
+ * Directive for easily displaying a card with html content
+ *
+ * @example
+ <example module="demo">
+
+ <file name="index.html">
+   <div ng-controller="ChartCtrl">
+     <label class="label-title">Timeframe filter in header</label>
+       <div pf-card head-title="Card Title" sub-title="Card Subtitle" show-top-border="true" filter="filterConfigHeader" style="width: 50%">
+         Card Contents
+       </div>
+     <label class="label-title">Footer with Link & Timeframe filter</label>
+     <div pf-card head-title="Card Title" sub-title="Card Subtitle" show-top-border="true"
+          footer="footerConfig" filter="filterConfig" style="width: 50%">
+        Card Contents
+     </div>
+   </div>
+ </file>
+ <file name="script.js">
+ angular.module( 'demo', ['patternfly.charts', 'patternfly.card'] ).controller( 'ChartCtrl', function( $scope ) {
+
+       $scope.footerConfig = {
+         'iconClass' : 'fa fa-flag',
+         'text'      : 'View All Events',
+         'callBackFn': function () {
+            alert("Footer Callback Fn Called");
+          }
+       }
+
+       $scope.filterConfigHeader = {
+         'filters' : [{label:'Last 30 Days', value:'30'},
+                      {label:'Last 15 Days', value:'15'},
+                      {label:'Today', value:'today'}],
+         'callBackFn': function (f) {
+            alert("Header Filter Callback Fn Called for '" + f.label + "' value = " + f.value);
+          },
+        'position' : 'header'
+       }
+
+       $scope.filterConfig = {
+         'filters' : [{label:'Last 30 Days', value:'30'},
+                      {label:'Last 15 Days', value:'15'},
+                      {label:'Today', value:'today'}],
+         'callBackFn': function (f) {
+            alert("Filter Callback Fn Called for '" + f.label + "' value = " + f.value);
+          },
+        'defaultFilter' : '1'
+       }
+     });
+ </file>
+ </example>
+ */

--- a/src/card/basic/card-trend.js
+++ b/src/card/basic/card-trend.js
@@ -1,0 +1,145 @@
+/**
+ * @ngdoc directive
+ * @name patternfly.examples.card:pfCard - Trends
+ * @restrict A
+ * @element ANY
+ * @param {string} headTitle Title for the card
+ * @param {string=} subTitle Sub-Title for the card
+ * @param {boolean=} showTopBorder Show/Hide the blue top border. True shows top border, false (default) hides top border
+ * @param {boolean=} showTitlesSeparator Show/Hide the grey line between the title and sub-title.
+ * True (default) shows the line, false hides the line
+ * @param {object=} footer footer configuration properties:<br/>
+ * <ul style='list-style-type: none'>
+ * <li>.iconClass  - (optional) the icon to show on the bottom left of the footer panel
+ * <li>.text       - (optional) the text to show on the bottom left of the footer panel, to the right of the icon
+ * <li>.href       - (optional) the href link to navigate to when the footer href is clicked
+ * <li>.callBackFn - (optional) user defined function to call when the footer href is clicked
+ * </ul>
+ * *Note: If a href link and a callBackFn are specified, the href link will be called
+ * @param {object=} filter filter configuration properties:<br/>
+ * <ul style='list-style-type: none'>
+ * <li>.filters    - drop down items for the filter.
+ *<pre class=''>
+ *  Ex:  'filters' : [{label:'Last 30 Days', value:'30'},
+ *                    {label:'Last 15 Days', value:'15'},
+ *                    {label:'Today', value:'today'}]</pre>
+ * <li>.defaultFilter - integer, 0 based index into the filters array
+ * <li>.callBackFn - user defined function to call when a filter is selected
+ * </ul>
+ * @description
+ * Directive for easily displaying a card with html content
+ *
+ * @example
+ <example module="demo">
+
+ <file name="index.html">
+   <div ng-controller="ChartCtrl">
+     <label class="label-title">Card With Single Trend Chart</label>
+     <div pf-card head-title="Cluster Utilization" show-top-border="true" footer="footerConfig" filter="filterConfig" style="width: 50%">
+       <div pf-trends-chart config="configSingle" chart-data="dataSingle"></div>
+     </div>
+     <label class="label-title">Card With Multiple Trends</label>
+     <div pf-card head-title="Performance" sub-title="Last 30 Days" show-top-border="false"
+          show-titles-separator="false" style="width: 65%" footer="actionBarConfig">
+       <div pf-trends-chart config="configVirtual" chart-data="dataVirtual"></div>
+       <div pf-trends-chart config="configPhysical" chart-data="dataPhysical"></div>
+       <div pf-trends-chart config="configMemory" chart-data="dataMemory"></div>
+     </div>
+    </div>
+   </div>
+ </file>
+ <file name="script.js">
+ angular.module( 'demo', ['patternfly.charts', 'patternfly.card'] ).controller( 'ChartCtrl', function( $scope ) {
+
+       $scope.footerConfig = {
+         'iconClass' : 'fa fa-flag',
+         'text'      : 'View All Events',
+         'callBackFn': function () {
+            alert("Footer Callback Fn Called");
+          }
+       }
+
+       $scope.filterConfig = {
+         'filters' : [{label:'Last 30 Days', value:'30'},
+                      {label:'Last 15 Days', value:'15'},
+                      {label:'Today', value:'today'}],
+         'callBackFn': function (f) {
+            alert("Filter Callback Fn Called for '" + f.label + "' value = " + f.value);
+          },
+        'defaultFilter' : '1'
+       }
+
+       var today = new Date();
+       var dates = ['dates'];
+       for (var d = 20 - 1; d >= 0; d--) {
+         dates.push(new Date(today.getTime() - (d * 24 * 60 * 60 * 1000)));
+       }
+
+       $scope.configSingle = {
+         'chartId'      : 'example2TrendsChart',
+         'title'        : 'Storage Capacity',
+         'layout'       : 'compact',
+         'valueType'    : 'actual',
+         'units'        : 'TB',
+         'tooltipType'  : 'percentage'
+       };
+
+       $scope.dataSingle = {
+         'total': '250',
+         'xData': dates,
+         'yData': ['used', '90', '20', '30', '20', '20', '10', '14', '20', '25', '68', '44', '56', '78', '56', '67', '88', '76', '65', '87', '76']
+       };
+
+       $scope.configVirtual = {
+         'chartId'      : 'virtualTrendsChart',
+         'layout'       : 'inline',
+         'trendLabel'   : 'Virtual Disk I/O',
+         'units'        : 'GB',
+         'tooltipType'  : 'percentage'
+       };
+
+       $scope.dataVirtual = {
+         'total': '250',
+         'xData': dates,
+         'yData': ['used', '90', '20', '30', '20', '20', '10', '14', '20', '25', '68', '44', '56', '78', '56', '67', '88', '76', '65', '87', '76']
+       };
+
+       $scope.configPhysical = {
+         'chartId'      : 'physicalTrendsChart',
+         'layout'       : 'inline',
+         'trendLabel'   : 'Physical Disk I/O',
+         'units'        : 'MHz',
+         'tooltipType'  : 'percentage'
+       };
+
+       $scope.dataPhysical = {
+         'total': '250',
+         'xData': dates,
+         'yData': ['used', '20', '20', '35', '20', '20', '87', '14', '20', '25', '28', '44', '56', '78', '56', '67', '88', '76', '65', '87', '16']
+       };
+
+       $scope.configMemory = {
+         'chartId'      : 'memoryTrendsChart',
+         'layout'       : 'inline',
+         'trendLabel'   : 'Memory Utilization',
+         'units'        : 'GB',
+         'tooltipType'  : 'percentage'
+       };
+
+       $scope.dataMemory = {
+         'total': '250',
+         'xData': dates,
+         'yData': ['used', '20', '20', '35', '70', '20', '87', '14', '95', '25', '28', '44', '56', '66', '16', '67', '88', '76', '65', '87', '56']
+       };
+
+       $scope.actionBarConfig = {
+         'iconClass' : 'fa fa-plus-circle',
+         'text'      : 'Add New Cluster',
+         'callBackFn': function () {
+            alert("Footer Callback Fn Called");
+          }
+       }
+     });
+ </file>
+ </example>
+ */

--- a/src/card/basic/card.directive.js
+++ b/src/card/basic/card.directive.js
@@ -34,30 +34,6 @@
 
  <file name="index.html">
    <div ng-controller="ChartCtrl">
-     <label class="label-title">Timeframe filter in header</label>
-     <div pf-card head-title="Card Title" sub-title="Card Subtitle" show-top-border="true" filter="filterConfigHeader" style="width: 50%">
-       Card Contents
-     </div>
-
-     <label class="label-title">Footer with Link & Timeframe filter</label>
-     <div pf-card head-title="Card Title" sub-title="Card Subtitle" show-top-border="true"
-          footer="footerConfig" filter="filterConfig" style="width: 50%">
-       Card Contents
-     </div>
-
-     <label class="label-title">Card With Single Trend Chart</label>
-     <div pf-card head-title="Cluster Utilization" show-top-border="true" footer="footerConfig" filter="filterConfig" style="width: 50%">
-       <div pf-trends-chart config="configSingle" chart-data="dataSingle"></div>
-     </div>
-
-     <label class="label-title">Card With Multiple Trends</label>
-     <div pf-card head-title="Performance" sub-title="Last 30 Days" show-top-border="false"
-          show-titles-separator="false" style="width: 65%" footer="actionBarConfig">
-       <div pf-trends-chart config="configVirtual" chart-data="dataVirtual"></div>
-       <div pf-trends-chart config="configPhysical" chart-data="dataPhysical"></div>
-       <div pf-trends-chart config="configMemory" chart-data="dataMemory"></div>
-     </div>
-
      <label class="label-title">Card With Multiple Utilization Bars</label>
      <div pf-card head-title="System Resources" show-top-border="true" style="width: 65%">
        <div pf-utilization-bar-chart chart-data=data2 chart-title=title2 layout=layoutInline units=units2 threshold-error="85" threshold-warning="60"></div>
@@ -65,113 +41,13 @@
        <div pf-utilization-bar-chart chart-data=data4 chart-title=title4 layout=layoutInline units=units4 threshold-error="85" threshold-warning="60"></div>
        <div pf-utilization-bar-chart chart-data=data5 chart-title=title5 layout=layoutInline units=units5 threshold-error="85" threshold-warning="60"></div>
      </div>
-
    </div>
  </file>
  <file name="script.js">
  angular.module( 'demo', ['patternfly.charts', 'patternfly.card'] ).controller( 'ChartCtrl', function( $scope ) {
 
-       $scope.footerConfig = {
-         'iconClass' : 'fa fa-flag',
-         'text'      : 'View All Events',
-         'callBackFn': function () {
-            alert("Footer Callback Fn Called");
-          }
-       }
-
-       $scope.filterConfigHeader = {
-         'filters' : [{label:'Last 30 Days', value:'30'},
-                      {label:'Last 15 Days', value:'15'},
-                      {label:'Today', value:'today'}],
-         'callBackFn': function (f) {
-            alert("Header Filter Callback Fn Called for '" + f.label + "' value = " + f.value);
-          },
-        'position' : 'header'
-       }
-
-       $scope.filterConfig = {
-         'filters' : [{label:'Last 30 Days', value:'30'},
-                      {label:'Last 15 Days', value:'15'},
-                      {label:'Today', value:'today'}],
-         'callBackFn': function (f) {
-            alert("Filter Callback Fn Called for '" + f.label + "' value = " + f.value);
-          },
-        'defaultFilter' : '1'
-       }
-
-       var today = new Date();
-       var dates = ['dates'];
-       for (var d = 20 - 1; d >= 0; d--) {
-         dates.push(new Date(today.getTime() - (d * 24 * 60 * 60 * 1000)));
-       }
-
-       $scope.configSingle = {
-         'chartId'      : 'example2TrendsChart',
-         'title'        : 'Storage Capacity',
-         'layout'       : 'compact',
-         'valueType'    : 'actual',
-         'units'        : 'TB',
-         'tooltipType'  : 'percentage'
-       };
-
-       $scope.dataSingle = {
-         'total': '250',
-         'xData': dates,
-         'yData': ['used', '90', '20', '30', '20', '20', '10', '14', '20', '25', '68', '44', '56', '78', '56', '67', '88', '76', '65', '87', '76']
-       };
-
-       $scope.configVirtual = {
-         'chartId'      : 'virtualTrendsChart',
-         'layout'       : 'inline',
-         'trendLabel'   : 'Virtual Disk I/O',
-         'units'        : 'GB',
-         'tooltipType'  : 'percentage'
-       };
-
-       $scope.dataVirtual = {
-         'total': '250',
-         'xData': dates,
-         'yData': ['used', '90', '20', '30', '20', '20', '10', '14', '20', '25', '68', '44', '56', '78', '56', '67', '88', '76', '65', '87', '76']
-       };
-
-       $scope.configPhysical = {
-         'chartId'      : 'physicalTrendsChart',
-         'layout'       : 'inline',
-         'trendLabel'   : 'Physical Disk I/O',
-         'units'        : 'MHz',
-         'tooltipType'  : 'percentage'
-       };
-
-       $scope.dataPhysical = {
-         'total': '250',
-         'xData': dates,
-         'yData': ['used', '20', '20', '35', '20', '20', '87', '14', '20', '25', '28', '44', '56', '78', '56', '67', '88', '76', '65', '87', '16']
-       };
-
-       $scope.configMemory = {
-         'chartId'      : 'memoryTrendsChart',
-         'layout'       : 'inline',
-         'trendLabel'   : 'Memory Utilization',
-         'units'        : 'GB',
-         'tooltipType'  : 'percentage'
-       };
-
-       $scope.dataMemory = {
-         'total': '250',
-         'xData': dates,
-         'yData': ['used', '20', '20', '35', '70', '20', '87', '14', '95', '25', '28', '44', '56', '66', '16', '67', '88', '76', '65', '87', '56']
-       };
-
-       $scope.actionBarConfig = {
-         'iconClass' : 'fa fa-plus-circle',
-         'text'      : 'Add New Cluster',
-         'callBackFn': function () {
-            alert("Footer Callback Fn Called");
-          }
-       }
-
-       $scope.title2      = 'Memory';
-       $scope.units2      = 'GB';
+       $scope.title2 = 'Memory';
+       $scope.units2 = 'GB';
 
        $scope.data2 = {
          'used': '25',


### PR DESCRIPTION
This is an alternate approach to #220, where pfCard examples have been moved under the "patternfly.examples" doc name.

@jeff-phillips-18 and @dtaylor113 please comment.