### PR TITLE
Add pfToastNotification and pfToastNotificationList Directives

### DIFF
--- a/src/notification/toast-notification-list.directive.js
+++ b/src/notification/toast-notification-list.directive.js
@@ -1,0 +1,213 @@
+/**
+ * @ngdoc directive
+ * @name patternfly.notification.directive:pfToastNotificationList
+ * @restrict A
+ * @scope
+ *
+ * @param {Array} notifications The list of current notifcations to display. Each notification should have the following (see pfToastNotification):
+ *           <ul style='list-style-type: none'>
+ *             <li>.type - (String) The type of the notification message. Allowed value is one of these: 'success','info','danger', 'warning'
+ *             <li>.header - (String) The header to display for the notification (optional)
+ *             <li>.message - (String) The main text message of the notification.
+ *             <li>.actionTitle Text to show for the primary action, optional.
+ *             <li>.actionCallback (function(this notification)) Function to invoke when primary action is selected, optional
+ *             <li>.menuActions  Optional list of actions to place in the kebab menu:<br/>
+ *               <ul style='list-style-type: none'>
+ *                 <li>.name - (String) The name of the action, displayed on the button
+ *                 <li>.actionFn - (function(action, this notification)) Function to invoke when the action selected
+ *                 <li>.isDisabled - (Boolean) set to true to disable the action
+ *                 <li>.isSeparator - (Boolean) set to true if this is a placehodler for a separator rather than an action
+ *               </ul>
+ *             <li>.isPersistent Flag to show close button for the notification even if showClose is false.
+ *           </ul>
+ * @param {Boolean} showClose Flag to show the close button on all notifications (not shown if the notification has menu actions)
+ * @param {function} closeCallback (function(data)) Function to invoke when closes a toast notification
+ * @param {function} updateViewing (function(boolean, data)) Function to invoke when user is viewing/not-viewing (hovering on) a toast notification
+ *
+ * @description
+ * Using this directive displayes a list of toast notifications
+ *
+ * @example
+ <example module="patternfly.notification">
+
+   <file name="index.html">
+     <div ng-controller="ToastNotificationListDemoCtrl" >
+       <div pf-toast-notification-list notifications="notifications" show-close="showClose" close-callback="handleClose" update-viewing="updateViewing"></div>
+       <div class="row example-container">
+         <div class="col-md-12">
+           <form class="form-horizontal">
+             <div class="form-group">
+               <label class="col-sm-3 control-label" for="type">Show Close buttons:</label>
+               <div class="col-sm-1">
+                 <input type="checkbox" ng-model="showClose"/>
+               </div>
+             </div>
+             <div class="form-group">
+               <label class="col-sm-2 control-label" for="type">Type:</label>
+               <div class="col-sm-10">
+                <select pf-select ng-model="type" id="type" ng-options="o as o for o in types"></select>
+               </div>
+             </div>
+             <div class="form-group">
+               <label class="col-sm-2 control-label" for="header">Header:</label>
+               <div class="col-sm-10">
+                 <input type="text" class="form-control" ng-model="header" id="header"/>
+               </div>
+             </div>
+             <div class="form-group">
+               <label class="col-sm-2 control-label" for="message">Message:</label>
+               <div class="col-sm-10">
+                <input type="text" class="form-control" ng-model="message" id="message"/>
+               </div>
+             </div>
+             <div class="form-group">
+               <label class="col-sm-2 control-label" for="message">Primary Action:</label>
+               <div class="col-sm-10">
+                 <input type="text" class="form-control" ng-model="primaryAction" id="primaryAction"/>
+               </div>
+             </div>
+             <div class="form-group">
+               <label class="col-sm-2 control-label" for="type">Persistent:</label>
+               <div class="col-sm-1">
+                 <input type="checkbox" ng-model="persistent"/>
+               </div>
+               <label class="col-sm-2 control-label" for="type">Show Menu:</label>
+               <div class="col-sm-2">
+                 <input type="checkbox" ng-model="showMenu"/>
+               </div>
+             </div>
+             <div class="form-group">
+               <div class="col-sm-12">
+                 <button ng-click="notify()">Add notification - Click me several times</button>
+               </div>
+             </div>
+           </form>
+         </div>
+         <div class="col-md-12">
+           <label class="actions-label">Actions: </label>
+         </div>
+         <div class="col-md-12">
+           <textarea rows="3" class="col-md-12">{{actionText}}</textarea>
+         </div>
+       </div>
+     </div>
+   </file>
+
+   <file name="script.js">
+     angular.module('patternfly.notification').controller( 'ToastNotificationListDemoCtrl', function( $scope, $rootScope, Notifications ) {
+       $scope.message = 'Default Message.';
+
+       var typeMap = { 'Info': 'info',
+                       'Success': 'success',
+                       'Warning': 'warning',
+                       'Danger': 'danger' };
+
+       $scope.types = Object.keys(typeMap);
+
+       $scope.type = $scope.types[0];
+       $scope.header = 'Default header.';
+       $scope.message = 'Default notification message.';
+       $scope.showClose = false;
+       $scope.persistent = false;
+
+       $scope.primaryAction = '';
+
+       $scope.showMenu = false;
+       var performAction = function (menuAction, data) {
+         $scope.actionText += menuAction.name +  ": " + data.message + '\n';
+       };
+       $scope.menuActions = [
+          {
+            name: 'Action',
+            title: 'Perform an action',
+            actionFn: performAction
+          },
+          {
+            name: 'Another Action',
+            title: 'Do something else',
+            actionFn: performAction
+          },
+          {
+            name: 'Disabled Action',
+            title: 'Unavailable action',
+            actionFn: performAction,
+            isDisabled: true
+          },
+          {
+            name: 'Something Else',
+            title: '',
+            actionFn: performAction
+          },
+          {
+            isSeparator: true
+          },
+          {
+            name: 'Grouped Action 1',
+            title: 'Do something',
+            actionFn: performAction
+          },
+          {
+            name: 'Grouped Action 2',
+            title: 'Do something similar',
+            actionFn: performAction
+          }
+        ];
+
+       $scope.actionText = "";
+
+       $scope.handleAction = function (data) {
+         $scope.actionText = $scope.primaryAction + ": " + data.message + '\n' + $scope.actionText;
+       };
+       $scope.handleClose = function (data) {
+         $scope.actionText = "Closed: " + data.message + '\n'+ $scope.actionText;
+         Notifications.remove(data);
+       };
+       $scope.updateViewing = function (viewing, data) {
+         Notifications.setViewing(data, viewing);
+       };
+
+       $scope.notify = function () {
+         Notifications.message (
+           typeMap[$scope.type],
+           $scope.header,
+           $scope.message,
+           $scope.persistent,
+           $scope.handleClose,
+           $scope.primaryAction,
+           $scope.handleAction,
+           ($scope.showMenu ? $scope.menuActions : undefined)
+         );
+       }
+
+       $scope.notifications = Notifications.data;
+     });
+   </file>
+
+ </example>
+ */
+angular.module('patternfly.notification').directive('pfToastNotificationList', function () {
+  'use strict';
+
+  return {
+    restrict: 'A',
+    scope: {
+      notifications: '=',
+      showClose: '=?',
+      closeCallback: '=?',
+      updateViewing: '=?'
+    },
+    templateUrl: 'notification/toast-notification-list.html',
+    controller: function ($scope) {
+      $scope.handleClose = function (notification) {
+        if (angular.isFunction($scope.closeCallback)) {
+          $scope.closeCallback(notification);
+        }
+      };
+      $scope.handleViewingChange = function (isViewing, notification) {
+        if (angular.isFunction($scope.updateViewing)) {
+          $scope.updateViewing(isViewing, notification);
+        }
+      };
+    }
+  };
+});

