### PR TITLE
Require the child patternfly module instead of a sibling one

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,6 @@ require('angular-animate');
 require('angular-sanitize');
 require('angular-ui-bootstrap');
 require('lodash');
-require('../patternfly/dist/js/patternfly.min');
+require('patternfly/dist/js/patternfly.min');
 require('./dist/angular-patternfly');
 module.exports = 'angular-patternfly';


### PR DESCRIPTION
Fixes #340 

**ATTENTION: As per @dgutride suggestion, #337 should be merged before merging this PR**