### PR TITLE
Add ability to include badges on nav items in pfVerticalNavigation

### DIFF
--- a/misc/examples.css
+++ b/misc/examples.css
@@ -123,3 +123,10 @@ hr {
 .example-info-text:first-of-type {
   margin-top: 10px;
 }
+
+.example-error-background {
+  background-color: #cc0000 !important;
+}
+.example-warning-background {
+  background-color: #ec7a08 !important;
+}

--- a/src/navigation/vertical-navigation-directive.js
+++ b/src/navigation/vertical-navigation-directive.js
@@ -18,7 +18,7 @@
  *
  * @param {string} brandSrc src for brand image
  * @param {string} brandAlt  Text for product name when brand image is not available
- * @param {boolean} hasSubMenus Flag if there are secondary and/or tertiary navigation items, default: true
+ * @param {boolean} showBadges Flag if badges are used on navigation items, default: false
  * @param {boolean} persistentSecondary Flag to use persistent secondary menus, default: false
  * @param {boolean} hiddenIcons Flag to not show icons on the primary menu, default: false
  * @param {array} items List of navigation items
@@ -27,6 +27,13 @@
  * <li>.iconClass      - (string) Classes for icon to be shown on the menu (ex. "fa fa-dashboard")
  * <li>.href           - (string) href link to navigate to on click
  * <li>.children       - (array) Submenu items (same structure as top level items)
+ * <li>.badges         -  (array) Badges to display for the item, badges with a zero count are not displayed.
+ *   <ul style='list-style-type: none'>
+ *   <li>.count        - (number) Count to display in the badge
+ *   <li>.iconClass    - (string) Class to use for showing an icon before the count
+ *   <li>.tooltip      - (string) Tooltip to display for the badge
+ *   <li>.badgeClass:  - (string) Additional class(es) to add to the badge container
+ *   </ul>
  * </ul>
  * @param {function} navigateCallback function(item) Callback method invoked on a navigation item click (one with no submenus)
  * @param {function} itemClickCallback function(item) Callback method invoked on an item click
@@ -43,7 +50,7 @@
   </div>
   <div id="verticalNavLayout" class="layout-pf layout-pf-fixed faux-layout hidden" ng-controller="vertNavController">
     <div pf-vertical-navigation items="navigationItems" brand-alt="ANGULAR PATTERNFLY"
-         has-sub-menus="true" pinnable-menus="true" update-active-items-on-click="true"
+         show-badges="true" pinnable-menus="true" update-active-items-on-click="true"
          navigate-callback="handleNavigateClick">
       <div>
         <ul class="nav navbar-nav">
@@ -75,7 +82,7 @@
         </ul>
       </div>
     </div>
-    <div id="contentContainer" class="container-fluid container-cards-pf container-pf-nav-pf-vertical container-pf-nav-pf-vertical-with-sub-menus example-page-container">
+    <div id="contentContainer" class="container-fluid container-cards-pf container-pf-nav-pf-vertical example-page-container">
       <div id="includedContent"></div>
       </div>
     </div>
@@ -92,7 +99,13 @@
         {
            title: "Dolor",
            iconClass : "fa fa-shield",
-           href: "#/dolor"
+           href: "#/dolor",
+           badges: [
+             {
+               count: 1283,
+               tooltip: "Total number of items"
+             }
+           ]
         },
         {
            title: "Ipsum",
@@ -103,15 +116,35 @@
                  children: [
                     {
                        title: "Recteque",
-                       href: "#/ipsum/intellegam/recteque"
+                       href: "#/ipsum/intellegam/recteque",
+                       badges: [
+                         {
+                           count: 6,
+                           tooltip: "Total number of error items",
+                           badgeClass: 'example-error-background'
+                         }
+                       ]
                     },
                     {
                        title: "Suavitate",
-                       href: "#/ipsum/intellegam/suavitate"
+                       href: "#/ipsum/intellegam/suavitate",
+                       badges: [
+                         {
+                           count: 2,
+                           tooltip: "Total number of items"
+                         }
+                       ]
                     },
                     {
                        title: "Vituperatoribus",
-                       href: "#/ipsum/intellegam/vituperatoribus"
+                       href: "#/ipsum/intellegam/vituperatoribus",
+                       badges: [
+                         {
+                           count: 18,
+                           tooltip: "Total number of warning items",
+                           badgeClass: 'example-warning-background'
+                         }
+                       ]
                     }
                  ]
               },
@@ -120,15 +153,51 @@
                  children: [
                     {
                        title: "Exerci",
-                       href: "#/ipsum/copiosae/exerci"
+                       href: "#/ipsum/copiosae/exerci",
+                       badges: [
+                         {
+                           count: 2,
+                           tooltip: "Total number of error items",
+                           iconClass: 'pficon pficon-error-circle-o'
+                         },
+                         {
+                           count: 6,
+                           tooltip: "Total number warning error items",
+                           iconClass: 'pficon pficon-warning-triangle-o'
+                         }
+                       ]
                     },
                     {
                        title: "Quaeque",
-                       href: "#/ipsum/copiosae/quaeque"
+                       href: "#/ipsum/copiosae/quaeque",
+                       badges: [
+                         {
+                           count: 0,
+                           tooltip: "Total number of error items",
+                           iconClass: 'pficon pficon-error-circle-o'
+                         },
+                         {
+                           count: 4,
+                           tooltip: "Total number warning error items",
+                           iconClass: 'pficon pficon-warning-triangle-o'
+                         }
+                       ]
                     },
                     {
                        title: "Utroque",
-                       href: "#/ipsum/copiosae/utroque"
+                       href: "#/ipsum/copiosae/utroque",
+                       badges: [
+                         {
+                           count: 1,
+                           tooltip: "Total number of error items",
+                           iconClass: 'pficon pficon-error-circle-o'
+                         },
+                         {
+                           count: 2,
+                           tooltip: "Total number warning error items",
+                           iconClass: 'pficon pficon-warning-triangle-o'
+                         }
+                       ]
                     }
                  ]
               },