--- a/src/notification/toast-notification-list.html
+++ b/src/notification/toast-notification-list.html
@@ -1,0 +1,15 @@
+<div class="toast-notification-list-pf" data-ng-show="notifications.length > 0">
+  <div ng-repeat="notification in notifications">
+    <div pf-toast-notification notification-type="{{notification.type}}"
+         header="{{notification.header}}"
+         message="{{notification.message}}"
+         show-close="{{(showClose || notification.isPersistent === true) && !(notification.menuActions && notification.menuActions.length > 0)}}"
+         close-callback="handleClose"
+         action-title="{{notification.actionTitle}}"
+         action-callback="notification.actionCallback"
+         menu-actions="notification.menuActions"
+         update-viewing="handleViewingChange"
+         data="notification">
+    </div>
+  </div>
+</div>

--- a/src/notification/toast-notification.directive.js
+++ b/src/notification/toast-notification.directive.js
@@ -1,0 +1,228 @@
+/**
+ * @ngdoc directive
+ * @name patternfly.notification.directive:pfToastNotification
+ * @restrict E
+ * @scope
+ *
+ * @param {string} notificationType The type of the notification message. Allowed value is one of these: 'success','info','danger', 'warning'
+ * @param {string} header The header text of the notification.
+ * @param {string} message The main text message of the notification.
+ * @param {boolean} showClose Flag to show the close button, default: true
+ * @param {function} closeCallback (function(data)) Function to invoke when close action is selected, optional
+ * @param {string} actionTitle Text to show for the primary action, optional.
+ * @param {function} actionCallback (function(data)) Function to invoke when primary action is selected, optional
+ * @param {Array} menuActions  Optional list of actions to place in the kebab menu:<br/>
+ *           <ul style='list-style-type: none'>
+ *             <li>.name - (String) The name of the action, displayed on the button
+ *             <li>.actionFn - (function(action, data)) Function to invoke when the action selected
+ *             <li>.isDisabled - (Boolean) set to true to disable the action
+ *             <li>.isSeparator - (Boolean) set to true if this is a placehodler for a separator rather than an action
+ *           </ul>
+ * @param {function} updateViewing (function(boolean, data)) Function to invoke when user is viewing/no-viewing (hovering on) the toast
+ * @param {object} data Any data needed by the callbacks (optional)
+ *
+ * @description
+ * Toast notifications are used to notify users of a system occurence. Toast notifications should be transient and stay on the screen for 8 seconds,
+ * so that they do not block the information behind them for too long, but allows the user to read the message.
+ * The pfToastNotification directive allows status, header, message, primary action and menu actions for the notification. The notification can also
+ * allow the user to close the notification.
+ *
+ * Note: Using the kebab menu (menu actions) with the close button is not currently supported. If both are specified the close button will not be shown.
+ * Add a close menu item if you want to have both capabilities.
+ *
+ * @example
+ <example module="patternfly.notification">
+
+   <file name="index.html">
+     <div ng-controller="ToastNotificationDemoCtrl" class="row example-container">
+       <div class="col-md-12">
+         <div pf-toast-notification notification-type="{{type}}" header="{{header}}" message="{{message}}"
+              show-close="{{showClose}}" close-callback="closeCallback"
+              action-title="{{primaryAction}}" action-callback="handleAction"
+              menu-actions="menuActions">
+         </div>
+
+         <form class="form-horizontal">
+           <div class="form-group">
+             <label class="col-sm-2 control-label" for="header">Header:</label>
+             <div class="col-sm-10">
+              <input type="text" class="form-control" ng-model="header" id="header"/>
+             </div>
+           </div>
+           <div class="form-group">
+             <label class="col-sm-2 control-label" for="message">Message:</label>
+             <div class="col-sm-10">
+               <input type="text" class="form-control" ng-model="message" id="message"/>
+             </div>
+           </div>
+           <div class="form-group">
+             <label class="col-sm-2 control-label" for="message">Primary Action:</label>
+             <div class="col-sm-10">
+              <input type="text" class="form-control" ng-model="primaryAction" id="primaryAction"/>
+             </div>
+           </div>
+           <div class="form-group">
+             <label class="col-sm-2 control-label" for="type">Type:</label>
+             <div class="col-sm-10">
+              <select pf-select ng-model="type" id="type" ng-options="o as o for o in types"></select>
+             </div>
+           </div>
+           <div class="form-group">
+             <label class="col-sm-2 control-label" for="type">Show Close:</label>
+             <div class="col-sm-3">
+             <input type="checkbox" ng-model="showClose"/>
+             </div>
+             <label class="col-sm-2 control-label" for="type">Show Menu:</label>
+             <div class="col-sm-3">
+              <input type="checkbox" ng-model="showMenu"/>
+             </div>
+           </div>
+         </form>
+       </div>
+       <div class="col-md-12">
+         <label class="actions-label">Actions: </label>
+       </div>
+       <div class="col-md-12">
+         <textarea rows="3" class="col-md-12">{{actionText}}</textarea>
+       </div>
+     </div>
+   </file>
+
+   <file name="script.js">
+     angular.module( 'patternfly.notification' ).controller( 'ToastNotificationDemoCtrl', function( $scope, Notifications ) {
+       $scope.types = ['success','info','danger', 'warning'];
+       $scope.type = $scope.types[0];
+       $scope.showClose = false;
+
+       $scope.header = 'Default Header.';
+       $scope.message = 'Default Message.';
+       $scope.primaryAction = '';
+
+       $scope.showMenu = false;
+       var performAction = function (menuAction) {
+         $scope.actionText += menuAction.name + '\n';
+       };
+       var menuActions = [
+          {
+            name: 'Action',
+            title: 'Perform an action',
+            actionFn: performAction
+          },
+          {
+            name: 'Another Action',
+            title: 'Do something else',
+            actionFn: performAction
+          },
+          {
+            name: 'Disabled Action',
+            title: 'Unavailable action',
+            actionFn: performAction,
+            isDisabled: true
+          },
+          {
+            name: 'Something Else',
+            title: '',
+            actionFn: performAction
+          },
+          {
+            isSeparator: true
+          },
+          {
+            name: 'Grouped Action 1',
+            title: 'Do something',
+            actionFn: performAction
+          },
+          {
+            name: 'Grouped Action 2',
+            title: 'Do something similar',
+            actionFn: performAction
+          }
+        ];
+
+       $scope.$watch('showMenu',  function () {
+          if ($scope.showMenu) {
+            $scope.menuActions = menuActions;
+          } else {
+            $scope.menuActions = undefined;
+          }
+       });
+
+       $scope.actionText = "";
+
+       $scope.handleAction = function () {
+         $scope.actionText = $scope.primaryAction + '\n' + $scope.actionText;
+       };
+       $scope.closeCallback = function () {
+         $scope.actionText = "Close" + '\n' + $scope.actionText;
+       };
+     });
+   </file>
+
+ </example>
+ */
+angular.module( 'patternfly.notification' ).directive('pfToastNotification', function () {
+  'use strict';
+
+  return {
+    scope: {
+      'notificationType': '@',
+      'message': '@',
+      'header': '@',
+      'showClose': '@',
+      'closeCallback': '=?',
+      'actionTitle': '@',
+      'actionCallback': '=?',
+      'menuActions': '=?',
+      'updateViewing': '=?',
+      'data': '=?'
+    },
+    restrict: 'A',
+    templateUrl: 'notification/toast-notification.html',
+    controller: function ($scope) {
+      $scope.notificationType = $scope.notificationType || 'info';
+
+      $scope.updateShowClose = function () {
+        $scope.showCloseButton = ($scope.showClose === 'true') && (angular.isUndefined($scope.menuActions) || $scope.menuActions.length < 1);
+      };
+
+      $scope.handleClose = function () {
+        if (angular.isFunction($scope.closeCallback)) {
+          $scope.closeCallback($scope.data);
+        }
+      };
+
+      $scope.handleAction = function () {
+        if (angular.isFunction($scope.actionCallback)) {
+          $scope.actionCallback($scope.data);
+        }
+      };
+
+      $scope.handleMenuAction = function (menuAction) {
+        if (menuAction && angular.isFunction(menuAction.actionFn) && (menuAction.isDisabled !== true)) {
+          menuAction.actionFn(menuAction, $scope.data);
+        }
+      };
+
+      $scope.handleEnter = function () {
+        if (angular.isFunction($scope.updateViewing)) {
+          $scope.updateViewing(true, $scope.data);
+        }
+      };
+      $scope.handleLeave = function () {
+        if (angular.isFunction($scope.updateViewing)) {
+          $scope.updateViewing(false, $scope.data);
+        }
+      };
+
+      $scope.updateShowClose ();
+    },
+    link: function (scope) {
+      scope.$watch('showClose', function () {
+        scope.updateShowClose();
+      });
+      scope.$watch('menuActions', function () {
+        scope.updateShowClose();
+      });
+    }
+  };
+});

