### PR TITLE
Add ability to include badges on nav items in pfVerticalNavigaton

### DIFF
--- a/misc/examples.css
+++ b/misc/examples.css
@@ -123,3 +123,10 @@ hr {
 .example-info-text:first-of-type {
   margin-top: 10px;
 }
+
+.example-error-background {
+  background-color: #cc0000 !important;
+}
+.example-warning-background {
+  background-color: #ec7a08 !important;
+}

--- a/src/navigation/vertical-navigation-directive.js
+++ b/src/navigation/vertical-navigation-directive.js
@@ -27,6 +27,12 @@
  * <li>.iconClass      - (string) Classes for icon to be shown on the menu (ex. "fa fa-dashboard")
  * <li>.href           - (string) href link to navigate to on click
  * <li>.children       - (array) Submenu items (same structure as top level items)
+ * <li>.badges         -  (array) Badges to display for the item, badges with a zero count are not displayed.
+ *   <ul style='list-style-type: none'>
+ *   <li>.count        - (number) Count to display in the badge
+ *   <li>.tooltip      - (string) Tooltip to display for the badge
+ *   <li>.badgeClass:  - (string) Additional class(es) to add to the badge
+ *   </ul>
  * </ul>
  * @param {function} navigateCallback function(item) Callback method invoked on a navigation item click (one with no submenus)
  * @param {function} itemClickCallback function(item) Callback method invoked on an item click
@@ -92,7 +98,13 @@
         {
            title: "Dolor",
            iconClass : "fa fa-shield",
-           href: "#/dolor"
+           href: "#/dolor",
+           badges: [
+             {
+               count: 1283,
+               tooltip: "Total number of items"
+             }
+           ]
         },
         {
            title: "Ipsum",
@@ -103,15 +115,35 @@
                  children: [
                     {
                        title: "Recteque",
-                       href: "#/ipsum/intellegam/recteque"
+                       href: "#/ipsum/intellegam/recteque",
+                       badges: [
+                         {
+                           count: 6,
+                           tooltip: "Total number of error items",
+                           badgeClass: 'example-error-background'
+                         }
+                       ]
                     },
                     {
                        title: "Suavitate",
-                       href: "#/ipsum/intellegam/suavitate"
+                       href: "#/ipsum/intellegam/suavitate",
+                       badges: [
+                         {
+                           count: 2,
+                           tooltip: "Total number of items"
+                         }
+                       ]
                     },
                     {
                        title: "Vituperatoribus",
-                       href: "#/ipsum/intellegam/vituperatoribus"
+                       href: "#/ipsum/intellegam/vituperatoribus",
+                       badges: [
+                         {
+                           count: 18,
+                           tooltip: "Total number of warning items",
+                           badgeClass: 'example-warning-background'
+                         }
+                       ]
                     }
                  ]
               },
@@ -573,10 +605,26 @@
           'desktop': 1200
         };
 
-        var bodyContentElement = angular.element(document.querySelector('.container-pf-nav-pf-vertical'));
+        var getBodyContentElement = function () {
+          return angular.element(document.querySelector('.container-pf-nav-pf-vertical'));
+        };
+
         var explicitCollapse = false;
         var hoverDelay = 500;
         var hideDelay = hoverDelay + 200;
