### PR TITLE
Updated angular-patternfly to use lodash 4.x.   

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -134,7 +134,7 @@ module.exports = function (grunt) {
             'lib/angular-animate/angular-animate.js',
             'lib/angular-bootstrap/ui-bootstrap-tpls.js',
             'misc/angular-bootstrap-prettify.js',
-            'lib/lodash/lodash.min.js',
+            'lib/lodash/dist/lodash.min.js',
             'dist/angular-patternfly.js',
             'lib/angular-ui-router/release/angular-ui-router.min.js'],
           html5Mode: false,

--- a/bower.json
+++ b/bower.json
@@ -37,15 +37,15 @@
     "url": "git://github.com/patternfly/angular-patternfly.git"
   },
   "dependencies": {
-    "angular": "1.3.0 - 1.5.*",
-    "angular-animate": "1.3.0 - 1.5.*",
-    "angular-sanitize": "1.3.0 - 1.5.*",
+    "angular": "1.5.*",
+    "angular-animate": "1.5.*",
+    "angular-sanitize": "1.5.*",
     "angular-bootstrap": "0.14.x",
     "lodash": "4.x",
     "patternfly": "~3.15.0"
   },
   "devDependencies": {
-    "angular-mocks": "1.3.0 - 1.5.*",
+    "angular-mocks": "1.5.*",
     "angular-ui-router": "^0.3.2"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
     "angular-animate": "1.3.0 - 1.5.*",
     "angular-sanitize": "1.3.0 - 1.5.*",
     "angular-bootstrap": "0.14.x",
-    "lodash": "3.x",
+    "lodash": "4.x",
     "patternfly": "~3.15.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "main": "index.js",
   "homepage": "https://github.com/patternfly/angular-patternfly",
   "dependencies": {
-    "angular": "1.3.0 - 1.5.*",
-    "angular-animate": "1.3.0 - 1.5.*",
-    "angular-sanitize": "1.3.0 - 1.5.*",
+    "angular": "1.5.*",
+    "angular-animate": "1.5.*",
+    "angular-sanitize": "1.5.*",
     "angular-ui-bootstrap": "0.14.x",
     "lodash": "4.x",
     "patternfly": "~3.15.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "angular-animate": "1.3.0 - 1.5.*",
     "angular-sanitize": "1.3.0 - 1.5.*",
     "angular-ui-bootstrap": "0.14.x",
-    "lodash": "3.x",
+    "lodash": "4.x",
     "patternfly": "~3.15.0"
   },
   "devDependencies": {

--- a/src/filters/filter-directive.js
+++ b/src/filters/filter-directive.js
@@ -179,7 +179,7 @@ angular.module('patternfly.filters').directive('pfFilter', function () {
     templateUrl: 'filters/filter.html',
     controller: function ($scope) {
       $scope.filterExists = function (filter) {
-        var foundFilter = _.findWhere($scope.config.appliedFilters, {title: filter.title, value: filter.value});
+        var foundFilter = _.find($scope.config.appliedFilters, {title: filter.title, value: filter.value});
         return foundFilter !== undefined;
       };
 

--- a/src/toolbars/toolbar-directive.js
+++ b/src/toolbars/toolbar-directive.js
@@ -434,7 +434,7 @@ angular.module('patternfly.toolbars').directive('pfToolbar', function () {
       };
 
       $scope.filterExists = function (filter) {
-        var foundFilter = _.findWhere($scope.config.filterConfig.appliedFilters, {title: filter.title, value: filter.value});
+        var foundFilter = _.find($scope.config.filterConfig.appliedFilters, {title: filter.title, value: filter.value});
         return foundFilter !== undefined;
       };
 


### PR DESCRIPTION
`._findWhere` was depreciated, switched to use`_.find` with iteratee shorthand

Also dropped angular-patternfly support of angular 1.3.x dependencies.

Tested pfToolbar and pfFilter, and ran through most other ngdoc examples.
All unit tests passing

Fixes #346 