### PR TITLE
Removing net-ssh lock to fix broken OpenShift deploy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ script:
 after_success:
   - sh -x ./scripts/publish.sh
 
-before_deploy:
-  - rvm 1.9.3 do gem install net-ssh -v 2.9.2
-
 deploy:
   provider: openshift
   user: "$OPENSHIFT_USER"
@@ -26,7 +23,8 @@ deploy:
   app: angular
   skip_cleanup: true
   on:
-    tags: true
+    branch: master-dist
+    condition: $TRAVIS_REPO_SLUG = "patternfly/angular-patternfly"
 
 notifications:
   email:


### PR DESCRIPTION
Ruby 1.9.3 is no longer supported by net-ssh and our previous workaround is no longer needed.