--- a/src/notification/toast-notification.html
+++ b/src/notification/toast-notification.html
@@ -1,0 +1,36 @@
+<div class="toast-pf alert alert-{{notificationType}}" ng-class="{'alert-dismissable': showCloseButton}"
+     ng-mouseenter="handleEnter()" ng-mouseleave="handleLeave()">
+  <div class="dropdown pull-right dropdown-kebab-pf" ng-if="menuActions && menuActions.length > 0">
+    <button class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+      <span class="fa fa-ellipsis-v"></span>
+    </button>
+    <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight">
+      <li ng-repeat="menuAction in menuActions"
+          role="{{menuAction.isSeparator === true ? 'separator' : 'menuitem'}}"
+          ng-class="{'divider': menuAction.isSeparator === true, 'disabled': menuAction.isDisabled === true}">
+        <a ng-if="menuAction.isSeparator !== true"
+           class="secondary-action"
+           title="{{menuAction.title}}"
+           ng-click="handleMenuAction(menuAction)">
+          {{menuAction.name}}
+        </a>
+      </li>
+    </ul>
+  </div>
+  <button ng-if="showCloseButton" type="button" class="close" aria-hidden="true" ng-click="handleClose()">
+    <span class="pficon pficon-close"></span>
+  </button>
+  <div class="pull-right toast-pf-action" ng-if="actionTitle">
+    <a ng-click="handleAction()">{{actionTitle}}</a>
+  </div>
+  <span class="pficon pficon-ok" ng-if="notificationType === 'success'"></span>
+  <span class="pficon pficon-info" ng-if="notificationType === 'info'"></span>
+  <span class="pficon pficon-error-circle-o" ng-if="notificationType === 'danger'"></span>
+  <span class="pficon pficon-warning-triangle-o" ng-if="notificationType === 'warning'"></span>
+  <span ng-if="header">
+    <strong>{{header}}</strong> {{message}}
+  </span>
+  <span ng-if="!header">
+    {{message}}
+  </span>
+</div>

