### PR TITLE
Add a timeout when updating vertical nav on window resize event

### DIFF
--- a/src/navigation/vertical-navigation-directive.js
+++ b/src/navigation/vertical-navigation-directive.js
@@ -1102,11 +1102,13 @@
 
         angular.element($window).bind('resize', function () {
           checkNavState();
-          try {
-            $scope.$apply();
-          } catch (e) {
-            // Ignore, if we already applied, that is fine.
-          }
+          $timeout(function () {
+            try {
+              $scope.$apply();
+            } catch (e) {
+              // Ignore, if we already applied, that is fine.
+            }
+          });
         });
       }
     };


### PR DESCRIPTION
This reduces/eliminates the number of times a $apply already in
progress exception is thrown. Although the exception is caught, some
applications still detect the exception and log to the console.