### PR TITLE
update package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -22,7 +22,6 @@ dist/docs/index.html
 
 
 /docs
-/dist
 node_modules
 npm-debug.log
 lib

--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+require('angular');
+require('angular-animate');
+require('angular-sanitize');
+require('angular-ui-bootstrap');
+require('lodash');
+require('../patternfly/dist/js/patternfly.min');
+require('./dist/angular-patternfly');
+module.exports = 'angular-patternfly';

--- a/package.json
+++ b/package.json
@@ -4,8 +4,17 @@
   "version": "3.8.1",
   "license": "Apache-2.0",
   "description": "Angular extension of the PatternFly project.",
+  "keywords": ["angular", "patternfly"],
+  "main": "index.js",
   "homepage": "https://github.com/patternfly/angular-patternfly",
-  "dependencies": {},
+  "dependencies": {
+    "angular": "1.3.0 - 1.5.*",
+    "angular-animate": "1.3.0 - 1.5.*",
+    "angular-sanitize": "1.3.0 - 1.5.*",
+    "angular-ui-bootstrap": "0.13.x",
+    "lodash": "3.x",
+    "patternfly": "~3.8.1"
+  },
   "devDependencies": {
     "express": "3.4.4",
     "grunt": "0.4.5",


### PR DESCRIPTION
* updates package.json with dependencies (so npm published distrubution is accurate) for [PTNFLY-1626](https://patternfly.atlassian.net/browse/PTNFLY-1626)
* add `.npmignore` to allow `dist` files in npm distribution
* add index.js to allow `Browserify` or CommonJS support. Noted [here](http://blog.npmjs.org/post/114584444410/using-angulars-new-improved-browserify-support)