### PR TITLE
Refactor unit tests to support breaking changes in UI Router 1.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -46,6 +46,6 @@
   },
   "devDependencies": {
     "angular-mocks": "1.3.0 - 1.5.*",
-    "angular-ui-router": "^0.3.2"
+    "angular-ui-router": "1.0.0-beta.3"
   }
 }

--- a/src/navigation/examples/vertical-navigation-router.js
+++ b/src/navigation/examples/vertical-navigation-router.js
@@ -23,6 +23,8 @@
  *   <li>.tooltip      - (string) Tooltip to display for the badge
  *   <li>.badgeClass:  - (string) Additional class(es) to add to the badge container
  *   </ul>
+ * <li>.uiSref         - (string) Optional Angular UI Router state name. If specified, href must be not defined, and vice versa.
+ * <li>.uiSrefOptions  - (object) Optional object to be passed to Angular UI Router $state.go() function
  * </ul>
  * @param {function} navigateCallback function(item) Callback method invoked on a navigation item click (one with no submenus)
  * @param {function} itemClickCallback function(item) Callback method invoked on an item click
@@ -121,7 +123,8 @@
             {
               title: "Dashboard",
               iconClass: "fa fa-dashboard",
-              uiSref: "dashboard"
+              uiSref: "dashboard",
+              uiSrefOptions: { someKey: 'SomeValue' }
             },
             {
               title: "Dolor",

--- a/test/navigation/vertical-navigation.spec.js
+++ b/test/navigation/vertical-navigation.spec.js
@@ -713,11 +713,13 @@ describe('Directive:  pfVerticalNavigation with ui.router', function () {
     $stateProvider.state('state0', {
       url: "/state0",
       controller: 'Controller0',
-      controllerAs: 'vm'
+      controllerAs: 'vm',
+      template: '<!-- -->'
     }).state('state1', {
       url: "/state1",
       controller: 'Controller1',
-      controllerAs: 'vm'
+      controllerAs: 'vm',
+      template: '<!-- -->'
     });
   });
 
@@ -756,7 +758,7 @@ describe('Directive:  pfVerticalNavigation with ui.router', function () {
         title: "Dashboard",
         iconClass: "fa fa-dashboard",
         uiSref: 'state1',
-        uiSrefOptions: 'testing'
+        uiSrefOptions: {name: "testing"}
       },
       {
         title: "Dolor",
@@ -806,7 +808,7 @@ describe('Directive:  pfVerticalNavigation with ui.router', function () {
     // Click dashboard item
     wellDefinedItem.click();
 
-    expect($state.go).toHaveBeenCalledWith('state1','testing');
+    expect($state.go).toHaveBeenCalledWith('state1',{name: "testing"});
 
     // Checking successful state transition
     expect($state.current.name).toBe("state1");


### PR DESCRIPTION
This is to make Angular UI router unit tests pass when using UI Router 1.0 (tested with 1.0.0-beta4). The directive itself was already good, only the unit tests needed a minor refactor.