### PR TITLE
Fix filter dropdowns for pf card directives

### DIFF
--- a/src/card/basic/card-filter.html
+++ b/src/card/basic/card-filter.html
@@ -1,11 +1,13 @@
-<button type="button" uib-dropdown-toggle class="btn btn-default">
-  {{currentFilter.label}}
-  <span class="caret"></span>
-</button>
-<ul uib-dropdown-menu class="dropdown-menu-right" role="menu">
-  <li ng-repeat="item in filter.filters" ng-class="{'selected': item === currentFilter}">
-    <a role="menuitem" tabindex="-1" ng-click="filterCallBackFn(item)">
-      {{item.label}}
-    </a>
-  </li>
-</ul>
+<div uib-dropdown class="card-pf-time-frame-filter">
+  <button type="button" uib-dropdown-toggle class="btn btn-default">
+    {{currentFilter.label}}
+    <span class="caret"></span>
+  </button>
+  <ul uib-dropdown-menu class="dropdown-menu-right" role="menu">
+    <li ng-repeat="item in filter.filters" ng-class="{'selected': item === currentFilter}">
+      <a role="menuitem" tabindex="-1" ng-click="filterCallBackFn(item)">
+        {{item.label}}
+      </a>
+    </li>
+  </ul>
+</div>

--- a/src/card/basic/card.html
+++ b/src/card/basic/card.html
@@ -1,8 +1,6 @@
 <div ng-class="showTopBorder === 'true' ? 'card-pf card-pf-accented' : 'card-pf'">
   <div ng-if="showHeader()" ng-class="shouldShowTitlesSeparator ? 'card-pf-heading' : 'card-pf-heading-no-bottom'">
-    <div ng-if="showFilterInHeader()" uib-dropdown class="card-pf-time-frame-filter">
-      <div ng-include="'card/basic/card-filter.html'"></div>
-    </div>
+    <div ng-if="showFilterInHeader()" ng-include="'card/basic/card-filter.html'"></div>
     <h2 class="card-pf-title">{{headTitle}}</h2>
   </div>
 
@@ -12,9 +10,7 @@
     <div ng-transclude></div>
   </div>
   <div ng-if="footer" class="card-pf-footer">
-    <div ng-if="showFilterInFooter()" uib-dropdown class="card-pf-time-frame-filter">
-      <div ng-include="'card/basic/card-filter.html'"></div>
-    </div>
+    <div ng-if="showFilterInFooter()" ng-include="'card/basic/card-filter.html'"></div>
     <p>
       <a ng-if="footer.href" href="{{footer.href}}" ng-class="{'card-pf-link-with-icon':footer.iconClass,'card-pf-link':!footer.iconClass}">
         <span ng-if="footer.iconClass" class="{{footer.iconClass}} card-pf-footer-text"></span>


### PR DESCRIPTION
Remove intermediate `div` used to `ng-include` the card filter partial.
The angular-ui-bootstrap dropdown directives require the `uib-dropdown`
directive to be a direct parent of the toggle and menu directives. This
change conditionally loads the card filter template without splitting
the `uib` dropdown directives.

Issue raised in https://github.com/patternfly/angular-patternfly/pull/353