### PR TITLE
fix notification removed when not found

### DIFF
--- a/src/notification/notification.js
+++ b/src/notification/notification.js
@@ -181,7 +181,10 @@ angular.module('patternfly.notification').provider('Notifications', function () 
     };
 
     notifications.remove = function (notification) {
-      notifications.removeIndex($rootScope.notifications.data.indexOf(notification));
+      var index = $rootScope.notifications.data.indexOf(notification);
+      if (index !== -1) {
+        notifications.removeIndex(index);
+      }
     };
 
     notifications.removeIndex = function (index) {


### PR DESCRIPTION
When a notification is closed, prior to timouting, from $rootScope (e.g.
from handleClose), then the timeout closes the wrong notification. This is because
notification is by the timeouting removed completely from list and the
`.indexOf` returns `-1`, which removes last notification.

There is a possibility that if same notification (with same data) is created between handleClose and timeout close, then it would be closed earlier by the first notification's timeout. Better solution would be to track timeouts and remove them with a notification removal.