### PR TITLE
Added TravisCI badge to README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/patternfly/angular-patternfly.svg?branch=master)](https://travis-ci.org/patternfly/angular-patternfly)
+
 # AngularJS directives for [PatternFly](https://www.patternfly.org) 
 
 This project will provide a set of common AngularJS directives for use with the PatternFly reference implementation.


### PR DESCRIPTION
TravisCI is already running in angular-patternfly, this just exposes the badge:

![image](https://cloud.githubusercontent.com/assets/12733153/16663962/2acbf8ca-444c-11e6-9ef3-b6c221a162c8.png)