+
+        var  initBodyElement = function () {
+          var bodyContentElement = getBodyContentElement();
+          if ($scope.hasSubMenus) {
+            bodyContentElement.addClass('container-pf-nav-pf-vertical-with-sub-menus');
+          }
+          if ($scope.persistentSecondary) {
+            bodyContentElement.addClass('nav-pf-persistent-secondary');
+          }
+          if ($scope.hiddenIcons) {
+            bodyContentElement.addClass('hidden-icons-pf');
+          }
+        };
 
         var updateMobileMenu = function (selected, secondaryItem) {
           $scope.items.forEach(function (item) {
@@ -606,6 +654,7 @@
 
         var checkNavState = function () {
           var width = $window.innerWidth;
+          var bodyContentElement = getBodyContentElement();
 
           // Check to see if we need to enter/exit the mobile state
           if (!$scope.ignoreMobile && width < breakpoints.tablet) {
@@ -640,6 +689,7 @@
         };
 
         var collapseMenu = function () {
+          var bodyContentElement = getBodyContentElement();
           $scope.navCollapsed = true;
 
           //Set the body class to the correct state
@@ -649,6 +699,7 @@
         };
 
         var expandMenu = function () {
+          var bodyContentElement = getBodyContentElement();
           $scope.navCollapsed = false;
 
           //Set the body class to the correct state
@@ -752,6 +803,7 @@
         };
 
         var updateSecondaryCollapsedState = function (setCollapsed, collapsedItem) {
+          var bodyContentElement = getBodyContentElement();
           if (collapsedItem) {
             collapsedItem.secondaryCollapsed = setCollapsed;
           }
@@ -773,6 +825,7 @@
         };
 
         var updateTertiaryCollapsedState = function (setCollapsed, collapsedItem) {
+          var bodyContentElement = getBodyContentElement();
           if (collapsedItem) {
             collapsedItem.tertiaryCollapsed = setCollapsed;
           }
@@ -807,16 +860,6 @@
         $scope.collapsedTertiaryNav = false;
         $scope.navCollapsed = false;
         $scope.forceHidden = false;
-
-        if ($scope.hasSubMenus) {
-          bodyContentElement.addClass('container-pf-nav-pf-vertical-with-sub-menus');
-        }
-        if ($scope.persistentSecondary) {
-          bodyContentElement.addClass('nav-pf-persistent-secondary');
-        }
-        if ($scope.hiddenIcons) {
-          bodyContentElement.addClass('hidden-icons-pf');
-        }
 
         $scope.handleNavBarToggleClick = function () {
 
@@ -981,6 +1024,7 @@
           event.stopImmediatePropagation();
         };
 
+        initBodyElement();
         checkNavState();
 
         angular.element($window).bind('resize', function () {

--- a/src/navigation/vertical-navigation.html
+++ b/src/navigation/vertical-navigation.html
@@ -39,6 +39,11 @@
           <a ng-click="handlePrimaryClick(item, $event)">
             <span class="{{item.iconClass}}" ng-if="item.iconClass" ng-class="{hidden: hiddenIcons}" tooltip-append-to-body="true" tooltip-enable="{{navCollapsed}}" tooltip-placement="bottom" tooltip="{{item.title}}" tooltip-class="nav-pf-vertical-tooltip"></span>
             <span class="list-group-item-value">{{item.title}}</span>
+            <div ng-if="item.badges" class="badge-container-pf">
+              <div class="badge {{badge.badgeClass}}" ng-repeat="badge in item.badges" tooltip-append-to-body="true" tooltip-placement="right" tooltip="{{badge.tooltip}}">
+                <span ng-if="badge.count">{{badge.count}}</span>
+              </div>
+            </div>
           </a>
           <div ng-if="item.children && item.children.length > 0" class="nav-pf-secondary-nav">
             <div class="nav-item-pf-header">
@@ -54,6 +59,11 @@
                   ng-mouseenter="handleSecondaryHover(secondaryItem)" ng-mouseleave="handleSecondaryUnHover(secondaryItem)">
                 <a ng-click="handleSecondaryClick(item, secondaryItem, $event)">
                   <span class="list-group-item-value">{{secondaryItem.title}}</span>
+                  <div ng-if="secondaryItem.badges" class="badge-container-pf">
+                    <div class="badge {{badge.badgeClass}}" ng-repeat="badge in secondaryItem.badges" tooltip-append-to-body="true" tooltip-placement="right" tooltip="{{badge.tooltip}}">
+                      <span ng-if="badge.count">{{badge.count}}</span>
+                    </div>
+                  </div>
                 </a>
                 <div ng-if="secondaryItem.children && secondaryItem.children.length > 0" class="nav-pf-tertiary-nav">
                   <div class="nav-item-pf-header">
@@ -64,6 +74,11 @@
                     <li ng-repeat="tertiaryItem in secondaryItem.children" class="list-group-item" ng-class="{'active': tertiaryItem.isActive}">
                       <a ng-click="handleTertiaryClick(item, secondaryItem, tertiaryItem, $event)">
                         <span class="list-group-item-value">{{tertiaryItem.title}}</span>
+                        <div ng-if="tertiaryItem.badges" class="badge-container-pf">
+                          <div class="badge {{badge.badgeClass}}" ng-repeat="badge in tertiaryItem.badges" tooltip-append-to-body="true" tooltip-placement="right" tooltip="{{badge.tooltip}}">
+                            <span ng-if="badge.count">{{badge.count}}</span>
+                          </div>
+                        </div>
                       </a>
                     </li>
                   </ul>

--- a/test/navigation/vertical-navigation.spec.js
+++ b/test/navigation/vertical-navigation.spec.js
@@ -32,7 +32,13 @@ describe('Directive:  pfVerticalNavigation', function () {
       {
         title: "Dolor",
         iconClass : "fa fa-shield",
-        href: "#/dolor"
+        href: "#/dolor",
+        badges: [
+          {
+            count: 1283,
+            tooltip: "Total number of items"
+          }
+        ]
       },
       {
         title: "Ipsum",
@@ -45,16 +51,36 @@ describe('Directive:  pfVerticalNavigation', function () {
             children: [
               {
                 title: "Recteque",
-                active: true,
-                href: "#/ipsum/intellegam/recteque"
+                href: "#/ipsum/intellegam/recteque",
+                badges: [
+                  {
+                    count: 6,
+                    tooltip: "Total number of error items",
+                    badgeClass: 'example-error-background'
+                  }
+                ]
               },
               {
                 title: "Suavitate",
-                href: "#/ipsum/intellegam/suavitate"
+                href: "#/ipsum/intellegam/suavitate",
+                badges: [
+                  {
+                    count: 0,
+                    tooltip: "Total number of items",
+                    badgeClass: 'example-ok-background'
+                  }
+                ]
               },
               {
                 title: "Vituperatoribus",
-                href: "#/ipsum/intellegam/vituperatoribus"
+                href: "#/ipsum/intellegam/vituperatoribus",
+                badges: [
+                  {
+                    count: 18,
+                    tooltip: "Total number of warning items",
+                    badgeClass: 'example-warning-background'
+                  }
+                ]
               }
             ]
           },
@@ -556,4 +582,77 @@ describe('Directive:  pfVerticalNavigation', function () {
 
     expect($scope.navigateItem).toBe($scope.navigationItems[2].children[0].children[0].title);
   });
+
+  it('should add badges', function () {
+    var primaryMenu = element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus');
+    expect(primaryMenu.length).toBe(1);
+
+    var primaryItems = primaryMenu.find('> .list-group > .list-group-item');
+    expect(primaryItems.length).toBe(6);
+
+    var badges = angular.element(primaryItems[1]).find('.badge');
+    expect(badges.length).toBe(1);
+
+    var secondaryMenu = angular.element(primaryItems[2]).find('.nav-pf-secondary-nav');
+    expect(secondaryMenu.length).toBe(1);
+
+    var secondaryItems = angular.element(secondaryMenu).find('> .list-group > .list-group-item');
+    expect(secondaryItems.length).toBe(4);
+
+    var tertiaryMenu = angular.element(secondaryItems[0]).find('.nav-pf-tertiary-nav');
+    expect(tertiaryMenu.length).toBe(1);
+
+    var tertiaryBadges = angular.element(tertiaryMenu).find('.badge');
+    expect(tertiaryBadges.length).toBe(3);
+  });
+
+  it('should set classes on badges', function () {
+    var primaryMenu = element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus');
+    expect(primaryMenu.length).toBe(1);
+
+    var primaryItems = primaryMenu.find('> .list-group > .list-group-item');
+    expect(primaryItems.length).toBe(6);
+
+    var secondaryMenu = angular.element(primaryItems[2]).find('.nav-pf-secondary-nav');
+    expect(secondaryMenu.length).toBe(1);
+
+    var secondaryItems = angular.element(secondaryMenu).find('> .list-group > .list-group-item');
+    expect(secondaryItems.length).toBe(4);
+
+    var tertiaryMenu = angular.element(secondaryItems[0]).find('.nav-pf-tertiary-nav');
+    expect(tertiaryMenu.length).toBe(1);
+
+    var errorBadge = angular.element(tertiaryMenu).find('.badge.example-error-background');
+    expect(errorBadge.length).toBe(1);
+
+    var warningBadge = angular.element(tertiaryMenu).find('.badge.example-warning-background');
+    expect(warningBadge.length).toBe(1);
+  });
+
+  it('should not show badges with a 0 count', function () {
+    var primaryMenu = element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus');
+    expect(primaryMenu.length).toBe(1);
+
+    var primaryItems = primaryMenu.find('> .list-group > .list-group-item');
+    expect(primaryItems.length).toBe(6);
+
+    var secondaryMenu = angular.element(primaryItems[2]).find('.nav-pf-secondary-nav');
+    expect(secondaryMenu.length).toBe(1);
+
+    var secondaryItems = angular.element(secondaryMenu).find('> .list-group > .list-group-item');
+    expect(secondaryItems.length).toBe(4);
+
+    var tertiaryMenu = angular.element(secondaryItems[0]).find('.nav-pf-tertiary-nav');
+    expect(tertiaryMenu.length).toBe(1);
+
+    var errorBadge = angular.element(tertiaryMenu).find('.badge.example-error-background > span');
+    expect(errorBadge.length).toBe(1);
+
+    var warningBadge = angular.element(tertiaryMenu).find('.badge.example-warning-background > span');
+    expect(warningBadge.length).toBe(1);
+
+    var warningBadge = angular.element(tertiaryMenu).find('.example-ok-background > span');
+    expect(warningBadge.length).toBe(0);
+  });
+
 });


### PR DESCRIPTION
This also fixes an issue where the body content might not have been
setup at startup. Rather than getting it once and holding a reference,
get the element each time

Note: Patternfly issue https://github.com/patternfly/patternfly/issues/435 is shown here. Correct display here will depend on this issue being resolved (PR is already up).

Primary Menu Badge:
![image](https://cloud.githubusercontent.com/assets/11633780/17941779/bf2c536c-6a02-11e6-90cd-c5e2b8ea9510.png)

Tertiary Menu Badges (with classes):
![image](https://cloud.githubusercontent.com/assets/11633780/17941792/d1263d4e-6a02-11e6-88a5-7c58bb0cf0ea.png)