--- a/styles/angular-patternfly.css
+++ b/styles/angular-patternfly.css
@@ -453,3 +453,19 @@ accordion > .panel-group .panel-open .panel-title > a:before {
 .drawer-pf-notification .expanded-notification .drawer-pf-notification-message {
   display: inline-block;
 }
+
+.toast-notification-list-pf {
+  position: fixed;
+  right: 15px;
+  top: 15px;
+  z-index: 1050;
+}
+.toast-notification-list-pf .toast-pf.alert {
+  float: right;
+}
+.toast-pf-action > a {
+  cursor: pointer;
+}
+.toast-pf .dropdown-menu > li > a {
+  cursor: pointer;
+}

--- a/test/notification/toast-notification-list.spec.js
+++ b/test/notification/toast-notification-list.spec.js
@@ -1,0 +1,210 @@
+describe('Directive: pfToastNotificationList', function () {
+
+  var $scope;
+  var $compile;
+  var element;
+
+  // load the controller's module
+  beforeEach(function () {
+    module('patternfly.notification', 'notification/toast-notification-list.html', 'notification/toast-notification.html');
+  });
+
+  beforeEach(inject(function (_$compile_, _$rootScope_) {
+    $compile = _$compile_;
+    $scope = _$rootScope_;
+  }));
+
+  var compileHTML = function (markup, scope) {
+    element = angular.element(markup);
+    $compile(element)(scope);
+
+    scope.$digest();
+  };
+
+  beforeEach(function () {
+    $scope.closeData = undefined;
+    $scope.handleClose = function (data) {
+      $scope.closeData = data;
+    };
+
+    $scope.actionData = undefined;
+    var handleAction = function (data) {
+      $scope.actionData = data;
+    };
+
+    $scope.menuAction = undefined;
+    $scope.menuData = undefined;
+    var handleMenuAction = function (menuAction, data) {
+      $scope.menuAction = menuAction;
+      $scope.menuData = data;
+    };
+
+    var menuActions = [
+      {
+        name: 'Action',
+        title: 'Perform an action',
+        actionFn: handleMenuAction
+      },
+      {
+        name: 'Another Action',
+        title: 'Do something else',
+        actionFn: handleMenuAction
+      },
+      {
+        name: 'Disabled Action',
+        title: 'Unavailable action',
+        actionFn: handleMenuAction,
+        isDisabled: true
+      },
+      {
+        name: 'Something Else',
+        title: '',
+        actionFn: handleMenuAction
+      },
+      {
+        isSeparator: true
+      },
+      {
+        name: 'Grouped Action 1',
+        title: 'Do something',
+        actionFn: handleMenuAction
+      },
+      {
+        name: 'Grouped Action 2',
+        title: 'Do something similar',
+        actionFn: handleMenuAction
+      }
+    ];
+
+    $scope.notifications = [
+      {
+        type: 'info',
+        header: 'Header 1',
+        message: 'Message 1',
+        isPersistent: true,
+        actionTitle: "Action 1",
+        actionCallback: handleAction,
+        menuActions: menuActions
+      },
+      {
+        type: 'danger',
+        header: 'Header 2',
+        message: 'Message 2',
+        isPersistent: false,
+        actionTitle: "Action 2",
+        actionCallback: handleAction,
+        menuActions: menuActions
+      },
+      {
+        type: 'warning',
+        header: 'Header 3',
+        message: 'Message 3',
+        isPersistent: true,
+        actionTitle: "Action 3",
+        actionCallback: handleAction,
+        menuActions: menuActions
+      },
+      {
+        type: 'success',
+        header: 'Header 4',
+        message: 'Message 4',
+        isPersistent: true,
+        actionTitle: "Action 4",
+        actionCallback: handleAction,
+        menuActions: menuActions
+      }
+    ];
+
+    var htmlTmp = '<div pf-toast-notification-list notifications="notifications" show-close="false" close-callback="handleClose"></div>';
+
+    compileHTML(htmlTmp, $scope);
+  });
+
+  it('should have the correct number of toast notifications', function () {
+    var toasts = element.find('.toast-notification-list-pf .toast-pf');
+    expect(toasts.length).toBe(4);
+
+    var okIcon = element.find('.pficon.pficon-ok');
+    var infoIcon = element.find('.pficon.pficon-info');
+    var errorIcon = element.find('.pficon.pficon-error-circle-o');
+    var warnIcon = element.find('.pficon.pficon-warning-triangle-o');
+    expect(okIcon.length).toBe(1);
+    expect(infoIcon.length).toBe(1);
+    expect(errorIcon.length).toBe(1);
+    expect(warnIcon.length).toBe(1);
+
+    $scope.notifications.splice(2, 1);
+    $scope.$digest();
+
+    toasts = element.find('.toast-notification-list-pf .toast-pf');
+    expect(toasts.length).toBe(3);
+
+    okIcon = element.find('.pficon.pficon-ok');
+    infoIcon = element.find('.pficon.pficon-info');
+    errorIcon = element.find('.pficon.pficon-error-circle-o');
+    warnIcon = element.find('.pficon.pficon-warning-triangle-o');
+    expect(okIcon.length).toBe(1);
+    expect(infoIcon.length).toBe(1);
+    expect(errorIcon.length).toBe(1);
+    expect(warnIcon.length).toBe(0);
+  });
+
+  it('should get the close callback invoked when an item is closed', function () {
+    // No close buttons when there are menu actions
+    var closeButton = element.find('.toast-notification-list-pf .toast-pf button.close');
+    expect(closeButton.length).toBe(0);
+
+    // No Menu Actions
+    $scope.notifications.forEach(function(nextItem) {
+      nextItem.menuActions = undefined;
+    })
+    var htmlTmp = '<div pf-toast-notification-list notifications="notifications" show-close="false" close-callback="handleClose"></div>';
+
+    compileHTML(htmlTmp, $scope);
+
+    var closeButton = element.find('.toast-notification-list-pf .toast-pf button.close');
+    expect(closeButton.length).toBe(3);
+
+    expect($scope.closeData).toBeUndefined();
+
+    eventFire(closeButton[1], 'click');
+    $scope.$digest();
+
+    expect($scope.closeData).toBeDefined();
+    expect($scope.closeData.header).toBe("Header 3");
+  });
+
+  it('should get the action callback invoked when an action button is closed', function () {
+    // No close buttons when there are menu actions
+    var closeButton = element.find('.toast-notification-list-pf .toast-pf .toast-pf-action > a');
+    expect(closeButton.length).toBe(4);
+
+    expect($scope.actionData).toBeUndefined();
+
+    eventFire(closeButton[1], 'click');
+    $scope.$digest();
+
+    expect($scope.actionData).toBeDefined();
+    expect($scope.actionData.header).toBe("Header 2");
+  });
+
+  it('should have the correct kebab menu and call the correct callback when items are clicked', function () {
+    var menuIndicator = element.find('.dropdown-kebab-pf');
+    expect(menuIndicator.length).toBe(4);
+    var menuItems = angular.element(menuIndicator[0]).find('.dropdown-menu li');
+    expect(menuItems.length).toBe(7);
+    var menuActions = angular.element(menuIndicator[0]).find('.dropdown-menu li > a');
+    expect(menuActions.length).toBe(6);
+
+    expect($scope.menuAction).toBeUndefined();
+    expect($scope.menuData).toBeUndefined();
+
+    eventFire(menuActions[1], 'click');
+    $scope.$digest();
+
+    expect($scope.menuAction).toBeDefined();
+    expect($scope.menuAction.name).toBe("Another Action");
+    expect($scope.menuData).toBeDefined();
+    expect($scope.menuData.header).toBe("Header 1");
+  });
+});

--- a/test/notification/toast-notification.spec.js
+++ b/test/notification/toast-notification.spec.js
@@ -1,0 +1,241 @@
+describe('Directive: pfToastNotification', function () {
+
+  var $scope;
+  var $compile;
+  var element;
+
+  // load the controller's module
+  beforeEach(function () {
+    module('patternfly.notification', 'notification/toast-notification.html');
+  });
+
+  beforeEach(inject(function (_$compile_, _$rootScope_) {
+    $compile = _$compile_;
+    $scope = _$rootScope_;
+  }));
+
+  var compileHTML = function (markup, scope) {
+    element = angular.element(markup);
+    $compile(element)(scope);
+
+    scope.$digest();
+  };
+
+  var setupHTML = function (notificationType, header, showClose, primaryAction, showMenu, data) {
+    $scope.type = notificationType;
+    $scope.header = header;
+    $scope.message = "Test Toast Notification Message";
+    $scope.showClose = showClose;
+    $scope.primaryAction = primaryAction;
+    $scope.data = data
+
+    $scope.closeData = undefined;
+    $scope.closeCallback = function (data) {
+      $scope.closeData = data;
+    };
+
+    $scope.actionData = undefined;
+    $scope.handleAction = function (data) {
+      $scope.actionData = data;
+    };
+
+    $scope.menuActions = undefined;
+    if (showMenu) {
+
+      $scope.menuAction = undefined;
+      $scope.menuData = undefined;
+      var handleMenuAction = function (menuAction, data) {
+        $scope.menuAction = menuAction;
+        $scope.menuData = data;
+      };
+
+      $scope.menuActions = [
+        {
+          name: 'Action',
+          title: 'Perform an action',
+          actionFn: handleMenuAction
+        },
+        {
+          name: 'Another Action',
+          title: 'Do something else',
+          actionFn: handleMenuAction
+        },
+        {
+          name: 'Disabled Action',
+          title: 'Unavailable action',
+          actionFn: handleMenuAction,
+          isDisabled: true
+        },
+        {
+          name: 'Something Else',
+          title: '',
+          actionFn: handleMenuAction
+        },
+        {
+          isSeparator: true
+        },
+        {
+          name: 'Grouped Action 1',
+          title: 'Do something',
+          actionFn: handleMenuAction
+        },
+        {
+          name: 'Grouped Action 2',
+          title: 'Do something similar',
+          actionFn: handleMenuAction
+        }
+      ];
+    }
+
+    $scope.data = {
+      title: "Test Notification"
+    };
+    var htmlTmp = '<div pf-toast-notification notification-type="{{type}}" header="{{header}}" message="{{message}}"' +
+                  '    show-close="{{showClose}}" close-callback="closeCallback"' +
+                  '    action-title="{{primaryAction}}" action-callback="handleAction"' +
+                  '    menu-actions="menuActions" data="data">' +
+                  '    </div>';
+
+    compileHTML(htmlTmp, $scope);
+  };
+
+  it('should have the correct header and message', function () {
+    setupHTML ("info", "Test Header", false, '', false);
+    header = element.find('.toast-pf span strong');
+    expect(header.length).toBe(1);
+    expect(header.text()).toBe("Test Header");
+    message = element.find('.toast-pf span');
+    expect(message.length).toBe(2);
+    expect(angular.element(message[1]).text()).toContain("Test Toast Notification Message");
+  });
+
+  it('should have the correct message when no header is given', function () {
+    setupHTML ("info", "", false, '', false);
+    var header = element.find('.toast-pf span strong');
+    expect(header.length).toBe(0);
+    var message = element.find('.toast-pf span');
+    expect(message.length).toBe(2);
+    expect(angular.element(message[1]).text()).toContain("Test Toast Notification Message");
+  });
+
+  it('should have the correct status icon', function () {
+    setupHTML ("success", "Test Header", false, '', false);
+    var okIcon = element.find('.pficon.pficon-ok');
+    var infoIcon = element.find('.pficon.pficon-info');
+    var errorIcon = element.find('.pficon.pficon-error-circle-o');
+    var warnIcon = element.find('.pficon.pficon-warning-triangle-o');
+    expect(okIcon.length).toBe(1);
+    expect(infoIcon.length).toBe(0);
+    expect(errorIcon.length).toBe(0);
+    expect(warnIcon.length).toBe(0);
+
+    setupHTML ("info", "Test Header", false, '', false);
+    okIcon = element.find('.pficon.pficon-ok');
+    infoIcon = element.find('.pficon.pficon-info');
+    errorIcon = element.find('.pficon.pficon-error-circle-o');
+    warnIcon = element.find('.pficon.pficon-warning-triangle-o');
+    expect(okIcon.length).toBe(0);
+    expect(infoIcon.length).toBe(1);
+    expect(errorIcon.length).toBe(0);
+    expect(warnIcon.length).toBe(0);
+
+    setupHTML ("danger", "Test Header", false, '', false);
+    okIcon = element.find('.pficon.pficon-ok');
+    infoIcon = element.find('.pficon.pficon-info');
+    errorIcon = element.find('.pficon.pficon-error-circle-o');
+    warnIcon = element.find('.pficon.pficon-warning-triangle-o');
+    expect(okIcon.length).toBe(0);
+    expect(infoIcon.length).toBe(0);
+    expect(errorIcon.length).toBe(1);
+    expect(warnIcon.length).toBe(0);
+
+    setupHTML ("warning", "Test Header", false, '', false);
+    okIcon = element.find('.pficon.pficon-ok');
+    infoIcon = element.find('.pficon.pficon-info');
+    errorIcon = element.find('.pficon.pficon-error-circle-o');
+    warnIcon = element.find('.pficon.pficon-warning-triangle-o');
+    expect(okIcon.length).toBe(0);
+    expect(infoIcon.length).toBe(0);
+    expect(errorIcon.length).toBe(0);
+    expect(warnIcon.length).toBe(1);
+
+  });
+
+  it('should have the close button when specified', function () {
+    setupHTML ("success", "Test Header", false, 'Test Action', true);
+    var closeButton = element.find('button.close');
+    expect(closeButton.length).toBe(0);
+
+    setupHTML ("success", "Test Header", true, 'Test Action', false);
+    closeButton = element.find('button.close');
+    expect(closeButton.length).toBe(1);
+
+    expect($scope.closeData).toBeUndefined();
+
+    eventFire(closeButton[0], 'click');
+    $scope.$digest();
+
+    expect($scope.closeData).toBeDefined();
+    expect($scope.closeData.title).toBe("Test Notification");
+
+    // No close button even if specified when menu actions exist
+    setupHTML ("success", "Test Header", true, 'Test Action', true);
+    closeButton = element.find('button.close');
+    expect(closeButton.length).toBe(0);
+  });
+
+  it('should have the correct primary action and call the correct callback when clicked', function () {
+    setupHTML ("success", "Test Header", false, 'Test Action', false);
+    var actionButton = element.find('.toast-pf-action > a');
+    expect(actionButton.length).toBe(1);
+    expect($scope.actionData).toBeUndefined();
+
+    eventFire(actionButton[0], 'click');
+    $scope.$digest();
+
+    expect($scope.actionData).toBeDefined();
+    expect($scope.actionData.title).toBe("Test Notification");
+  });
+
+  it('should have the correct kebab menu and call the correct callback when items are clicked', function () {
+    setupHTML ("success", "Test Header", false, 'Test Action', true);
+    var menuIndicator = element.find('.dropdown-kebab-pf');
+    expect(menuIndicator.length).toBe(1);
+    var menuItems = element.find('.dropdown-kebab-pf .dropdown-menu li');
+    expect(menuItems.length).toBe(7);
+    var menuActions = element.find('.dropdown-kebab-pf .dropdown-menu li > a');
+    expect(menuActions.length).toBe(6);
+
+    expect($scope.menuAction).toBeUndefined();
+    expect($scope.menuData).toBeUndefined();
+
+    eventFire(menuActions[1], 'click');
+    $scope.$digest();
+
+    expect($scope.menuAction).toBeDefined();
+    expect($scope.menuAction.name).toBe("Another Action");
+    expect($scope.menuData).toBeDefined();
+    expect($scope.menuData.title).toBe("Test Notification");
+  });
+
+  it('should have correct number of separators', function () {
+    setupHTML ("success", "Test Header", false, 'Test Action', true);
+    var fields = element.find('.dropdown-kebab-pf .dropdown-menu .divider');
+    expect(fields.length).toBe(1);
+  });
+
+  it('should correctly disable actions and not call the callback if clicked', function () {
+    setupHTML ("success", "Test Header", false, 'Test Action', true);
+    var fields = element.find('.dropdown-kebab-pf .dropdown-menu .disabled > a');
+    expect(fields.length).toBe(1);
+
+    expect($scope.menuAction).toBeUndefined();
+    expect($scope.menuData).toBeUndefined();
+
+    eventFire(fields[0], 'click');
+    $scope.$digest();
+
+    expect($scope.menuAction).toBeUndefined();
+    expect($scope.menuData).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This also fixes the notification service to:

1) appropriately timeout on each toast notification and dismiss them singularly. Also does not dismiss the toast notification if the user is currently hovering over it (viewing).

2) provide the list of notifications via the notification service rather than requiring the use of $rootScope.