### PR TITLE
pfSelect - destroy the selectpicker when the directive is destroyed

### DIFF
--- a/src/select/select.js
+++ b/src/select/select.js
@@ -81,6 +81,10 @@ angular.module('patternfly.select', []).directive('pfSelect', function ($timeout
         });
       };
 
+      var selectpickerDestroy = function () {
+        element.selectpicker('destroy');
+      };
+
       element.selectpicker(scope.selectPickerOptions);
 
       ngModel.$render = function () {
@@ -101,6 +105,8 @@ angular.module('patternfly.select', []).directive('pfSelect', function ($timeout
       }
 
       attrs.$observe('disabled', selectpickerRefresh);
+
+      scope.$on('$destroy', selectpickerDestroy);
     }
   };
 });


### PR DESCRIPTION
Since patternfly 3.8, the structure of the HTML generated by the selectpicker js component has changed, and removing the original select element no longer necessarily removes the selectpicker div that's actually visible.

(Previously, the `select` would just get a class to hide it, and the `div` would appear right after it (as a sibling), whereas now, the new `div` eats up the `select` and moves it inside itself.)

This PR makes `pf-select` explicitly destroy the selectpicker when the element with that `pf-select` is going away.

---

Code like:

```
<div ng-if="condition">
  <select pf-select>...</select>
</div>
```

always works, but when the if is on the select:

```
<select pf-select ng-if="condition">...</select>
```

then making the condition true and then false causes the selectpicker to stay on the page without this PR.