### PR TITLE
Remove JQuery dependency from default modules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -192,6 +192,11 @@ module.exports = function (grunt) {
           src: ['charts/**/*.html'],
           dest: 'templates/charts.js'
         },
+        'patternfly.jquery': {
+          cwd: 'src/',
+          src: ['form/datepicker/*.html'],
+          dest: 'templates/jquery.js'
+        },
         'patternfly.filters': {
           cwd: 'src/',
           src: ['filters/**/*.html'],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -167,6 +167,11 @@ module.exports = function (grunt) {
           src: ['form/**/*.html'],
           dest: 'templates/form.js'
         },
+        'patternfly.bsselect': {
+          cwd: 'src/',
+          src: ['bootstrap-select/**/*.html'],
+          dest: 'templates/bootstrap-select.js'
+        },
         'patternfly.navigation': {
           cwd: 'src/',
           src: ['navigation/**/*.html'],
@@ -247,6 +252,10 @@ module.exports = function (grunt) {
         main: {
           files: ['Gruntfile.js'],
           tasks: ['eslint']
+        },
+        test: {
+          files: ['test/**/*.js'],
+          tasks: ['test']
         },
         all: {
           files: ['Gruntfile.js', 'src/**/*.js', 'src/**/*.html', 'styles/**/*.css'],

--- a/README.md
+++ b/README.md
@@ -83,16 +83,22 @@ Note:
         <script src="bower_components/patternfly/components/c3/c3.min.js"></script>
         <script src="bower_components/patternfly/components/d3/d3.min.js"></script>
 
-5. (optional) The 'patternfly.charts' module is not a dependency in the default angular 'patternfly' module.
-   In order to use patternfly charts you must add 'patternfly.charts' as a dependency in your application:
+        <!-- Patternfly settings-->
+        <script src="bower_components/patternfly/dist/js/patternfly-settings.js"></script>
+
+5. (optional) The 'patternfly.charts' module and 'patternfly.jquery' modules are not dependencies in the default angular 'patternfly' module.
+   In order to use these you must add 'patternfly.charts' and/or 'patternfly.jquery' as dependencies in your application:
 
         my-app.module.js:
 
         angular.module('myApp', [
           'patternfly',
-          'patternfly.charts'
-        ]);
+          'patternfly.charts',
+          'patternfly.jquery'
+]);
 
+    Note: the pfSelect and datepicker directives are only available in the patternfly.jquery module. Using these directives requires the inclusion of the jQuery library.
+    
 ## API documentation
 
 The API documentation can be built with:

--- a/index.js
+++ b/index.js
@@ -3,6 +3,6 @@ require('angular-animate');
 require('angular-sanitize');
 require('angular-ui-bootstrap');
 require('lodash');
-require('../patternfly/dist/js/patternfly.min');
+require('patternfly/dist/js/patternfly-settings.min');
 require('./dist/angular-patternfly');
 module.exports = 'angular-patternfly';

--- a/src/bootstrap-select/bootstrap-select.directive.js
+++ b/src/bootstrap-select/bootstrap-select.directive.js
@@ -1,0 +1,89 @@
+/**
+ * @ngdoc directive
+ * @name patternfly.bsselect:pfBootstrapSelect
+ * @element select
+ *
+ * @param {array=} selections - List of possible selections. Value displayed will be the objects' label field or the object itself
+ * @param {object?} currentSelection - The current selected object
+ * @param {string?} updateOnSelect - Flag to update the current selected object on user seleection, optional - default is true
+ * @param {function?} onChange - Optional callback function when user selection is made
+ * @param {string?} placeholder - placeholder text to show when there is no current selection
+ * @param {string?}  dropdownMenuClass - Class to add to the dropdown menu (typically dropdown-menu-right and such)
+ *
+ * @description
+ * An AngularJS wrapper for the {@link  https://angular-ui.github.io/bootstrap/#/dropdown} Angular Bootstrap dropdown directive
+ *
+ * @example
+ <example module="patternfly.bsselect" deps="">
+
+ <file name="index.html">
+ <div ng-controller="SelectDemoCtrl">
+
+ <form class="form-horizontal">
+   <div class="form-group">
+     <label class="col-sm-2 control-label" for="pet">Preferred pet:</label>
+     <div class="col-sm-4">
+       <div pf-bootstrap-select selections="pets" current-selection="pet" placeholder="No pet selected">
+         </div>
+       </div>
+   </div>
+ </form>
+
+ <p>Your preferred pet is {{pet || 'None'}}.</p>
+
+ </div>
+ </file>
+
+ <file name="script.js">
+ angular.module( 'patternfly.bsselect' ).controller( 'SelectDemoCtrl', function( $scope ) {
+       $scope.pets = ['Dog', 'Cat', 'Chicken'];
+       $scope.pet = null;
+     });
+ </file>
+
+ </example>
+ */
+angular.module('patternfly.bsselect').directive('pfBootstrapSelect', ['$timeout', function ($timeout) {
+  'use strict';
+
+  return {
+    restrict: 'A',
+    scope: {
+      selections: '=',
+      currentSelection: '=?',
+      updateOnSelect: '@',
+      onChange: "=?",
+      placeholder: '@',
+      dropdownMenuClass: "@"
+    },
+    templateUrl: 'bootstrap-select/bootstrap-select.html',
+    controller: function ($scope) {
+      $scope.menuOpen = false;
+      $scope.updateOnSelect = !angular.isDefined($scope.updateOnSelect) || $scope.updateOnSelect !== 'false' || $scope.updateOnSelect === false;
+
+      $scope.selectItem = function (item) {
+        if ($scope.updateOnSelect === true) {
+          $scope.currentSelection = item;
+        }
+        if (angular.isFunction($scope.onChange)) {
+          $scope.onChange(item);
+        }
+        $scope.menuOpen = false;
+      };
+    },
+    link: function (scope, element, attrs) {
+      scope.onItemKeyPress = function (keyEvent, item) {
+        if (keyEvent.which === 13) {
+          scope.selectItem(item);
+        }
+      };
+
+      scope.onItemKeyDown = function (keyEvent, item) {
+        if (keyEvent.which === 32) {
+          keyEvent.preventDefault();
+          scope.selectItem(item);
+        }
+      };
+    }
+  };
+}]);

--- a/src/bootstrap-select/bootstrap-select.html
+++ b/src/bootstrap-select/bootstrap-select.html
@@ -1,0 +1,22 @@
+<div dropdown class="dropdown btn-group bootstrap-select form-control" is-open="menuOpen" keyboard-nav="true">
+  <button dropdown-toggle type="button" class="btn dropdown-toggle btn-default"
+          aria-haspopup="true" aria-expanded="false">
+    <span class="filter-option pull-left">{{currentSelection ? currentSelection.label || currentSelection : placeholder}}</span>&nbsp;
+    <span class="bs-caret">
+      <span class="caret"></span>
+    </span>
+  </button>
+  <div dropdown-menu class="dropdown-menu {{dropdownMenuClass}}" ng-class="{open: menuOpen}">
+    <ul class="dropdown-menu inner" role="menu">
+      <li ng-repeat="item in selections track by $index" ng-class="{divider: item.divider, selected: item == currentSelection}">
+        <a ng-if="!item.divider" role="menuitem" tabindex="0"
+           ng-click="selectItem(item)"
+           ng-keypress="onItemKeyPress($event, item)"
+           ng-keydown="onItemKeyDown($event, item)">
+          <span class="text">{{item.label || item}}</span>
+          <span class="glyphicon glyphicon-ok check-mark"></span>
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/src/bootstrap-select/bootstrap-select.module.js
+++ b/src/bootstrap-select/bootstrap-select.module.js
@@ -1,0 +1,8 @@
+/**
+ * @name  patternfly card
+ *
+ * @description
+ *   Card module for patternfly.
+ *
+ */
+angular.module('patternfly.bsselect', ['patternfly.autofocus', 'ui.bootstrap']);

--- a/src/card/basic/card-filter.html
+++ b/src/card/basic/card-filter.html
@@ -1,11 +1,3 @@
-<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-  {{currentFilter.label}}
-  <span class="caret"></span>
-</button>
-<ul class="dropdown-menu dropdown-menu-right" role="menu">
-  <li ng-repeat="item in filter.filters" ng-class="{'selected': item === currentFilter}">
-    <a role="menuitem" tabindex="-1" ng-click="filterCallBackFn(item)">
-      {{item.label}}
-    </a>
-  </li>
-</ul>
+<div pf-bootstrap-select selections="filter.filters" current-selection="currentFilter"
+     on-change="filterCallBackFn" dropdown-menu-class="dropdown-menu-right">
+</div>

--- a/src/card/card.module.js
+++ b/src/card/card.module.js
@@ -5,4 +5,4 @@
  *   Card module for patternfly.
  *
  */
-angular.module('patternfly.card', []);
+angular.module('patternfly.card', ['patternfly.bsselect']);

--- a/src/charts/c3/c3-chart-defaults.js
+++ b/src/charts/c3/c3-chart-defaults.js
@@ -1,7 +1,7 @@
 (function () {
   'use strict';
 
-  var patternflyDefaults = $().c3ChartDefaults();
+  var patternflyDefaults = patternfly.c3ChartDefaults();
 
   angular.module('patternfly.charts').constant('c3ChartDefaults', {
     getDefaultColors: patternflyDefaults.getDefaultColors,

--- a/src/charts/c3/c3-chart.directive.js
+++ b/src/charts/c3/c3-chart.directive.js
@@ -38,7 +38,7 @@
        $scope.total = 1000;
        $scope.available =  $scope.total - $scope.used;
 
-       $scope.chartConfig = $().c3ChartDefaults().getDefaultDonutConfig('MHz Used');
+       $scope.chartConfig = patternfly.c3ChartDefaults().getDefaultDonutConfig('MHz Used');
        $scope.chartConfig.data = {
          type: "donut",
          columns: [

--- a/src/charts/donut/donut-pct-chart-directive.js
+++ b/src/charts/donut/donut-pct-chart-directive.js
@@ -384,7 +384,7 @@ angular.module('patternfly.charts').directive('pfDonutPctChart', function (pfUti
           $scope.config.data.onclick = $scope.config.onClickFn;
         };
 
-        $scope.config = pfUtils.merge($().c3ChartDefaults().getDefaultDonutConfig(), $scope.config);
+        $scope.config = pfUtils.merge(patternfly.c3ChartDefaults().getDefaultDonutConfig(), $scope.config);
         $scope.updateAll($scope);
 
 

--- a/src/charts/line/line-chart.directive.js
+++ b/src/charts/line/line-chart.directive.js
@@ -174,7 +174,7 @@ angular.module('patternfly.charts').directive('pfLineChart', function (pfUtils) 
           $scope.showYAxis = ($scope.config.showAxis !== undefined) && $scope.config.showAxis;
         }
 
-        $scope.defaultConfig = $().c3ChartDefaults().getDefaultLineConfig();
+        $scope.defaultConfig = patternfly.c3ChartDefaults().getDefaultLineConfig();
         $scope.defaultConfig.axis = {
           x: {
             show: $scope.showXAxis === true,

--- a/src/charts/sparkline/sparkline-chart.directive.js
+++ b/src/charts/sparkline/sparkline-chart.directive.js
@@ -232,7 +232,7 @@ angular.module('patternfly.charts').directive('pfSparklineChart', function (pfUt
                     '</tr>';
                   break;
                 default:
-                  tipRows = $().c3ChartDefaults().getDefaultSparklineTooltip().contents(d);
+                  tipRows = patternfly.c3ChartDefaults().getDefaultSparklineTooltip().contents(d);
                 }
               }
               return $scope.getTooltipTableHTML(tipRows);
@@ -278,7 +278,7 @@ angular.module('patternfly.charts').directive('pfSparklineChart', function (pfUt
           $scope.showYAxis = ($scope.config.showAxis !== undefined) && $scope.config.showAxis;
         }
 
-        $scope.defaultConfig = $().c3ChartDefaults().getDefaultSparklineConfig();
+        $scope.defaultConfig = patternfly.c3ChartDefaults().getDefaultSparklineConfig();
         $scope.defaultConfig.axis = {
           x: {
             show: $scope.showXAxis === true,

--- a/src/charts/trends/trends-chart.directive.js
+++ b/src/charts/trends/trends-chart.directive.js
@@ -59,12 +59,7 @@
            <form role="form" >
              <div class="form-group">
                <label>Layout</label></br>
-               <select pf-select class="pf-select-sm" ng-model="layout" id="layout">
-                 <option value="large" ng-selected="true" selected>Large</option>
-                 <option value="small">Small</option>
-                 <option value="compact">Compact</option>
-                 <option value="inline">Inline</option>
-               </select>
+               <div pf-bootstrap-select class="pf-select-sm" selections="layouts" current-selection="config.layout"></div>
              </div>
            </form>
          </div>
@@ -100,6 +95,7 @@
  <file name="script.js">
  angular.module( 'demo', ['patternfly.charts', 'patternfly.card'] ).controller( 'ChartCtrl', function( $scope ) {
 
+       $scope.layouts = ["large", "small", "compact", "inline"];
        $scope.config = {
          chartId      : 'exampleTrendsChart',
          title        : 'Network Utilization Trends',
@@ -152,11 +148,6 @@
        $scope.$watch('valueType', function (newValue) {
          $scope.config.valueType = newValue;
        });
-
-       $scope.$watch('layout', function (newValue) {
-         $scope.config.layout = newValue;
-       });
-
      });
  </file>
  </example>

--- a/src/filters/filter-directive.js
+++ b/src/filters/filter-directive.js
@@ -22,7 +22,7 @@
  * </ul>
  *
  * @example
-<example module="patternfly.filters" deps="patternfly.select">
+<example module="patternfly.filters">
   <file name="index.html">
     <div ng-controller="ViewCtrl" class="row example-container">
       <div class="col-md-12">

--- a/src/filters/filter-fields-directive.js
+++ b/src/filters/filter-fields-directive.js
@@ -57,6 +57,13 @@ angular.module('patternfly.filters').directive('pfFilterFields', function () {
       scope.selectValue = function (filterValue) {
         scope.addFilterFn(scope.currentField, filterValue);
       };
+
+      scope.onValueKeyPress = function (keyEvent) {
+        if (keyEvent.which === 13 && scope.config.currentValue && scope.config.currentValue !== '') {
+          scope.addFilterFn(scope.currentField, scope.config.currentValue);
+          scope.config.currentValue = undefined;
+        }
+      };
     }
   };
 });

--- a/src/filters/filter-fields-directive.js
+++ b/src/filters/filter-fields-directive.js
@@ -30,41 +30,32 @@ angular.module('patternfly.filters').directive('pfFilterFields', function () {
     },
     templateUrl: 'filters/filter-fields.html',
     controller: function ($scope) {
+      $scope.currentValue = null;
+
       $scope.setupConfig = function () {
         if ($scope.fields === undefined) {
           $scope.fields = [];
         }
         if (!$scope.currentField) {
           $scope.currentField = $scope.config.fields[0];
-          $scope.config.currentValue = null;
-        }
-
-        if ($scope.config.currentValue === undefined) {
-          $scope.config.currentValue = null;
         }
       };
 
       $scope.$watch('config', function () {
         $scope.setupConfig();
       }, true);
+
+      $scope.setupConfig();
     },
 
     link: function (scope, element, attrs) {
       scope.selectField = function (item) {
         scope.currentField = item;
-        scope.config.currentValue = null;
+        scope.currentValue = null;
       };
 
       scope.selectValue = function (filterValue) {
         scope.addFilterFn(scope.currentField, filterValue);
-        scope.config.currentValue = null;
-      };
-
-      scope.onValueKeyPress = function (keyEvent) {
-        if (keyEvent.which === 13) {
-          scope.addFilterFn(scope.currentField, scope.config.currentValue);
-          scope.config.currentValue = undefined;
-        }
       };
     }
   };

--- a/src/filters/filter-fields.html
+++ b/src/filters/filter-fields.html
@@ -21,12 +21,13 @@
                  ng-keypress="onValueKeyPress($event)"/>
         </div>
         <div ng-if="currentField.filterType === 'select'">
-          <select pf-select class="form-control filter-select" id="currentValue"
-                  ng-model="config.currentValue"
-                  ng-options="filterValue for filterValue in currentField.filterValues"
-                  ng-change="selectValue(config.currentValue)">
-          <option value="">{{currentField.placeholder}}</option>
-          </select>
+          <div pf-bootstrap-select class="filter-select"
+               selections="currentField.filterValues"
+               current-selection="currentValue"
+               update-on-select="false"
+               on-change="selectValue"
+               placeholder="{{currentField.placeholder}}">
+          </div>
         </div>
       </div>
     </div>

--- a/src/filters/filters.module.js
+++ b/src/filters/filters.module.js
@@ -5,4 +5,4 @@
  *   Filters module for patternfly.
  *
  */
-angular.module('patternfly.filters', ['patternfly.select', 'ui.bootstrap']);
+angular.module('patternfly.filters', ['patternfly.bsselect', 'ui.bootstrap']);

--- a/src/form/datepicker/datepicker.directive.js
+++ b/src/form/datepicker/datepicker.directive.js
@@ -9,7 +9,7 @@
  * @param {string} options the configuration options for the date picker
  *
  * @example
- <example module="patternfly.datepicker">
+ <example module="patternfly.jquery">
    <file name="index.html">
      <form class="form-horizontal" ng-controller="FormDemoCtrl">
      <div>

--- a/src/form/datepicker/datepicker.directive.js
+++ b/src/form/datepicker/datepicker.directive.js
@@ -1,6 +1,6 @@
 /**
  * @ngdoc directive
- * @name patternfly.form.directive:pfDatepicker
+ * @name patternfly.jquery.directive:pfDatepicker
  *
  * @description
  *  Angular directive to wrap the bootstrap datepicker http://bootstrap-datepicker.readthedocs.org/en/latest/
@@ -9,7 +9,7 @@
  * @param {string} options the configuration options for the date picker
  *
  * @example
- <example module="patternfly.form">
+ <example module="patternfly.datepicker">
    <file name="index.html">
      <form class="form-horizontal" ng-controller="FormDemoCtrl">
      <div>
@@ -21,7 +21,7 @@
    </file>
 
    <file name="script.js">
-     angular.module( 'patternfly.form' ).controller( 'FormDemoCtrl', function( $scope ) {
+     angular.module( 'patternfly.jquery' ).controller( 'FormDemoCtrl', function( $scope ) {
        $scope.setToday = function () {
          $scope.date = new Date();
        }
@@ -35,7 +35,7 @@
    </file>
  </example>
  */
-angular.module('patternfly.form').directive('pfDatepicker', function () {
+angular.module('patternfly.jquery').directive('pfDatepicker', function () {
   'use strict';
 
   return {

--- a/src/navigation/examples/vertical-navigation-basic.js
+++ b/src/navigation/examples/vertical-navigation-basic.js
@@ -43,8 +43,8 @@
  * @example
  <example module="patternfly.navigation" deps="patternfly.utils, patternfly.filters, patternfly.sort, patternfly.views">
   <file name="index.html">
-  <div>
-    <button class="btn btn-primary" id="showVerticalNav" onclick="showVerticalNav">Show Vertical Navigation</button>
+  <div ng-controller="showDemoController">
+    <button class="btn btn-primary" id="showVerticalNav" ng-click="showVerticalNav()">Show Vertical Navigation</button>
     <label class="example-info-text">This will display the vertical nav bar and some mock content over the content of this page.</label>
     <label class="example-info-text">Exit the demo to return back to this page.</label>
   </div>
@@ -54,7 +54,7 @@
          navigate-callback="handleNavigateClick">
       <div>
         <ul class="nav navbar-nav">
-        <li><button id="hideVerticalNav" class="hide-vertical-nav">Exit Vertical Navigation Demo</button></li>
+          <li><button id="hideVerticalNav" ng-click="hideVerticalNav()" class="hide-vertical-nav">Exit Vertical Navigation Demo</button></li>
         </ul>
         <ul class="nav navbar-nav navbar-right navbar-iconic">
           <li class="dropdown">
@@ -83,9 +83,18 @@
       </div>
     </div>
     <div id="contentContainer" class="container-fluid container-cards-pf container-pf-nav-pf-vertical example-page-container">
-      <div id="includedContent"></div>
-      </div>
+      <div id="includedContent" ng-include="'add_content.html'"></div>
     </div>
+  </div>
+  </file>
+  <file name="demo.js">
+  angular.module('patternfly.navigation').controller('showDemoController', ['$scope',
+   function ($scope) {
+     $scope.showVerticalNav = function () {
+       angular.element(document.querySelector("#verticalNavLayout")).removeClass("hidden");
+     };
+   }
+  ]);
   </file>
   <file name="script.js">
   angular.module('patternfly.navigation').controller('vertNavController', ['$scope',
@@ -311,248 +320,247 @@
            title: "Exit Demo"
         }
       ];
+      $scope.hideVerticalNav = function () {
+        angular.element(document.querySelector("#verticalNavLayout")).addClass("hidden");
+      };
       $scope.handleNavigateClick = function (item) {
         if (item.title === "Exit Demo") {
-          angular.element(document.querySelector("#verticalNavLayout")).addClass("hidden");
+          $scope.hideVerticalNav();
         }
       };
     }
   ]);
   </file>
-  <file name="add_content.js">
-    $(document).ready(function() {
-      $("#includedContent")[0].innerHTML = '\
-      <div class="row row-cards-pf"> \
-        <div class="col-xs-12 col-sm-6 col-md-3">\
-          <div class="card-pf card-pf-accented card-pf-aggregate-status" style="height: 89px;">\
-            <h2 class="card-pf-title" style="height: 17px;">\
-            <span class="fa fa-shield"></span><span class="card-pf-aggregate-status-count">0</span> Ipsum\
-            </h2>\
-            <div class="card-pf-body" style="height: 50px;">\
-              <p class="card-pf-aggregate-status-notifications">\
-                <span class="card-pf-aggregate-status-notification"><a href="#" class="add" data-toggle="tooltip" data-placement="top" title="Add Ipsum"><span class="pficon pficon-add-circle-o"></span></a></span>\
-              </p>\
-            </div>\
-          </div>\
-        </div>\
-        <div class="col-xs-12 col-sm-6 col-md-3">\
-          <div class="card-pf card-pf-accented card-pf-aggregate-status" style="height: 89px;">\
-            <h2 class="card-pf-title" style="height: 17px;">\
-              <a href="#"><span class="fa fa-shield"></span><span class="card-pf-aggregate-status-count">20</span> Amet</a>\
-            </h2>\
-            <div class="card-pf-body" style="height: 50px;">\
-              <p class="card-pf-aggregate-status-notifications">\
-                <span class="card-pf-aggregate-status-notification"><a href="#"><span class="pficon pficon-error-circle-o"></span>4</a></span>\
-                <span class="card-pf-aggregate-status-notification"><a href="#"><span class="pficon pficon-warning-triangle-o"></span>1</a></span>\
-              </p>\
-            </div>\
-          </div>\
-        </div>\
-        <div class="col-xs-12 col-sm-6 col-md-3">\
-            <div class="card-pf card-pf-accented card-pf-aggregate-status" style="height: 89px;">\
-              <h2 class="card-pf-title" style="height: 17px;">\
-                <a href="#"><span class="fa fa-shield"></span><span class="card-pf-aggregate-status-count">9</span> Adipiscing</a>\
-              </h2>\
-              <div class="card-pf-body" style="height: 50px;">\
-                <p class="card-pf-aggregate-status-notifications">\
-                  <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok"></span></span>\
-                </p>\
-              </div>\
-          </div>\
-        </div>\
-        <div class="col-xs-12 col-sm-6 col-md-3">\
-          <div class="card-pf card-pf-accented card-pf-aggregate-status" style="height: 89px;">\
-            <h2 class="card-pf-title" style="height: 17px;">\
-              <a href="#"><span class="fa fa-shield"></span><span class="card-pf-aggregate-status-count">12</span> Lorem</a>\
-            </h2>\
-            <div class="card-pf-body" style="height: 50px;">\
-              <p class="card-pf-aggregate-status-notifications">\
-                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o"></span>1</span></a>\
-              </p>\
-            </div>\
-          </div>\
-        </div>\
-      </div>\
-      <div class="row row-cards-pf">\
-        <div class="col-xs-12 col-sm-6 col-md-3">\
-          <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-aggregate-status-mini" style="height: 59px;">\
-            <h2 class="card-pf-title" style="height: 42px;">\
-              <span class="fa fa-rebel"></span>\
-              <span class="card-pf-aggregate-status-count">0</span> Ipsum\
-            </h2>\
-            <div class="card-pf-body" style="height: 24px;">\
-              <p class="card-pf-aggregate-status-notifications">\
-                <span class="card-pf-aggregate-status-notification"><a href="#" class="add" data-toggle="tooltip" data-placement="top" title="Add Ipsum"><span class="pficon pficon-add-circle-o"></span></a></span>\
-              </p>\
-            </div>\
-          </div>\
-        </div>\
-        <div class="col-xs-12 col-sm-6 col-md-3">\
-          <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-aggregate-status-mini" style="height: 59px;">\
-            <h2 class="card-pf-title" style="height: 42px;">\
-              <a href="#">\
-                <span class="fa fa-paper-plane"></span>\
-                <span class="card-pf-aggregate-status-count">20</span> Amet\
-              </a>\
-            </h2>\
-            <div class="card-pf-body" style="height: 24px;">\
-              <p class="card-pf-aggregate-status-notifications">\
-                <span class="card-pf-aggregate-status-notification"><a href="#"><span class="pficon pficon-error-circle-o"></span>4</a></span>\
-              </p>\
-            </div>\
-          </div>\
-        </div>\
-        <div class="col-xs-12 col-sm-6 col-md-3">\
-          <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-aggregate-status-mini" style="height: 59px;">\
-            <h2 class="card-pf-title" style="height: 42px;">\
-              <a href="#">\
-                <span class="pficon pficon-cluster"></span>\
-                <span class="card-pf-aggregate-status-count">9</span> Adipiscing\
-              </a>\
-            </h2>\
-            <div class="card-pf-body" style="height: 24px;">\
-              <p class="card-pf-aggregate-status-notifications">\
-                <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok"></span></span>\
-              </p>\
-            </div>\
-          </div>\
-        </div>\
-        <div class="col-xs-12 col-sm-6 col-md-3">\
-          <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-aggregate-status-mini" style="height: 59px;">\
-            <h2 class="card-pf-title" style="height: 42px;">\
-              <a href="#">\
-                <span class="pficon pficon-image"></span>\
-                <span class="card-pf-aggregate-status-count">12</span> Lorem\
-              </a>\
-            </h2>\
-            <div class="card-pf-body" style="height: 24px;">\
-              <p class="card-pf-aggregate-status-notifications">\
-                <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o"></span>1</span></a>\
-              </p>\
-            </div>\
-          </div>\
-        </div>\
-      </div>\
-      <div class="row row-cards-pf">\
-        <div class="col-xs-12 col-sm-6">\
-          <div class="card-pf" style="height: 360px;">\
-            <div class="card-pf-heading">\
-              <h2 class="card-pf-title" style="height: 17px;">\
-                Top Utilized\
-              </h2>\
-            </div>\
-            <div class="card-pf-body" style="height: 280px;">\
-              <div class="progress-description">\
-                Ipsum\
-              </div>\
-              <div class="progress progress-label-top-right">\
-                <div class="progress-bar progress-bar-danger" role="progressbar"style="width: 95%;" data-toggle="tooltip" title="95% Used">\
-                  <span><strong>190.0 of 200.0 GB</strong> Used</span>\
-                </div>\
-                <div class="progress-bar progress-bar-remaining" role="progressbar" style="width: 5%;" data-toggle="tooltip" title="5% Available">\
-                  <span class="sr-only">5% Available</span>\
-                </div>\
-              </div>\
-              <div class="progress-description">\
-                Amet\
-              </div>\
-              <div class="progress progress-label-top-right">\
-                <div class="progress-bar progress-bar-success" role="progressbar" style="width: 50%;" data-toggle="tooltip" title="50% Used">\
-                  <span><strong>100.0 of 200.0 GB</strong> Used</span>\
-                </div>\
-                <div class="progress-bar progress-bar-remaining" role="progressbar" style="width: 50%;" data-toggle="tooltip" title="50% Available">\
-                  <span class="sr-only">50% Available</span>\
-                </div>\
-              </div>\
-              <div class="progress-description">\
-                Adipiscing\
-              </div>\
-              <div class="progress progress-label-top-right">\
-                <div class="progress-bar progress-bar-warning" role="progressbar" style="width: 70%;" data-toggle="tooltip" title="70% Used">\
-                  <span><strong>140.0 of 200.0 GB</strong> Used</span>\
-                </div>\
-                <div class="progress-bar progress-bar-remaining" role="progressbar" style="width: 30%;" data-toggle="tooltip" title="30% Available">\
-                  <span class="sr-only">30% Available</span>\
-                </div>\
-              </div>\
-              <div class="progress-description">\
-                Lorem\
-              </div>\
-              <div class="progress progress-label-top-right">\
-                <div class="progress-bar progress-bar-warning" role="progressbar" style="width: 76.5%;" data-toggle="tooltip" title="76.5% Used">\
-                  <span><strong>153.0 of 200.0 GB</strong> Used</span>\
-                </div>\
-                <div class="progress-bar progress-bar-remaining" role="progressbar" style="width: 23.5%;" data-toggle="tooltip" title="23.5% Available">\
-                  <span class="sr-only">23.5% Available</span>\
-                </div>\
-              </div>\
-            </div>\
-          </div>\
-        </div>\
-        <div class="col-xs-12 col-sm-6">\
-          <div class="card-pf" style="height: 360px;">\
-            <div class="card-pf-heading">\
-              <h2 class="card-pf-title" style="height: 17px;">\
-                Quotas\
-              </h2>\
-            </div>\
-            <div class="card-pf-body" style="height: 280px;">\
-              <div class="progress-container progress-description-left progress-label-right">\
-                <div class="progress-description">\
-                  Ipsum\
-                </div>\
-                <div class="progress">\
-                  <div class="progress-bar" role="progressbar" style="width: 25%;" data-toggle="tooltip" title="25% Used">\
-                    <span><strong>115 of 460</strong> MHz</span>\
-                  </div>\
-                  <div class="progress-bar progress-bar-remaining" role="progressbar" style="width: 75%;" data-toggle="tooltip" title="75% Available">\
-                    <span class="sr-only">75% Available</span>\
-                  </div>\
-                </div>\
-              </div>\
-              <div class="progress-container progress-description-left progress-label-right">\
-                <div class="progress-description">\
-                  Amet\
-                </div>\
-                <div class="progress">\
-                  <div class="progress-bar" role="progressbar" style="width: 50%;" data-toggle="tooltip" title="8 GB Used">\
-                    <span><strong>8 of 16</strong> GB</span>\
-                  </div>\
-                  <div class="progress-bar progress-bar-remaining" role="progressbar" style="width: 50%;" data-toggle="tooltip" title="8 GB Available">\
-                    <span class="sr-only">50% Available</span>\
-                  </div>\
-                </div>\
-              </div>\
-              <div class="progress-container progress-description-left progress-label-right">\
-                <div class="progress-description">\
-                  Adipiscing\
-                </div>\
-                <div class="progress">\
-                  <div class="progress-bar" role="progressbar" style="width: 62.5%;" data-toggle="tooltip" title="62.5% Used">\
-                    <span><strong>5 of 8</strong> Total</span>\
-                  </div>\
-                  <div class="progress-bar progress-bar-remaining" role="progressbar" style="width: 37.5%;" data-toggle="tooltip" title="37.5% Available">\
-                    <span class="sr-only">37.5% Available</span>\
-                  </div>\
-                </div>\
-              </div>\
-              <div class="progress-container progress-description-left progress-label-right">\
-                <div class="progress-description">\
-                  Lorem\
-                </div>\
-                <div class="progress">\
-                  <div class="progress-bar" role="progressbar" style="width: 100%;" data-toggle="tooltip" title="100% Used">\
-                    <span><strong>2 of 2</strong> Total</span>\
-                  </div>\
-                </div>\
-              </div>\
-            </div>\
-          </div>\
-        </div>\
-      </div>\
-      ';
-    });
-  </file>
+  <file name="add_content.html">
+    <div class="row row-cards-pf">
+      <div class="col-xs-12 col-sm-6 col-md-3">
+        <div class="card-pf card-pf-accented card-pf-aggregate-status" style="height: 89px;">
+          <h2 class="card-pf-title" style="height: 17px;">
+            <span class="fa fa-shield"></span><span class="card-pf-aggregate-status-count">0</span> Ipsum
+          </h2>
+          <div class="card-pf-body" style="height: 50px;">
+            <p class="card-pf-aggregate-status-notifications">
+              <span class="card-pf-aggregate-status-notification"><a href="#" class="add" data-toggle="tooltip" data-placement="top" title="Add Ipsum"><span class="pficon pficon-add-circle-o"></span></a></span>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="col-xs-12 col-sm-6 col-md-3">
+        <div class="card-pf card-pf-accented card-pf-aggregate-status" style="height: 89px;">
+          <h2 class="card-pf-title" style="height: 17px;">
+            <a href="#"><span class="fa fa-shield"></span><span class="card-pf-aggregate-status-count">20</span> Amet</a>
+          </h2>
+          <div class="card-pf-body" style="height: 50px;">
+            <p class="card-pf-aggregate-status-notifications">
+              <span class="card-pf-aggregate-status-notification"><a href="#"><span class="pficon pficon-error-circle-o"></span>4</a></span>
+              <span class="card-pf-aggregate-status-notification"><a href="#"><span class="pficon pficon-warning-triangle-o"></span>1</a></span>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="col-xs-12 col-sm-6 col-md-3">
+        <div class="card-pf card-pf-accented card-pf-aggregate-status" style="height: 89px;">
+          <h2 class="card-pf-title" style="height: 17px;">
+            <a href="#"><span class="fa fa-shield"></span><span class="card-pf-aggregate-status-count">9</span> Adipiscing</a>
+          </h2>
+          <div class="card-pf-body" style="height: 50px;">
+            <p class="card-pf-aggregate-status-notifications">
+              <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok"></span></span>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="col-xs-12 col-sm-6 col-md-3">
+        <div class="card-pf card-pf-accented card-pf-aggregate-status" style="height: 89px;">
+          <h2 class="card-pf-title" style="height: 17px;">
+            <a href="#"><span class="fa fa-shield"></span><span class="card-pf-aggregate-status-count">12</span> Lorem</a>
+          </h2>
+          <div class="card-pf-body" style="height: 50px;">
+            <p class="card-pf-aggregate-status-notifications">
+              <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o"></span>1</span></a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row row-cards-pf">
+      <div class="col-xs-12 col-sm-6 col-md-3">
+        <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-aggregate-status-mini" style="height: 59px;">
+          <h2 class="card-pf-title" style="height: 42px;">
+            <span class="fa fa-rebel"></span>
+            <span class="card-pf-aggregate-status-count">0</span> Ipsum
+          </h2>
+          <div class="card-pf-body" style="height: 24px;">
+            <p class="card-pf-aggregate-status-notifications">
+              <span class="card-pf-aggregate-status-notification"><a href="#" class="add" data-toggle="tooltip" data-placement="top" title="Add Ipsum"><span class="pficon pficon-add-circle-o"></span></a></span>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="col-xs-12 col-sm-6 col-md-3">
+        <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-aggregate-status-mini" style="height: 59px;">
+          <h2 class="card-pf-title" style="height: 42px;">
+            <a href="#">
+              <span class="fa fa-paper-plane"></span>
+              <span class="card-pf-aggregate-status-count">20</span> Amet
+            </a>
+          </h2>
+          <div class="card-pf-body" style="height: 24px;">
+            <p class="card-pf-aggregate-status-notifications">
+              <span class="card-pf-aggregate-status-notification"><a href="#"><span class="pficon pficon-error-circle-o"></span>4</a></span>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="col-xs-12 col-sm-6 col-md-3">
+        <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-aggregate-status-mini" style="height: 59px;">
+          <h2 class="card-pf-title" style="height: 42px;">
+            <a href="#">
+              <span class="pficon pficon-cluster"></span>
+              <span class="card-pf-aggregate-status-count">9</span> Adipiscing
+            </a>
+          </h2>
+        <div class="card-pf-body" style="height: 24px;">
+          <p class="card-pf-aggregate-status-notifications">
+            <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok"></span></span>
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="col-xs-12 col-sm-6 col-md-3">
+      <div class="card-pf card-pf-accented card-pf-aggregate-status card-pf-aggregate-status-mini" style="height: 59px;">
+        <h2 class="card-pf-title" style="height: 42px;">
+          <a href="#">
+            <span class="pficon pficon-image"></span>
+            <span class="card-pf-aggregate-status-count">12</span> Lorem
+          </a>
+        </h2>
+        <div class="card-pf-body" style="height: 24px;">
+          <p class="card-pf-aggregate-status-notifications">
+            <a href="#"><span class="card-pf-aggregate-status-notification"><span class="pficon pficon-error-circle-o"></span>1</span></a>
+          </p>
+        </div>
+      </div>
+    </div>
+    </div>
+    <div class="row row-cards-pf">
+    <div class="col-xs-12 col-sm-6">
+      <div class="card-pf" style="height: 360px;">
+        <div class="card-pf-heading">
+          <h2 class="card-pf-title" style="height: 17px;">
+            Top Utilized
+          </h2>
+        </div>
+        <div class="card-pf-body" style="height: 280px;">
+          <div class="progress-description">
+            Ipsum
+          </div>
+          <div class="progress progress-label-top-right">
+            <div class="progress-bar progress-bar-danger" role="progressbar"style="width: 95%;" data-toggle="tooltip" title="95% Used">
+              <span><strong>190.0 of 200.0 GB</strong> Used</span>
+            </div>
+            <div class="progress-bar progress-bar-remaining" role="progressbar" style="width: 5%;" data-toggle="tooltip" title="5% Available">
+              <span class="sr-only">5% Available</span>
+            </div>
+          </div>
+          <div class="progress-description">
+            Amet
+          </div>
+          <div class="progress progress-label-top-right">
+            <div class="progress-bar progress-bar-success" role="progressbar" style="width: 50%;" data-toggle="tooltip" title="50% Used">
+              <span><strong>100.0 of 200.0 GB</strong> Used</span>
+            </div>
+            <div class="progress-bar progress-bar-remaining" role="progressbar" style="width: 50%;" data-toggle="tooltip" title="50% Available">
+              <span class="sr-only">50% Available</span>
+            </div>
+          </div>
+          <div class="progress-description">
+            Adipiscing
+          </div>
+          <div class="progress progress-label-top-right">
+            <div class="progress-bar progress-bar-warning" role="progressbar" style="width: 70%;" data-toggle="tooltip" title="70% Used">
+              <span><strong>140.0 of 200.0 GB</strong> Used</span>
+            </div>
+            <div class="progress-bar progress-bar-remaining" role="progressbar" style="width: 30%;" data-toggle="tooltip" title="30% Available">
+              <span class="sr-only">30% Available</span>
+            </div>
+          </div>
+          <div class="progress-description">
+            Lorem
+          </div>
+          <div class="progress progress-label-top-right">
+            <div class="progress-bar progress-bar-warning" role="progressbar" style="width: 76.5%;" data-toggle="tooltip" title="76.5% Used">
+              <span><strong>153.0 of 200.0 GB</strong> Used</span>
+            </div>
+            <div class="progress-bar progress-bar-remaining" role="progressbar" style="width: 23.5%;" data-toggle="tooltip" title="23.5% Available">
+              <span class="sr-only">23.5% Available</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-xs-12 col-sm-6">
+      <div class="card-pf" style="height: 360px;">
+        <div class="card-pf-heading">
+          <h2 class="card-pf-title" style="height: 17px;">
+            Quotas
+          </h2>
+        </div>
+        <div class="card-pf-body" style="height: 280px;">
+          <div class="progress-container progress-description-left progress-label-right">
+            <div class="progress-description">
+              Ipsum
+            </div>
+            <div class="progress">
+              <div class="progress-bar" role="progressbar" style="width: 25%;" data-toggle="tooltip" title="25% Used">
+                <span><strong>115 of 460</strong> MHz</span>
+              </div>
+              <div class="progress-bar progress-bar-remaining" role="progressbar" style="width: 75%;" data-toggle="tooltip" title="75% Available">
+                <span class="sr-only">75% Available</span>
+              </div>
+            </div>
+          </div>
+          <div class="progress-container progress-description-left progress-label-right">
+            <div class="progress-description">
+              Amet
+            </div>
+            <div class="progress">
+              <div class="progress-bar" role="progressbar" style="width: 50%;" data-toggle="tooltip" title="8 GB Used">
+                <span><strong>8 of 16</strong> GB</span>
+              </div>
+              <div class="progress-bar progress-bar-remaining" role="progressbar" style="width: 50%;" data-toggle="tooltip" title="8 GB Available">
+                <span class="sr-only">50% Available</span>
+              </div>
+            </div>
+          </div>
+          <div class="progress-container progress-description-left progress-label-right">
+          <div class="progress-description">
+            Adipiscing
+          </div>
+          <div class="progress">
+            <div class="progress-bar" role="progressbar" style="width: 62.5%;" data-toggle="tooltip" title="62.5% Used">
+              <span><strong>5 of 8</strong> Total</span>
+            </div>
+            <div class="progress-bar progress-bar-remaining" role="progressbar" style="width: 37.5%;" data-toggle="tooltip" title="37.5% Available">
+              <span class="sr-only">37.5% Available</span>
+            </div>
+          </div>
+        </div>
+        <div class="progress-container progress-description-left progress-label-right">
+          <div class="progress-description">
+          Lorem
+          </div>
+          <div class="progress">
+            <div class="progress-bar" role="progressbar" style="width: 100%;" data-toggle="tooltip" title="100% Used">
+              <span><strong>2 of 2</strong> Total</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  </div>
+ </file>
   <file name="hide-show.js">
     $(document).ready(function() {
       $(document).on('click', '#showVerticalNav', function() {

--- a/src/navigation/examples/vertical-navigation-router.js
+++ b/src/navigation/examples/vertical-navigation-router.js
@@ -32,8 +32,8 @@
  * @example
  <example module="myApp" deps="patternfly.utils, patternfly.filters, patternfly.sort, patternfly.views">
   <file name="index.html">
-    <div>
-      <button class="btn btn-primary" id="showVerticalNavWithRouter" onclick="showVerticalNavWithRouter">Show Vertical Navigation with UIRouter</button>
+    <div ng-controller="showDemoController">
+      <button class="btn btn-primary" id="showVerticalNavWithRouter" ng-click="showVerticalNav()">Show Vertical Navigation with UIRouter</button>
       <label class="example-info-text">This will display the vertical nav bar and some mock content over the content of this page.</label>
       <label class="example-info-text">Exit the demo to return back to this page.</label>
     </div>
@@ -43,7 +43,7 @@
           navigate-callback="handleNavigateClickRouter">
         <div>
           <ul class="nav navbar-nav">
-          <li><button id="hideVerticalNavWithRouter" class="hide-vertical-nav">Exit Vertical Navigation Demo</button></li>
+          <li><button id="hideVerticalNavWithRouter" class="hide-vertical-nav" ng-click="hideVerticalNav()">Exit Vertical Navigation Demo</button></li>
           </ul>
           <ul class="nav navbar-nav navbar-right navbar-iconic">
             <li class="dropdown">
@@ -77,6 +77,15 @@
         </ui-view>
       </div>
     </div>
+  </file>
+  <file name="demo.js">
+   angular.module('patternfly.navigation').controller('showDemoController', ['$scope',
+   function ($scope) {
+       $scope.showVerticalNav = function () {
+         angular.element(document.querySelector("#verticalNavWithRouterLayout")).removeClass("hidden");
+       };
+     }
+   ]);
   </file>
   <file name="script.js">
     angular.module('myApp',['patternfly.navigation', 'ui.router'])
@@ -137,23 +146,16 @@
               title: "Exit Demo"
             }
           ];
+          $scope.hideVerticalNav = function() {
+            angular.element(document.querySelector("#verticalNavWithRouterLayout")).addClass("hidden");
+          };
           $scope.handleNavigateClickRouter = function (item) {
             if (item.title === "Exit Demo") {
-              angular.element(document.querySelector("#verticalNavWithRouterLayout")).addClass("hidden");
+              $scope.hideVerticalNav();
             }
           };
         }
       ]);
-  </file>
-  <file name="hide-show.js">
-    $(document).ready(function() {
-      $(document).on('click', '#showVerticalNavWithRouter', function() {
-        $(document.getElementById("verticalNavWithRouterLayout")).removeClass("hidden");
-      });
-      $(document).on('click', '#hideVerticalNavWithRouter', function() {
-        $(document.getElementById("verticalNavWithRouterLayout")).addClass("hidden");
-      });
-    });
   </file>
 </example>
 */

--- a/src/navigation/vertical-navigation-directive.js
+++ b/src/navigation/vertical-navigation-directive.js
@@ -90,11 +90,6 @@ angular.module('patternfly.navigation').directive('pfVerticalNavigation', ['$loc
         }
       },
       link: function ($scope) {
-        var breakpoints = {
-          'tablet': 768,
-          'desktop': 1200
-        };
-
         var getBodyContentElement = function () {
           return angular.element(document.querySelector('.container-pf-nav-pf-vertical'));
         };
@@ -147,7 +142,7 @@ angular.module('patternfly.navigation').directive('pfVerticalNavigation', ['$loc
           var bodyContentElement = getBodyContentElement();
 
           // Check to see if we need to enter/exit the mobile state
-          if (!$scope.ignoreMobile && width < breakpoints.tablet) {
+          if (!$scope.ignoreMobile && width < patternfly.pfBreakpoints.tablet) {
             if (!$scope.inMobileState) {
               $scope.inMobileState = true;
 

--- a/src/notification/inline-notification.directive.js
+++ b/src/notification/inline-notification.directive.js
@@ -39,13 +39,13 @@
          </div>
          <div class="form-group">
            <label class="col-sm-2 control-label" for="type">Type:</label>
-           <div class="col-sm-10">
-            <select pf-select ng-model="type" id="type" ng-options="o as o for o in types"></select>
+           <div class="col-sm-4">
+            <div pf-bootstrap-select current-selection="type" id="type" selections="types"></divselect>
            </div>
          </div>
          <div class="form-group">
            <label class="col-sm-2 control-label" for="type">Persistent:</label>
-           <div class="col-sm-10">
+           <div class="col-sm-4">
             <input type="checkbox" ng-model="isPersistent"></input>
            </div>
          </div>

--- a/src/notification/inline-notification.directive.js
+++ b/src/notification/inline-notification.directive.js
@@ -40,7 +40,7 @@
          <div class="form-group">
            <label class="col-sm-2 control-label" for="type">Type:</label>
            <div class="col-sm-4">
-            <div pf-bootstrap-select current-selection="type" id="type" selections="types"></divselect>
+            <div pf-bootstrap-select current-selection="type" id="type" selections="types"></div>
            </div>
          </div>
          <div class="form-group">

--- a/src/notification/notification-drawer.directive.js
+++ b/src/notification/notification-drawer.directive.js
@@ -76,8 +76,8 @@
  </file>
  <file name="notification-body.html">
    <div ng-if="!drawerExpanded">
-     <div class="dropdown pull-right dropdown-kebab-pf" ng-if="notification.actions && notification.actions.length > 0">
-       <button class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+     <div dropdown class="dropdown pull-right dropdown-kebab-pf" ng-if="notification.actions && notification.actions.length > 0">
+       <button dropdown-toggle class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
          <span class="fa fa-ellipsis-v"></span>
        </button>
        <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight">

--- a/src/notification/notification.module.js
+++ b/src/notification/notification.module.js
@@ -5,4 +5,4 @@
  *   Notification module for patternfly.
  *
  */
-angular.module('patternfly.notification', ['patternfly.utils']);
+angular.module('patternfly.notification', ['patternfly.utils', 'patternfly.bsselect']);

--- a/src/notification/toast-notification.html
+++ b/src/notification/toast-notification.html
@@ -1,7 +1,7 @@
 <div class="toast-pf alert alert-{{notificationType}}" ng-class="{'alert-dismissable': showCloseButton}"
      ng-mouseenter="handleEnter()" ng-mouseleave="handleLeave()">
-  <div class="dropdown pull-right dropdown-kebab-pf" ng-if="menuActions && menuActions.length > 0">
-    <button class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+  <div dropdown class="dropdown pull-right dropdown-kebab-pf" ng-if="menuActions && menuActions.length > 0">
+    <button dropdown-toggle class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
       <span class="fa fa-ellipsis-v"></span>
     </button>
     <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight">

--- a/src/patternfly.jquery.module.js
+++ b/src/patternfly.jquery.module.js
@@ -1,0 +1,8 @@
+/**
+ * @name  patternfly
+ *
+ * @description
+ *   Base module for patternfly.
+ */
+angular.module('patternfly.jquery', []);
+

--- a/src/patternfly.module.js
+++ b/src/patternfly.module.js
@@ -13,6 +13,7 @@ angular.module('patternfly', [
   'patternfly.navigation',
   'patternfly.notification',
   'patternfly.select',
+  'patternfly.bsselect',
   'patternfly.sort',
   'patternfly.toolbars',
   'patternfly.utils',

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -1,6 +1,6 @@
 /**
  * @ngdoc directive
- * @name patternfly.select:pfSelect
+ * @name patternfly.jquery.directive:pfSelect
  * @element select
  *
  * @param {string} ngModel Model binding using the {@link https://docs.angularjs.org/api/ng/type/ngModel.NgModelController/ NgModelController} is mandatory.
@@ -12,7 +12,7 @@
  * as a default select decorator in {@link https://www.patternfly.org/widgets/#bootstrap-select Patternfly}.
  *
  * @example
- <example module="patternfly.select">
+ <example module="patternfly.jquery">
 
    <file name="index.html">
      <div ng-controller="SelectDemoCtrl">
@@ -53,7 +53,7 @@
    </file>
 
    <file name="script.js">
-     angular.module( 'patternfly.select' ).controller( 'SelectDemoCtrl', function( $scope ) {
+     angular.module( 'patternfly.jquery').controller( 'SelectDemoCtrl', function( $scope ) {
        $scope.drinks = ['tea', 'coffee', 'water'];
        $scope.pets = ['Dog', 'Cat', 'Chicken'];
        $scope.pet = $scope.pets[0];
@@ -63,7 +63,7 @@
 
  </example>
  */
-angular.module('patternfly.select', []).directive('pfSelect', function ($timeout) {
+angular.module('patternfly.jquery').directive('pfSelect', function ($timeout) {
   'use strict';
 
   return {

--- a/src/sort/sort.html
+++ b/src/sort/sort.html
@@ -1,22 +1,20 @@
 <div class="sort-pf">
-  <form>
-    <div class="form-group">
-      <div class="dropdown btn-group">
-        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          {{config.currentField.title}}
-          <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu">
-          <li ng-repeat="item in config.fields" ng-class="{'selected': item === config.currentField}">
-            <a href="javascript:void(0);" class="sort-field" role="menuitem" tabindex="-1" ng-click="selectField(item)">
-              {{item.title}}
-            </a>
-          </li>
-        </ul>
-      </div>
-      <button class="btn btn-link" type="button"  ng-click="changeDirection()">
-        <span class="sort-direction" ng-class="getSortIconClass()"></span>
+  <div class="form-group">
+    <div dropdown class="dropdown btn-group" keyboard-nav="true">
+      <button dropdown-toggle type="button" class="btn btn-default dropdown-toggle filter-fields" aria-haspopup="true" aria-expanded="false">
+        {{config.currentField.title}}
+        <span class="caret"></span>
       </button>
+      <ul dropdown-menu class="dropdown-menu">
+        <li ng-repeat="item in config.fields">
+          <a class="sort-field" role="menuitem" tabindex="-1" ng-click="selectField(item)">
+            {{item.title}}
+          </a>
+        </li>
+      </ul>
     </div>
-  </form>
+    <button class="btn btn-link" type="button"  ng-click="changeDirection()">
+      <span class="sort-direction" ng-class="getSortIconClass()"></span>
+    </button>
+  </div>
 </div>

--- a/src/toolbars/toolbar-directive.js
+++ b/src/toolbars/toolbar-directive.js
@@ -45,7 +45,7 @@
  *   </ul>
  *
  * @example
-<example module="patternfly.toolbars" deps="patternfly.filters, patternfly.sort, patternfly.views">
+<example module="patternfly.toolbars">
   <file name="index.html">
     <div ng-controller="ViewCtrl" class="row example-container">
       <div class="col-md-12">

--- a/src/toolbars/toolbar.html
+++ b/src/toolbars/toolbar.html
@@ -16,8 +16,8 @@
             {{action.name}}
           </button>
           <div ng-if="config.actionsConfig.actionsInclude" pf-transclude class="toolbar-pf-include-actions" ng-tranclude="actions"></div>
-          <div class="dropdown  dropdown-kebab-pf" ng-if="config.actionsConfig.moreActions && config.actionsConfig.moreActions.length > 0">
-            <button class="btn btn-link dropdown-toggle" type="button" id="{{filterDomId}}_kebab" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+          <div dropdown class="dropdown  dropdown-kebab-pf" ng-if="config.actionsConfig.moreActions && config.actionsConfig.moreActions.length > 0">
+            <button dropdown-toggle class="btn btn-link dropdown-toggle" type="button" id="{{filterDomId}}_kebab" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
               <span class="fa fa-ellipsis-v"></span>
             </button>
             <ul class="dropdown-menu " aria-labelledby="dropdownKebab">

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -30,7 +30,7 @@
       return mergeDeep({}, angular.copy(source1), angular.copy(source2));
     },
 
-    colorPalette: $.pfPaletteColors
+    colorPalette: patternfly.pfPaletteColors
   });
 })();
 

--- a/src/validation/validation.js
+++ b/src/validation/validation.js
@@ -42,10 +42,9 @@
        </div>
 
        <div class="form-group">
-         <label class="col-sm-2 control-label" for="message">Validation disabled:</label>
-         <div class="col-sm-10">
-           <input class="form-control" type="checkbox" ng-model="isValidationDisabled"/>
-         </div>
+         <label class="col-sm-offset-1 col-sm-2 control-label checkbox-inline">
+           <input type="checkbox" ng-model="isValidationDisabled">Validation disabled</input>
+         </label>
        </div>
      </form>
      </div>

--- a/src/wizard/wizard-buttons.js
+++ b/src/wizard/wizard-buttons.js
@@ -5,7 +5,7 @@
       .directive(action, function () {
         return {
           restrict: 'A',
-          require: '^pf-wizard',
+          require: '^pfWizard',
           scope: {
             callback: "=?"
           },

--- a/src/wizard/wizard-review-page-directive.js
+++ b/src/wizard/wizard-review-page-directive.js
@@ -17,7 +17,7 @@ angular.module('patternfly.wizard').directive('pfWizardReviewPage', function () 
       shown: '=',
       wizardData: "="
     },
-    require: '^pf-wizard',
+    require: '^pfWizard',
     templateUrl: 'wizard/wizard-review-page.html',
     controller: function ($scope) {
       $scope.toggleShowReviewDetails = function (step) {

--- a/src/wizard/wizard-step-directive.js
+++ b/src/wizard/wizard-step-directive.js
@@ -27,6 +27,7 @@ angular.module('patternfly.wizard').directive('pfWizardStep', function () {
   'use strict';
   return {
     restrict: 'A',
+    require: '^pfWizard',
     transclude: true,
     scope: {
       stepTitle: '@',
@@ -47,7 +48,6 @@ angular.module('patternfly.wizard').directive('pfWizardStep', function () {
       showReviewDetails: '@?',
       reviewTemplate: '@?'
     },
-    require: '^pf-wizard',
     templateUrl: 'wizard/wizard-step.html',
     controller: function ($scope, $timeout) {
       var firstRun = true;

--- a/src/wizard/wizard-substep-directive.js
+++ b/src/wizard/wizard-substep-directive.js
@@ -39,7 +39,7 @@ angular.module('patternfly.wizard').directive('pfWizardSubstep', function () {
       showReviewDetails: '@?',
       reviewTemplate: '@?'
     },
-    require: '^pf-wizard-step',
+    require: '^pfWizardStep',
     templateUrl: 'wizard/wizard-substep.html',
     controller: function ($scope) {
       if (angular.isUndefined($scope.nextEnabled)) {

--- a/test/bootstrap-select/bootstrap-select.spec.js
+++ b/test/bootstrap-select/bootstrap-select.spec.js
@@ -1,0 +1,202 @@
+describe('pf-bootstrap-select', function () {
+  var $scope;
+  var $compile;
+  var element;
+  var isoScope;
+
+  beforeEach(module('patternfly.bsselect', 'bootstrap-select/bootstrap-select.html'));
+
+  beforeEach(inject(function (_$rootScope_, _$compile_, _$timeout_) {
+    $scope = _$rootScope_;
+    $compile = _$compile_;
+    $timeout = _$timeout_;
+  }));
+
+  describe('Page with pf-bootstrap-select directive', function () {
+
+    var compileHTML = function (markup, scope) {
+      element = angular.element(markup);
+      var el = $compile(element)(scope);
+
+      scope.$digest();
+
+      isoScope = el.isolateScope();
+    };
+
+    it('should generate correct options from selections', function () {
+
+      $scope.options = ['a','b','c'];
+      $scope.modelValue = $scope.options[1];
+
+      compileHTML('<div pf-bootstrap-select current-selection="modelValue" selections="options" placeholder="test placeholder"></div>', $scope);
+
+      var selection = element.find('.filter-option');
+      expect(selection.length).toBe(1);
+
+      expect(selection.text()).toBe('b');
+
+      var bsToggle = element.find('.dropdown-toggle');
+      expect(bsToggle.length).toBe(1);
+
+      var bsSelect = angular.element(bsToggle).siblings('.dropdown-menu');
+      expect(bsSelect.length).toBe(1);
+
+      var bsSelItems = bsSelect.find('li > a > span.text');
+      expect(bsSelItems.length).toBe($scope.options.length);
+      expect(angular.element(bsSelItems[0]).text()).toBe($scope.options[0]);
+      expect(angular.element(bsSelItems[1]).text()).toBe($scope.options[1]);
+      expect(angular.element(bsSelItems[2]).text()).toBe($scope.options[2]);
+
+      var bsSelected = bsSelect.find('li.selected .text');
+      expect(bsSelected.length).toBe(1);
+      expect(bsSelected.text()).toBe('b');
+    });
+
+    it('should show the placeholder when there is no current selection', function () {
+      $scope.options = ['a','b','c'];
+      $scope.modelValue = null;
+
+      compileHTML('<div pf-bootstrap-select current-selection="modelValue" selections="options" placeholder="test placeholder"></div>', $scope);
+
+      var selection = element.find('.filter-option');
+      expect(selection.length).toBe(1);
+      expect(selection.text()).toBe('test placeholder');
+    });
+
+    it('should respond to changes in selections', function () {
+
+      $scope.options = ['a','b','c'];
+      $scope.modelValue = $scope.options[0];
+      compileHTML('<div pf-bootstrap-select current-selection="modelValue" selections="options" placeholder="test placeholder"></div>', $scope);
+
+      var bsToggle = element.find('.dropdown-toggle');
+      expect(bsToggle.length).toBe(1);
+
+      var bsSelect = angular.element(bsToggle).siblings('.dropdown-menu');
+      expect(bsSelect.length).toBe(1);
+
+      var bsSelItems = bsSelect.find('li > a > span.text');
+      expect(bsSelItems.length).toBe($scope.options.length);
+      expect(angular.element(bsSelItems[0]).text()).toBe($scope.options[0]);
+      expect(angular.element(bsSelItems[1]).text()).toBe($scope.options[1]);
+      expect(angular.element(bsSelItems[2]).text()).toBe($scope.options[2]);
+
+      $scope.$apply(function() {
+        $scope.options.push('d');
+      });
+
+      $timeout.flush();
+
+      var bsToggle = element.find('.dropdown-toggle');
+      expect(bsToggle.length).toBe(1);
+
+      var bsSelItems = bsSelect.find('li > a > span.text');
+      expect(bsSelItems.length).toBe($scope.options.length);
+      expect(angular.element(bsSelItems[0]).text()).toBe($scope.options[0]);
+      expect(angular.element(bsSelItems[1]).text()).toBe($scope.options[1]);
+      expect(angular.element(bsSelItems[2]).text()).toBe($scope.options[2]);
+      expect(angular.element(bsSelItems[3]).text()).toBe($scope.options[3]);
+    });
+
+    it('should respond to current selection change', function () {
+
+      $scope.options = ['a','b','c'];
+      $scope.modelValue = $scope.options[0];
+      compileHTML('<div pf-bootstrap-select current-selection="modelValue" selections="options" placeholder="test placeholder"></div>', $scope);
+
+      var selection = element.find('.filter-option');
+      expect(selection.length).toBe(1);
+
+      expect(selection.text()).toBe('a');
+
+      $scope.$apply(function() {
+        $scope.modelValue = $scope.options[1];
+      });
+
+      selection = element.find('.filter-option');
+      expect(selection.length).toBe(1);
+
+      expect(selection.text()).toBe('b');
+
+      $scope.$apply(function() {
+        $scope.modelValue = $scope.options[2];
+      });
+
+      selection = element.find('.filter-option');
+      expect(selection.length).toBe(1);
+
+      expect(selection.text()).toBe('c');
+    });
+
+    it('should not update selection when updateOnSelect is false', function () {
+
+      $scope.options = ['a','b','c'];
+      $scope.modelValue = $scope.options[0];
+      compileHTML('<div pf-bootstrap-select current-selection="modelValue" update-on-select="false" selections="options" placeholder="test placeholder"></div>', $scope);
+
+      var selection = element.find('.filter-option');
+      expect(selection.length).toBe(1);
+
+      expect(selection.text()).toBe('a');
+
+      var bsToggle = element.find('.dropdown-toggle');
+      expect(bsToggle.length).toBe(1);
+
+      var bsSelect = angular.element(bsToggle).siblings('.dropdown-menu');
+      expect(bsSelect.length).toBe(1);
+
+      var bsSelItems = bsSelect.find('li > a');
+
+      eventFire(bsSelItems[1], 'click');
+      $scope.$digest();
+
+      selection = element.find('.filter-option');
+      expect(selection.length).toBe(1);
+
+      expect(selection.text()).toBe('a');
+    });
+
+    it('should invoke the onChange callback when an item is selected', function () {
+
+      $scope.options = ['a','b','c'];
+      $scope.modelValue = $scope.options[0];
+
+      var selectedItem = null;
+      $scope.handleChange = function (item) {
+        selectedItem = item;
+      };
+
+      compileHTML('<div pf-bootstrap-select current-selection="modelValue" on-change="handleChange" selections="options" placeholder="test placeholder"></div>', $scope);
+
+      var selection = element.find('.filter-option');
+      expect(selection.length).toBe(1);
+
+      expect(selection.text()).toBe('a');
+
+      expect(selectedItem).toBeNull();
+
+      var bsToggle = element.find('.dropdown-toggle');
+      expect(bsToggle.length).toBe(1);
+
+      var bsSelect = angular.element(bsToggle).siblings('.dropdown-menu');
+      expect(bsSelect.length).toBe(1);
+
+      var bsSelItems = bsSelect.find('li > a');
+
+      eventFire(bsSelItems[1], 'click');
+      $scope.$digest();
+
+      expect(selectedItem).toBe($scope.options[1]);
+    });
+
+    it('should add the class to the dropdown menu when specified', function () {
+      $scope.options = ['a','b','c'];
+      $scope.modelValue = $scope.options[0];
+
+      compileHTML('<div pf-bootstrap-select current-selection="modelValue" dropdown-menu-class="dropdown-menu-right" selections="options" placeholder="test placeholder"></div>', $scope);
+
+      var menu = element.find('.dropdown-menu.dropdown-menu-right');
+      expect(menu.length).toBe(1);
+    });
+  });
+});

--- a/test/card/basic/card.spec.js
+++ b/test/card/basic/card.spec.js
@@ -4,7 +4,8 @@ describe('Directive: pfCard', function() {
   beforeEach(module(
     'patternfly.card',
     'card/basic/card.html',
-    'card/basic/card-filter.html'
+    'card/basic/card-filter.html',
+    'bootstrap-select/bootstrap-select.html'
   ));
 
   beforeEach(inject(function(_$compile_, _$rootScope_) {

--- a/test/filters/filter.spec.js
+++ b/test/filters/filter.spec.js
@@ -6,7 +6,9 @@ describe('Directive:  pfFilter', function () {
 
   // load the controller's module
   beforeEach(function () {
-    module('patternfly.filters', 'patternfly.select', 'filters/filter.html', 'filters/filter-fields.html', 'filters/filter-results.html');
+    module('patternfly.filters',
+           'filters/filter.html', 'filters/filter-fields.html', 'filters/filter-results.html',
+           'bootstrap-select/bootstrap-select.html');
   });
 
   beforeEach(inject(function (_$compile_, _$rootScope_) {
@@ -101,10 +103,10 @@ describe('Directive:  pfFilter', function () {
     eventFire(fields[2], 'click');
     $scope.$digest();
     pfSelects = element.find('.filter-select');
-    expect(pfSelects.length).toBe(2); // 2 because it is a directive
+    expect(pfSelects.length).toBe(1);
 
     var items = pfSelects.find('li');
-    expect(items.length).toBe($scope.filterConfig.fields[2].filterValues.length + 1); // +1 for the null value
+    expect(items.length).toBe($scope.filterConfig.fields[2].filterValues.length);
   });
 
   it ('should enforce single selection for select dropdowns, accumative for others', function() {

--- a/test/form/datepicker/datepicker.directive.spec.js
+++ b/test/form/datepicker/datepicker.directive.spec.js
@@ -1,7 +1,7 @@
 describe('Directive: pfDatepicker', function() {
-  var $scope, $compile, $timeout, element, datepicker, dateInput;
+  var $scope, $compile, datepicker, dateInput;
 
-  beforeEach(module('patternfly.form', 'form/datepicker/datepicker.html'));
+  beforeEach(module('patternfly.jquery', 'form/datepicker/datepicker.html'));
 
   beforeEach(inject(function(_$compile_, _$rootScope_) {
     $compile = _$compile_;

--- a/test/select/select.spec.js
+++ b/test/select/select.spec.js
@@ -2,7 +2,7 @@ describe('pf-select', function () {
 
   var $scope, $compile;
 
-  beforeEach(module('patternfly.select'));
+  beforeEach(module('patternfly.jquery'));
 
   beforeEach(inject(function (_$rootScope_, _$compile_, _$timeout_) {
     $scope = _$rootScope_;

--- a/test/toolbars/toolbar.spec.js
+++ b/test/toolbars/toolbar.spec.js
@@ -7,9 +7,9 @@ describe('Directive:  pfToolbar', function () {
 
   // load the controller's module
   beforeEach(function () {
-    module('patternfly.toolbars', 'patternfly.views', 'patternfly.filters', 'patternfly.select', 'toolbars/toolbar.html',
+    module('patternfly.toolbars', 'patternfly.views', 'patternfly.filters', 'patternfly.jquery', 'toolbars/toolbar.html',
            'filters/filter.html', 'filters/filter-fields.html', 'filters/filter-results.html',
-           'sort/sort.html');
+           'sort/sort.html', 'bootstrap-select/bootstrap-select.html');
   });
 
   beforeEach(inject(function (_$compile_, _$rootScope_, pfViewUtils) {
@@ -183,10 +183,10 @@ describe('Directive:  pfToolbar', function () {
     eventFire(fields[2], 'click');
     $scope.$digest();
     pfSelects = element.find('.filter-select');
-    expect(pfSelects.length).toBe(2); // 2 because it is a directive
+    expect(pfSelects.length).toBe(1);
 
     var items = pfSelects.find('li');
-    expect(items.length).toBe($scope.config.filterConfig.fields[2].filterValues.length + 1); // +1 for the null value
+    expect(items.length).toBe($scope.config.filterConfig.fields[2].filterValues.length);
   });
 
   it ('should clear a filter when the close button is clicked', function () {


### PR DESCRIPTION
## Description

This PR removes the JQuery dependency from the default patternfly module. Two of the existing directives have been moved from the default module to patternfly.jquery: pfSelect and pfDatepicker. To use either of these directives add the patternfly.jquery module to your application module.

An additional directive, pfBootstrapSelect, has been added to achieve the same basic features of pfSelect but without the JQuery dependency.

The angular patternfly code has been adjusted to use the non-JQuery patternfly settings. To keep JQuery independence, include only patternfly-settings.js rather than patternfly.js.

@dtaylor113 @dgutride @dlabrecq @bleathem 