### PR TITLE
Wrap wizard button in an IIFE to prevent access globally.

### DIFF
--- a/src/wizard/wizard-buttons.js
+++ b/src/wizard/wizard-buttons.js
@@ -1,6 +1,6 @@
 (function () {
   'use strict';
-  function wizardButtonDirective (action) {
+  function pfWizardButtonDirective (action) {
     angular.module('patternfly.wizard')
       .directive(action, function () {
         return {
@@ -23,9 +23,9 @@
       });
   }
 
-  wizardButtonDirective('pfWizNext');
-  wizardButtonDirective('pfWizPrevious');
-  wizardButtonDirective('pfWizFinish');
-  wizardButtonDirective('pfWizCancel');
-  wizardButtonDirective('pfWizReset');
+  pfWizardButtonDirective('pfWizNext');
+  pfWizardButtonDirective('pfWizPrevious');
+  pfWizardButtonDirective('pfWizFinish');
+  pfWizardButtonDirective('pfWizCancel');
+  pfWizardButtonDirective('pfWizReset');
 })();

--- a/src/wizard/wizard-buttons.js
+++ b/src/wizard/wizard-buttons.js
@@ -1,30 +1,31 @@
-function wizardButtonDirective (action) {
+(function () {
   'use strict';
-
-  angular.module('patternfly.wizard')
-    .directive(action, function () {
-      return {
-        restrict: 'A',
-        require: '^pf-wizard',
-        scope: {
-          callback: "=?"
-        },
-        link: function ($scope, $element, $attrs, wizard) {
-          $element.on("click", function (e) {
-            e.preventDefault();
-            $scope.$apply(function () {
-              // scope apply in button module
-              $scope.$eval($attrs[action]);
-              wizard[action.replace("pfWiz", "").toLowerCase()]($scope.callback);
+  function wizardButtonDirective (action) {
+    angular.module('patternfly.wizard')
+      .directive(action, function () {
+        return {
+          restrict: 'A',
+          require: '^pf-wizard',
+          scope: {
+            callback: "=?"
+          },
+          link: function ($scope, $element, $attrs, wizard) {
+            $element.on("click", function (e) {
+              e.preventDefault();
+              $scope.$apply(function () {
+                // scope apply in button module
+                $scope.$eval($attrs[action]);
+                wizard[action.replace("pfWiz", "").toLowerCase()]($scope.callback);
+              });
             });
-          });
-        }
-      };
-    });
-}
+          }
+        };
+      });
+  }
 
-wizardButtonDirective('pfWizNext');
-wizardButtonDirective('pfWizPrevious');
-wizardButtonDirective('pfWizFinish');
-wizardButtonDirective('pfWizCancel');
-wizardButtonDirective('pfWizReset');
+  wizardButtonDirective('pfWizNext');
+  wizardButtonDirective('pfWizPrevious');
+  wizardButtonDirective('pfWizFinish');
+  wizardButtonDirective('pfWizCancel');
+  wizardButtonDirective('pfWizReset');
+})();


### PR DESCRIPTION
ManageIQ identified an issue with this function because the same function had been defined globally in their codebase.  This wraps the function an IIFE which causes the directives to be immediately created and the function is disposed of (and not available on the window object any longer).  

Testing done:
Prior to the fix - wizardButtonDirective() can be called in the console when the wizard code is loaded, afterwards, the directives are created upon load and then the function isn't available globally.