### PR TITLE
bootstrap-select tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -129,7 +129,7 @@ module.exports = function (grunt) {
             'lib/bootstrap-combobox/js/bootstrap-combobox.js',
             'lib/bootstrap-datepicker/dist/js/bootstrap-datepicker.js',
             'lib/bootstrap-select/js/bootstrap-select.js',
-            'lib/bootstrap-treeview/src/js/bootstrap-treeview.js',
+            'lib/patternfly-bootstrap-treeview/src/js/bootstrap-treeview.js',
             'lib/c3/c3.js',
             'lib/d3/d3.js',
             'lib/patternfly/dist/js/patternfly.js',

--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "angular-sanitize": "1.3.0 - 1.5.*",
     "angular-bootstrap": "0.13.x",
     "lodash": "3.x",
-    "patternfly": "~3.7.0"
+    "patternfly": "~3.8.0"
   },
   "devDependencies": {
     "angular-mocks": "1.3.0 - 1.5.*"

--- a/test/charts/heatmap/heatmap.spec.js
+++ b/test/charts/heatmap/heatmap.spec.js
@@ -54,7 +54,8 @@ describe('Directive: pfHeatmap', function() {
     expect(tooltip).toBe('Node 8 : My OpenShift Provider<br>96% : 96 Used of 100 Total<br>4 Available');
 
     color = block.attr('style');
-    expect(color.trim()).toBe('fill: #ce0000;');
+    var result = color.trim() == 'fill: #ce0000;' || color.trim() == 'fill: rgb(206, 0, 0);';
+    expect(result).toBe(true);
   });
 
   it("should block color based on color pattern overrides", function() {
@@ -67,7 +68,9 @@ describe('Directive: pfHeatmap', function() {
     block = angular.element(element).find('.heatmap-pf-svg').children().first();
 
     color = block.attr('style');
-    expect(color.trim()).toBe('fill: #ff0000;');
+
+    var result = color.trim() == 'fill: #ff0000;' || color.trim() == 'fill: rgb(255, 0, 0);';
+    expect(result).toBe(true);
   });
 
   it("should set color based on threshold overrides", function() {
@@ -78,7 +81,9 @@ describe('Directive: pfHeatmap', function() {
     element = compileChart('<div pf-heatmap chart-title="title" data="data" legend-labels="legendLabels" heatmap-color-pattern="heatmapColorPattern" thresholds="thresholds"></div>',$scope);
     block = angular.element(element).find('.heatmap-pf-svg').children().first();
     color = block.attr('style');
-    expect(color.trim()).toBe('fill: #ce0000;');
+
+    var result = color.trim() == 'fill: #ce0000;' || color.trim() == 'fill: rgb(206, 0, 0);';
+    expect(result).toBe(true);
   });
 
   it("should show a legend by default", function() {

--- a/test/select/select.spec.js
+++ b/test/select/select.spec.js
@@ -30,7 +30,7 @@ describe('pf-select', function () {
       expect(select.text()).toBe('abc');
       expect(select).toEqualSelect(['a', ['b'], 'c']);
 
-      var bsSelect = angular.element(select).siblings('.bootstrap-select');
+      var bsSelect = angular.element(select).siblings('.dropdown-menu');
       var bsSelItems = bsSelect.find('li');
       expect(bsSelItems.length).toBe($scope.options.length);
       expect(bsSelItems.text()).toBe('abc');
@@ -49,7 +49,7 @@ describe('pf-select', function () {
       expect(select.text()).toBe('abc');
       expect(select).toEqualSelect([['a'], 'b', 'c']);
 
-      var bsSelect = angular.element(select).siblings('.bootstrap-select');
+      var bsSelect = angular.element(select).siblings('.dropdown-menu');
       var bsSelItems = bsSelect.find('li');
       expect(bsSelItems.length).toBe($scope.options.length);
       expect(bsSelItems.text()).toBe('abc');
@@ -63,7 +63,7 @@ describe('pf-select', function () {
       expect(select.text()).toBe('abcd');
       expect(select).toEqualSelect([['a'], 'b', 'c', 'd']);
 
-      bsSelect = angular.element(select).siblings('.bootstrap-select');
+      bsSelect = angular.element(select).siblings('.dropdown-menu');
       bsSelItems = bsSelect.find('li');
       expect(bsSelItems.length).toBe($scope.options.length);
       expect(bsSelItems.text()).toBe('abcd');
@@ -78,7 +78,7 @@ describe('pf-select', function () {
       expect(select.text()).toBe('abc');
       expect(select).toEqualSelect([['a'], 'b', 'c']);
 
-      var bsSelect = angular.element(select).siblings('.bootstrap-select');
+      var bsSelect = angular.element(select).siblings('.dropdown-menu');
       var bsSelItems = bsSelect.find('li');
       expect(bsSelItems.length).toBe($scope.options.length);
       expect(bsSelItems.text()).toBe('abc');


### PR DESCRIPTION
A couple things happening with this PR for release prep.

* Referencing #master-dist for testing until release is complete:
```
"patternfly": "git://github.com/patternfly/patternfly.git#master-dist"
```
* Re-referencing `patternfly-bootrap-treeview` after [#382](https://github.com/patternfly/patternfly/pull/382) in Patternfly
* Noticed that `heatmap.spec.js` would fail when running `karma start` and debugging in Chrome due to styles being converted to rgb
* Fixes tests in `select.spec.js` due to `bootstrap-select` dependency upgrade in Patternfly [#365](https://github.com/patternfly/patternfly/pull/365)

Bootstrap-select now renders select options within the `bootstrap-select` div as of `v1.10.0`, so the sibling selector should now be `.dropdown-menu`.

i.e. new rendering looks like this:
```
<div class="btn-group bootstrap-select">
	<button type="button" class="btn dropdown-toggle btn-default"></button>
	<div class="dropdown-menu open">
		<ul class="dropdown-menu inner" role="menu">
			<li></li>
			<li></li>
			<li></li>
		</ul>
	</div>
	<select pf-select="" ng-model="modelValue" ng-options="o as o for o in options">
		<option></option>
		<option></option>
		<option></option>
	</select>
</div>
```

old rendering looks like this:
```
 <select pf-select="" ng-model="modelValue" ng-options="o as o for o in options">
	<option></option>
	<option></option>
	<option></option>
</select>
<div class="btn-group bootstrap-select">
	<button type="button" class="btn dropdown-toggle btn-default"></button>
	<div class="dropdown-menu open">
		<ul class="dropdown-menu inner" role="menu">
			<li></li>
			<li></li>
			<li></li>
		</ul>
	</div>
</div>
```