@@ -151,7 +220,19 @@
               },
               {
                  title: "Accumsan",
-                 href: "#/ipsum/Accumsan"
+                 href: "#/ipsum/Accumsan",
+                 badges: [
+                   {
+                     count: 2,
+                     tooltip: "Total number of error items",
+                     iconClass: 'pficon pficon-error-circle-o'
+                   },
+                   {
+                     count: 6,
+                     tooltip: "Total number warning error items",
+                     iconClass: 'pficon pficon-warning-triangle-o'
+                   }
+                 ]
               }
            ]
         },
@@ -492,7 +573,7 @@
       scope: {
         brandSrc: '@',
         brandAlt: '@',
-        hasSubMenus: '@',
+        showBadges: '@',
         persistentSecondary: '@',
         pinnableMenus: '@',
         hiddenIcons: '@',
@@ -508,12 +589,13 @@
       controller: function ($scope) {
         var routeChangeListener;
 
-        $scope.hasSubMenus = $scope.hasSubMenus !== 'false';
+        $scope.showBadges = $scope.showBadges === 'true';
         $scope.persistentSecondary = $scope.persistentSecondary === 'true';
         $scope.pinnableMenus = $scope.pinnableMenus === 'true';
         $scope.hiddenIcons = $scope.hiddenIcons === 'true';
         $scope.updateActiveItemsOnClick = $scope.updateActiveItemsOnClick === 'true';
         $scope.ignoreMobile = $scope.ignoreMobile === 'true';
+        $scope.activeSecondary = false;
 
         $scope.clearActiveItems = function () {
           $scope.items.forEach(function (item) {
@@ -573,10 +655,26 @@
           'desktop': 1200
         };
 
-        var bodyContentElement = angular.element(document.querySelector('.container-pf-nav-pf-vertical'));
+        var getBodyContentElement = function () {
+          return angular.element(document.querySelector('.container-pf-nav-pf-vertical'));
+        };
+
         var explicitCollapse = false;
         var hoverDelay = 500;
         var hideDelay = hoverDelay + 200;
+
+        var  initBodyElement = function () {
+          var bodyContentElement = getBodyContentElement();
+          if ($scope.showBadges) {
+            bodyContentElement.addClass('nav-pf-vertical-with-badges');
+          }
+          if ($scope.persistentSecondary) {
+            bodyContentElement.addClass('nav-pf-persistent-secondary');
+          }
+          if ($scope.hiddenIcons) {
+            bodyContentElement.addClass('hidden-icons-pf');
+          }
+        };
 
         var updateMobileMenu = function (selected, secondaryItem) {
           $scope.items.forEach(function (item) {
@@ -606,6 +704,7 @@
 
         var checkNavState = function () {
           var width = $window.innerWidth;
+          var bodyContentElement = getBodyContentElement();
 
           // Check to see if we need to enter/exit the mobile state
           if (!$scope.ignoreMobile && width < breakpoints.tablet) {
@@ -640,6 +739,7 @@
         };
 
         var collapseMenu = function () {
+          var bodyContentElement = getBodyContentElement();
           $scope.navCollapsed = true;
 
           //Set the body class to the correct state
@@ -649,6 +749,7 @@
         };
 
         var expandMenu = function () {
+          var bodyContentElement = getBodyContentElement();
           $scope.navCollapsed = false;
 
           //Set the body class to the correct state
@@ -666,17 +767,6 @@
           $timeout(function () {
             $scope.forceHidden = false;
           }, 500);
-        };
-
-        var setFirstChildActive = function (item) {
-          if (item && item.children && item.children.length > 0) {
-            if ($scope.updateActiveItemsOnClick ) {
-              item.children[0].isActive = true;
-            }
-            setFirstChildActive(item.children[0]);
-          } else if (item && $scope.navigateCallback) {
-            $scope.navigateCallback(item);
-          }
         };
 
         var setParentActive = function (item) {
@@ -699,10 +789,44 @@
           });
         };
 
-        var navigateToItem = function (item) {
-          var navTo = item.href;
+        var getFirstNavigateChild = function (item) {
+          var firstChild;
           if (!item.children || item.children.length < 1) {
+            firstChild = item;
+          } else {
+            firstChild = getFirstNavigateChild(item.children[0]);
+          }
+          return firstChild;
+        };
+
+        var setSecondaryItemVisible = function () {
+          var bodyContentElement = getBodyContentElement();
+          $scope.activeSecondary = false;
+
+          if ($scope.persistentSecondary && !$scope.inMobileState) {
+            $scope.items.forEach(function (topLevel) {
+              if (topLevel.children) {
+                topLevel.children.forEach(function (secondLevel) {
+                  if (secondLevel.isActive) {
+                    $scope.activeSecondary = true;
+                  }
+                });
+              }
+            });
+            if ($scope.activeSecondary) {
+              bodyContentElement.addClass('secondary-visible-pf');
+            } else {
+              bodyContentElement.removeClass('secondary-visible-pf');
+            }
+          }
+        };
+
+        var navigateToItem = function (item) {
+          var navItem = getFirstNavigateChild(item);
+          var navTo;
+          if (navItem) {
             $scope.showMobileNav = false;
+            navTo = navItem.href;
             if (navTo) {
               if (navTo.startsWith('#/')) {
                 navTo = navTo.substring(2);
@@ -710,7 +834,7 @@
               location.path(navTo);
             }
             if ($scope.navigateCallback) {
-              $scope.navigateCallback(item);
+              $scope.navigateCallback(navItem);
             }
           }
 
@@ -720,11 +844,11 @@
 
           if ($scope.updateActiveItemsOnClick ) {
             $scope.clearActiveItems();
-            item.isActive = true;
-            setParentActive(item);
+            navItem.isActive = true;
+            setParentActive(navItem);
+            setSecondaryItemVisible();
           }
-
-          setFirstChildActive(item);
+          setSecondaryItemVisible();
         };
 
         var primaryHover = function () {
@@ -752,6 +876,7 @@
         };
 
         var updateSecondaryCollapsedState = function (setCollapsed, collapsedItem) {
+          var bodyContentElement = getBodyContentElement();
           if (collapsedItem) {
             collapsedItem.secondaryCollapsed = setCollapsed;
           }
@@ -773,6 +898,7 @@
         };
 
         var updateTertiaryCollapsedState = function (setCollapsed, collapsedItem) {
+          var bodyContentElement = getBodyContentElement();
           if (collapsedItem) {
             collapsedItem.tertiaryCollapsed = setCollapsed;
           }
@@ -807,16 +933,6 @@
         $scope.collapsedTertiaryNav = false;
         $scope.navCollapsed = false;
         $scope.forceHidden = false;
-
-        if ($scope.hasSubMenus) {
-          bodyContentElement.addClass('container-pf-nav-pf-vertical-with-sub-menus');
-        }
-        if ($scope.persistentSecondary) {
-          bodyContentElement.addClass('nav-pf-persistent-secondary');
-        }
-        if ($scope.hiddenIcons) {
-          bodyContentElement.addClass('hidden-icons-pf');
-        }
 
         $scope.handleNavBarToggleClick = function () {
 
@@ -981,6 +1097,7 @@
           event.stopImmediatePropagation();
         };
 
+        initBodyElement();
         checkNavState();
 
         angular.element($window).bind('resize', function () {

--- a/src/navigation/vertical-navigation.html
+++ b/src/navigation/vertical-navigation.html
@@ -14,10 +14,11 @@
     </div>
     <nav class="collapse navbar-collapse" ng-transclude></nav>
     <div class="nav-pf-vertical"
-         ng-class="{'nav-pf-vertical-with-sub-menus': hasSubMenus,
-                    'nav-pf-persistent-secondary': persistentSecondary,
+         ng-class="{'nav-pf-persistent-secondary': persistentSecondary,
                     'nav-pf-vertical-collapsible-menus': pinnableMenus,
                     'hidden-icons-pf': hiddenIcons,
+                    'nav-pf-vertical-with-badges': showBadges,
+                    'secondary-visible-pf': activeSecondary,
                     'show-mobile-secondary': showMobileSecondary,
                     'show-mobile-tertiary': showMobileTertiary,
                     'hover-secondary-nav-pf': hoverSecondaryNav,
@@ -39,6 +40,12 @@
           <a ng-click="handlePrimaryClick(item, $event)">
             <span class="{{item.iconClass}}" ng-if="item.iconClass" ng-class="{hidden: hiddenIcons}" tooltip-append-to-body="true" tooltip-enable="{{navCollapsed}}" tooltip-placement="bottom" tooltip="{{item.title}}" tooltip-class="nav-pf-vertical-tooltip"></span>
             <span class="list-group-item-value">{{item.title}}</span>
+            <div ng-if="showBadges && item.badges" class="badge-container-pf">
+              <div class="badge {{badge.badgeClass}}" ng-repeat="badge in item.badges" tooltip-append-to-body="true" tooltip-placement="right" tooltip="{{badge.tooltip}}">
+                <span ng-if="badge.count && badge.iconClass" class="{{badge.iconClass}}"></span>
+                <span ng-if="badge.count">{{badge.count}}</span>
+              </div>
+            </div>
           </a>
           <div ng-if="item.children && item.children.length > 0" class="nav-pf-secondary-nav">
             <div class="nav-item-pf-header">
@@ -54,6 +61,12 @@
                   ng-mouseenter="handleSecondaryHover(secondaryItem)" ng-mouseleave="handleSecondaryUnHover(secondaryItem)">
                 <a ng-click="handleSecondaryClick(item, secondaryItem, $event)">
                   <span class="list-group-item-value">{{secondaryItem.title}}</span>
+                  <div ng-if="showBadges && secondaryItem.badges" class="badge-container-pf">
+                    <div class="badge {{badge.badgeClass}}" ng-repeat="badge in secondaryItem.badges" tooltip-append-to-body="true" tooltip-placement="right" tooltip="{{badge.tooltip}}">
+                      <span ng-if="badge.count && badge.iconClass" class="{{badge.iconClass}}"></span>
+                      <span ng-if="badge.count">{{badge.count}}</span>
+                    </div>
+                  </div>
                 </a>
                 <div ng-if="secondaryItem.children && secondaryItem.children.length > 0" class="nav-pf-tertiary-nav">
                   <div class="nav-item-pf-header">
@@ -64,6 +77,12 @@
                     <li ng-repeat="tertiaryItem in secondaryItem.children" class="list-group-item" ng-class="{'active': tertiaryItem.isActive}">
                       <a ng-click="handleTertiaryClick(item, secondaryItem, tertiaryItem, $event)">
                         <span class="list-group-item-value">{{tertiaryItem.title}}</span>
+                        <div ng-if="showBadges && tertiaryItem.badges" class="badge-container-pf">
+                          <div class="badge {{badge.badgeClass}}" ng-repeat="badge in tertiaryItem.badges" tooltip-append-to-body="true" tooltip-placement="right" tooltip="{{badge.tooltip}}">
+                            <span ng-if="badge.count && badge.iconClass" class="{{badge.iconClass}}"></span>
+                            <span ng-if="badge.count">{{badge.count}}</span>
+                          </div>
+                        </div>
                       </a>
                     </li>
                   </ul>

--- a/test/navigation/vertical-navigation.spec.js
+++ b/test/navigation/vertical-navigation.spec.js
@@ -32,7 +32,13 @@ describe('Directive:  pfVerticalNavigation', function () {
       {
         title: "Dolor",
         iconClass : "fa fa-shield",
-        href: "#/dolor"
+        href: "#/dolor",
+        badges: [
+          {
+            count: 1283,
+            tooltip: "Total number of items"
+          }
+        ]
       },
       {
         title: "Ipsum",
@@ -45,16 +51,36 @@ describe('Directive:  pfVerticalNavigation', function () {
             children: [
               {
                 title: "Recteque",
-                active: true,
-                href: "#/ipsum/intellegam/recteque"
+                href: "#/ipsum/intellegam/recteque",
+                badges: [
+                  {
+                    count: 6,
+                    tooltip: "Total number of error items",
+                    badgeClass: 'example-error-background'
+                  }
+                ]
               },
               {
                 title: "Suavitate",
-                href: "#/ipsum/intellegam/suavitate"
+                href: "#/ipsum/intellegam/suavitate",
+                badges: [
+                  {
+                    count: 0,
+                    tooltip: "Total number of items",
+                    badgeClass: 'example-ok-background'
+                  }
+                ]
               },
               {
                 title: "Vituperatoribus",
-                href: "#/ipsum/intellegam/vituperatoribus"
+                href: "#/ipsum/intellegam/vituperatoribus",
+                badges: [
+                  {
+                    count: 18,
+                    tooltip: "Total number of warning items",
+                    badgeClass: 'example-warning-background'
+                  }
+                ]
               }
             ]
           },
@@ -182,7 +208,7 @@ describe('Directive:  pfVerticalNavigation', function () {
     var htmlTmp = '' +
       '<div id="verticalNavLayout" class="layout-pf layout-pf-fixed">' +
       '  <div pf-vertical-navigation items="navigationItems" brand-src="images/test.svg" brand-alt="ANGULAR PATTERNFLY"' +
-      '       has-sub-menus="true" pinnable-menus="true" update-active-items-on-click="true"' +
+      '       show-badges="true" pinnable-menus="true" update-active-items-on-click="true"' +
       '       navigate-callback="handleNavigateClick" item-click-callback="handleItemClick"' +
       '       ignore-mobile="true"' +
       '    <div>' +
@@ -203,7 +229,7 @@ describe('Directive:  pfVerticalNavigation', function () {
   });
 
   it('should add the vertical navigation menus', function () {
-    var primaryMenu = element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus');
+    var primaryMenu = element.find('.nav-pf-vertical');
     expect(primaryMenu.length).toBe(1);
 
     var primaryItems = primaryMenu.find('> .list-group > .list-group-item');
@@ -223,7 +249,7 @@ describe('Directive:  pfVerticalNavigation', function () {
   });
 
   it('should update the content element', function () {
-    var content = element.find('.container-pf-nav-pf-vertical-with-sub-menus');
+    var content = element.find('.container-pf-nav-pf-vertical.nav-pf-vertical-with-badges');
     expect(content.length).toBe(0); // (1);  // This does not work for some reason the class is not there yet
   });
 
@@ -234,7 +260,7 @@ describe('Directive:  pfVerticalNavigation', function () {
     collased = element.find('.collapsed-tertiary-nav-pf');
     expect(collased.length).toBe(0);
 
-    var primaryItems = element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item');
+    var primaryItems = element.find('.nav-pf-vertical > .list-group > .list-group-item');
     expect(primaryItems.length).toBe(6);
 
     // third item is active, use it to check for pin icon
@@ -273,7 +299,7 @@ describe('Directive:  pfVerticalNavigation', function () {
     var htmlTmp = '' +
       '<div id="verticalNavLayout" class="layout-pf layout-pf-fixed">' +
       '  <div pf-vertical-navigation items="navigationItems" brand-src="images/test.svg" brand-alt="ANGULAR PATTERNFLY"' +
-      '       has-sub-menus="true" pinnable-menus="true" update-active-items-on-click="true"' +
+      '       show-badges="true" pinnable-menus="true" update-active-items-on-click="true"' +
       '       navigate-callback="handleNavigateClick" item-click-callback="handleItemClick"' +
       '       ignore-mobile="true" hidden-icons="true"' +
       '    <div>' +
@@ -287,7 +313,7 @@ describe('Directive:  pfVerticalNavigation', function () {
 
     compileHTML(htmlTmp, $scope);
 
-    var primaryItems = element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item');
+    var primaryItems = element.find('.nav-pf-vertical > .list-group > .list-group-item');
     expect(primaryItems.length).toBe(6);
 
     var iconSpan = angular.element(primaryItems[0]).find('> a > span');
@@ -295,10 +321,10 @@ describe('Directive:  pfVerticalNavigation', function () {
   });
 
   it('should go to collapse mode when collpase toggle is clicked', function () {
-    var menu = element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus');
+    var menu = element.find('.nav-pf-vertical');
     expect(menu.length).toBe(1);
 
-    var collapsedMenu = element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus.collapsed');
+    var collapsedMenu = element.find('.nav-pf-vertical.collapsed');
     expect(collapsedMenu.length).toBe(0);
 
     var navBarToggle = element.find('.navbar-header .navbar-toggle');
@@ -307,10 +333,10 @@ describe('Directive:  pfVerticalNavigation', function () {
     eventFire(navBarToggle[0], 'click');
     $scope.$digest();
 
-    menu = element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus');
+    menu = element.find('.nav-pf-vertical');
     expect(menu.length).toBe(1);
 
-    collapsedMenu = element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus.collapsed');
+    collapsedMenu = element.find('.nav-pf-vertical.collapsed');
     expect(collapsedMenu.length).toBe(1);
   });
 
@@ -323,7 +349,7 @@ describe('Directive:  pfVerticalNavigation', function () {
     var htmlTmp = '' +
       '<div id="verticalNavLayout" class="layout-pf layout-pf-fixed">' +
       '  <div pf-vertical-navigation items="navigationItems" brand-alt="ANGULAR PATTERNFLY"' +
-      '       has-sub-menus="true" pinnable-menus="true" update-active-items-on-click="true"' +
+      '       show-badges="true" pinnable-menus="true" update-active-items-on-click="true"' +
       '       navigate-callback="handleNavigateClick" item-click-callback="handleItemClick"' +
       '       ignore-mobile="true" hidden-icons="true"' +
       '    <div>' +
@@ -346,7 +372,7 @@ describe('Directive:  pfVerticalNavigation', function () {
   it('should invoke the navigateCallback when an item is clicked', function () {
     expect($scope.navigateItem).toBeUndefined();
 
-    var primaryItems = element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item > a');
+    var primaryItems = element.find('.nav-pf-vertical > .list-group > .list-group-item > a');
     expect(primaryItems.length).toBe(6);
 
     eventFire(primaryItems[0], 'click');
@@ -364,7 +390,7 @@ describe('Directive:  pfVerticalNavigation', function () {
   it('should invoke the itemClickCallback when any item is clicked', function () {
     expect($scope.clickItem).toBeUndefined();
 
-    var primaryItems = element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item > a');
+    var primaryItems = element.find('.nav-pf-vertical > .list-group > .list-group-item > a');
     expect(primaryItems.length).toBe(6);
 
     eventFire(primaryItems[0], 'click');
@@ -380,10 +406,10 @@ describe('Directive:  pfVerticalNavigation', function () {
   });
 
   it('should set active items on primary item click when updateActiveItemsOnClick is true', function () {
-    var primaryItems = element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item > a');
+    var primaryItems = element.find('.nav-pf-vertical > .list-group > .list-group-item > a');
     expect(primaryItems.length).toBe(6);
 
-    var activePrimary =  element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item.active');
+    var activePrimary =  element.find('.nav-pf-vertical > .list-group > .list-group-item.active');
     expect(activePrimary.length).toBe(0);
 
     var activeSecondary =  element.find('.nav-pf-secondary-nav > .list-group > .list-group-item.active');
@@ -397,7 +423,7 @@ describe('Directive:  pfVerticalNavigation', function () {
 
     expect($scope.clickItem).toBe($scope.navigationItems[0].title);
 
-    activePrimary =  element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item.active');
+    activePrimary =  element.find('.nav-pf-vertical > .list-group > .list-group-item.active');
     expect(activePrimary.length).toBe(1);
 
     activeSecondary =  element.find('.nav-pf-secondary-nav > .list-group > .list-group-item.active');
@@ -414,7 +440,7 @@ describe('Directive:  pfVerticalNavigation', function () {
 
     expect($scope.clickItem).toBe($scope.navigationItems[2].title);
 
-    activePrimary =  element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item.active');
+    activePrimary =  element.find('.nav-pf-vertical > .list-group > .list-group-item.active');
     expect(activePrimary.length).toBe(1);
 
     activeSecondary =  element.find('.nav-pf-secondary-nav > .list-group > .list-group-item.active');
@@ -427,7 +453,7 @@ describe('Directive:  pfVerticalNavigation', function () {
   });
 
   it('should set active items on secondary item click when updateActiveItemsOnClick is true', function () {
-    var primaryItems = element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item');
+    var primaryItems = element.find('.nav-pf-vertical > .list-group > .list-group-item');
     expect(primaryItems.length).toBe(6);
 
     var secondaryItems = angular.element(primaryItems[2]).find('.nav-pf-secondary-nav > .list-group > .list-group-item > a');
@@ -437,7 +463,7 @@ describe('Directive:  pfVerticalNavigation', function () {
     eventFire(secondaryItems[1], 'click');
     $scope.$digest();
 
-    activePrimary =  element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item.active');
+    activePrimary =  element.find('.nav-pf-vertical > .list-group > .list-group-item.active');
     expect(activePrimary.length).toBe(1);
 
     activeSecondary =  element.find('.nav-pf-secondary-nav > .list-group > .list-group-item.active');
@@ -452,7 +478,7 @@ describe('Directive:  pfVerticalNavigation', function () {
     eventFire(secondaryItems[3], 'click');
     $scope.$digest();
 
-    activePrimary =  element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item.active');
+    activePrimary =  element.find('.nav-pf-vertical > .list-group > .list-group-item.active');
     expect(activePrimary.length).toBe(1);
 
     activeSecondary =  element.find('.nav-pf-secondary-nav > .list-group > .list-group-item.active');
@@ -465,7 +491,7 @@ describe('Directive:  pfVerticalNavigation', function () {
   });
 
   it('should set active items on tertiary item click when updateActiveItemsOnClick is true', function () {
-    var primaryItems = element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item');
+    var primaryItems = element.find('.nav-pf-vertical > .list-group > .list-group-item');
     expect(primaryItems.length).toBe(6);
 
     var secondaryItems = angular.element(primaryItems[2]).find('.nav-pf-secondary-nav > .list-group > .list-group-item');
@@ -478,7 +504,7 @@ describe('Directive:  pfVerticalNavigation', function () {
     eventFire(tertiaryItems[1], 'click');
     $scope.$digest();
 
-    activePrimary =  element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item.active');
+    activePrimary =  element.find('.nav-pf-vertical > .list-group > .list-group-item.active');
     expect(activePrimary.length).toBe(1);
 
     activeSecondary =  element.find('.nav-pf-secondary-nav > .list-group > .list-group-item.active');
@@ -498,7 +524,7 @@ describe('Directive:  pfVerticalNavigation', function () {
     var htmlTmp = '' +
       '<div id="verticalNavLayout" class="layout-pf layout-pf-fixed">' +
       '  <div pf-vertical-navigation items="navigationItems" brand-src="images/test.svg" brand-alt="ANGULAR PATTERNFLY"' +
-      '       has-sub-menus="true" pinnable-menus="true"' +
+      '       show-badges="true" pinnable-menus="true"' +
       '       navigate-callback="handleNavigateClick" item-click-callback="handleItemClick"' +
       '       ignore-mobile="true"' +
       '    <div>' +
@@ -512,10 +538,10 @@ describe('Directive:  pfVerticalNavigation', function () {
 
     compileHTML(htmlTmp, $scope);
 
-    var primaryItems = element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item > a');
+    var primaryItems = element.find('.nav-pf-vertical > .list-group > .list-group-item > a');
     expect(primaryItems.length).toBe(6);
 
-    var activePrimary =  element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item.active');
+    var activePrimary =  element.find('.nav-pf-vertical > .list-group > .list-group-item.active');
     expect(activePrimary.length).toBe(0);
 
     var activeSecondary =  element.find('.nav-pf-secondary-nav > .list-group > .list-group-item.active');
@@ -529,7 +555,7 @@ describe('Directive:  pfVerticalNavigation', function () {
 
     expect($scope.clickItem).toBe($scope.navigationItems[0].title);
 
-    activePrimary =  element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item.active');
+    activePrimary =  element.find('.nav-pf-vertical > .list-group > .list-group-item.active');
     expect(activePrimary.length).toBe(0);
 
     activeSecondary =  element.find('.nav-pf-secondary-nav > .list-group > .list-group-item.active');
@@ -545,7 +571,7 @@ describe('Directive:  pfVerticalNavigation', function () {
 
     expect($scope.clickItem).toBe($scope.navigationItems[2].title);
 
-    activePrimary =  element.find('.nav-pf-vertical.nav-pf-vertical-with-sub-menus > .list-group > .list-group-item.active');
+    activePrimary =  element.find('.nav-pf-vertical > .list-group > .list-group-item.active');
     expect(activePrimary.length).toBe(0);
 
     activeSecondary =  element.find('.nav-pf-secondary-nav > .list-group > .list-group-item.active');
@@ -556,4 +582,113 @@ describe('Directive:  pfVerticalNavigation', function () {
 
     expect($scope.navigateItem).toBe($scope.navigationItems[2].children[0].children[0].title);
   });
+
+  it('should add badges', function () {
+    var primaryMenu = element.find('.nav-pf-vertical');
+    expect(primaryMenu.length).toBe(1);
+
+    var primaryItems = primaryMenu.find('> .list-group > .list-group-item');
+    expect(primaryItems.length).toBe(6);
+
+    var badges = angular.element(primaryItems[1]).find('.badge');
+    expect(badges.length).toBe(1);
+
+    var secondaryMenu = angular.element(primaryItems[2]).find('.nav-pf-secondary-nav');
+    expect(secondaryMenu.length).toBe(1);
+
+    var secondaryItems = angular.element(secondaryMenu).find('> .list-group > .list-group-item');
+    expect(secondaryItems.length).toBe(4);
+
+    var tertiaryMenu = angular.element(secondaryItems[0]).find('.nav-pf-tertiary-nav');
+    expect(tertiaryMenu.length).toBe(1);
+
+    var tertiaryBadges = angular.element(tertiaryMenu).find('.badge');
+    expect(tertiaryBadges.length).toBe(3);
+  });
+
+  it('should set classes on badges', function () {
+    var primaryMenu = element.find('.nav-pf-vertical');
+    expect(primaryMenu.length).toBe(1);
+
+    var primaryItems = primaryMenu.find('> .list-group > .list-group-item');
+    expect(primaryItems.length).toBe(6);
+
+    var secondaryMenu = angular.element(primaryItems[2]).find('.nav-pf-secondary-nav');
+    expect(secondaryMenu.length).toBe(1);
+
+    var secondaryItems = angular.element(secondaryMenu).find('> .list-group > .list-group-item');
+    expect(secondaryItems.length).toBe(4);
+
+    var tertiaryMenu = angular.element(secondaryItems[0]).find('.nav-pf-tertiary-nav');
+    expect(tertiaryMenu.length).toBe(1);
+
+    var errorBadge = angular.element(tertiaryMenu).find('.badge.example-error-background');
+    expect(errorBadge.length).toBe(1);
+
+    var warningBadge = angular.element(tertiaryMenu).find('.badge.example-warning-background');
+    expect(warningBadge.length).toBe(1);
+  });
+
+  it('should not show badges with a 0 count', function () {
+    var primaryMenu = element.find('.nav-pf-vertical');
+    expect(primaryMenu.length).toBe(1);
+
+    var primaryItems = primaryMenu.find('> .list-group > .list-group-item');
+    expect(primaryItems.length).toBe(6);
+
+    var secondaryMenu = angular.element(primaryItems[2]).find('.nav-pf-secondary-nav');
+    expect(secondaryMenu.length).toBe(1);
+
+    var secondaryItems = angular.element(secondaryMenu).find('> .list-group > .list-group-item');
+    expect(secondaryItems.length).toBe(4);
+
+    var tertiaryMenu = angular.element(secondaryItems[0]).find('.nav-pf-tertiary-nav');
+    expect(tertiaryMenu.length).toBe(1);
+
+    var errorBadge = angular.element(tertiaryMenu).find('.badge.example-error-background > span');
+    expect(errorBadge.length).toBe(1);
+
+    var warningBadge = angular.element(tertiaryMenu).find('.badge.example-warning-background > span');
+    expect(warningBadge.length).toBe(1);
+
+    var warningBadge = angular.element(tertiaryMenu).find('.example-ok-background > span');
+    expect(warningBadge.length).toBe(0);
+  });
+
+  it('should not show badges when show-badges is not set', function () {
+    var primaryMenu = element.find('.nav-pf-vertical');
+    expect(primaryMenu.length).toBe(1);
+
+    var badgesMenu = element.find('.nav-pf-vertical.nav-pf-vertical-with-badges');
+    expect(badgesMenu.length).toBe(1);
+
+    var badgesShown = element.find('.badge-container-pf');
+    expect(badgesShown.length).toBeGreaterThan(0);
+
+    var htmlTmp = '' +
+    '<div id="verticalNavLayout" class="layout-pf layout-pf-fixed">' +
+    '  <div pf-vertical-navigation items="navigationItems" brand-src="images/test.svg" brand-alt="ANGULAR PATTERNFLY"' +
+    '       pinnable-menus="true" update-active-items-on-click="true"' +
+    '       navigate-callback="handleNavigateClick" item-click-callback="handleItemClick"' +
+    '       ignore-mobile="true" hidden-icons="true"' +
+    '    <div>' +
+    '      <div class="test-included-content"></div>' +
+    '    </div>' +
+    '  </div>' +
+    '  <div id="contentContainer" class="container-pf-nav-pf-vertical">' +
+    '  </div>' +
+    '</div>' +
+    '';
+    compileHTML(htmlTmp, $scope);
+
+    var primaryMenu = element.find('.nav-pf-vertical');
+    expect(primaryMenu.length).toBe(1);
+
+    var badgesMenu = element.find('.nav-pf-vertical-with-badges');
+    expect(badgesMenu.length).toBe(0);
+
+    var badgesShown = element.find('.badge-container-pf');
+    expect(badgesShown.length).toBe(0);
+  });
+
 });


### PR DESCRIPTION
This also fixes an issue where the body content might not have been
setup at startup. Rather than getting it once and holding a reference,
get the element each time

Removed the hasSubmenus setting since this is no longer required. No backward compatibility issue since setting this has no effect.

This depends on https://github.com/patternfly/patternfly/pull/439 getting merged into Patternfly.

![image](https://cloud.githubusercontent.com/assets/11633780/18053637/7b04733e-6dce-11e6-90f3-f8a5cddddbc6.png)
