### PR TITLE
Remove config parameter from filter, sort, and toolbar components

### DIFF
--- a/src/filters/examples/filter.js
+++ b/src/filters/examples/filter.js
@@ -7,9 +7,7 @@
  *   Component for a filter bar
  *   <br><br>
  *
- * @param {object} config configuration settings for the filters:<br/>
- * <ul style='list-style-type: none'>
- * <li>.fields          - (Array) List of filterable fields containing:
+ * @param {array} fields List of filterable fields containing:
  * <ul style='list-style-type: none'>
  * <li>.id          - (String) Optional unique Id for the filter field, useful for comparisons
  * <li>.title       - (String) The title to display for the filter field
@@ -17,9 +15,9 @@
  * <li>.filterType  - (String) The filter input field type (any html input type, or 'select' for a single select box)
  * <li>.filterValues - (Array) List of valid select values used when filterType is 'select'
  * </ul>
- * <li>.appliedFilters - (Array) List of the currently applied filters
- * <li>.resultsCount   - (int) The number of results returned after the current applied filters have been applied
- * <li>.onFilterChange - ( function(array of filters) ) Function to call when the applied filters list changes
+ * @param {array} appliedFilters List of the currently applied filters
+ * @param {int} resultsCount The number of results returned after the current applied filters have been applied
+ * @param {function} onFilterChange function(array of filters) ) Function to call when the applied filters list changes
  * </ul>
  *
  * @example
@@ -27,7 +25,12 @@
   <file name="index.html">
     <div ng-controller="ViewCtrl" class="row example-container">
       <div class="col-md-12">
-        <pf-filter id="exampleFilter" config="filterConfig"></pf-filter>
+        <pf-filter id="exampleFilter"
+                   fields="fields"
+                   applied-filters="appliedFilters"
+                   results-count="{{resultsCount}}"
+                   on-filter-change="onFilterChange">
+        </pf-filter>
       </div>
       <hr class="col-md-12">
       <div class="col-md-12">
@@ -128,7 +131,7 @@
           } else {
             $scope.items = $scope.allItems;
           }
-          $scope.filterConfig.resultsCount = $scope.items.length;
+          $scope.resultsCount = $scope.items.length;
         };
 
         var filterChange = function (filters) {
@@ -139,32 +142,30 @@
           applyFilters(filters);
         };
 
-        $scope.filterConfig = {
-          fields: [
-            {
-              id: 'name',
-              title:  'Name',
-              placeholder: 'Filter by Name',
-              filterType: 'text'
-            },
-            {
-              id: 'address',
-              title:  'Address',
-              placeholder: 'Filter by Address',
-              filterType: 'text'
-            },
-            {
-              id: 'birthMonth',
-              title:  'Birth Month',
-              placeholder: 'Filter by Birth Month',
-              filterType: 'select',
-              filterValues: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
-            }
-          ],
-          resultsCount: $scope.items.length,
-          appliedFilters: [],
-          onFilterChange: filterChange
-        };
+        $scope.fields = [
+          {
+            id: 'name',
+            title:  'Name',
+            placeholder: 'Filter by Name',
+            filterType: 'text'
+          },
+          {
+            id: 'address',
+            title:  'Address',
+            placeholder: 'Filter by Address',
+            filterType: 'text'
+          },
+          {
+            id: 'birthMonth',
+            title:  'Birth Month',
+            placeholder: 'Filter by Birth Month',
+            filterType: 'select',
+            filterValues: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+          }
+        ];
+        $scope.resultsCount = $scope.items.length;
+        $scope.appliedFilters = [];
+        $scope.onFilterChange = filterChange;
       }
     ]);
   </file>

--- a/src/filters/filter-component.js
+++ b/src/filters/filter-component.js
@@ -1,6 +1,9 @@
 angular.module('patternfly.filters').component('pfFilter', {
   bindings: {
-    config: '='
+    fields: '=',
+    appliedFilters: '<',
+    resultsCount: '@',
+    onFilterChange: '<'
   },
   templateUrl: 'filters/filter.html',
   controller: function () {
@@ -10,20 +13,29 @@ angular.module('patternfly.filters').component('pfFilter', {
 
     ctrl.$onInit = function () {
 
+      if (angular.isUndefined(ctrl.appliedFilters)) {
+        ctrl.appliedFilters = [];
+      }
+
+      if (angular.isUndefined(ctrl.resultsCount)) {
+        ctrl.resultsCount = 0;
+      }
+
       angular.extend(ctrl,
         {
-          addFilter: addFilter
+          addFilter: addFilter,
+          resultsFilterChange: resultsFilterChange
         }
       );
     };
 
     function filterExists (filter) {
-      var foundFilter = _.find(ctrl.config.appliedFilters, {title: filter.title, value: filter.value});
+      var foundFilter = _.find(ctrl.appliedFilters, {title: filter.title, value: filter.value});
       return foundFilter !== undefined;
     }
 
     function enforceSingleSelect (filter) {
-      _.remove(ctrl.config.appliedFilters, {title: filter.title});
+      _.remove(ctrl.appliedFilters, {title: filter.title});
     }
 
     function addFilter (field, value) {
@@ -39,11 +51,18 @@ angular.module('patternfly.filters').component('pfFilter', {
           enforceSingleSelect(newFilter);
         }
 
-        ctrl.config.appliedFilters.push(newFilter);
+        ctrl.appliedFilters.push(newFilter);
 
-        if (ctrl.config.onFilterChange) {
-          ctrl.config.onFilterChange(ctrl.config.appliedFilters);
+        if (angular.isFunction(ctrl.onFilterChange)) {
+          ctrl.onFilterChange(ctrl.appliedFilters);
         }
+      }
+    }
+
+    function resultsFilterChange (filters) {
+      ctrl.appliedFilters = filters;
+      if (angular.isFunction(ctrl.onFilterChange)) {
+        ctrl.onFilterChange(ctrl.appliedFilters);
       }
     }
   }

--- a/src/filters/filter-fields-component.js
+++ b/src/filters/filter-fields-component.js
@@ -7,9 +7,7 @@
  *   Directive for the filter bar's filter entry components
  *   <br><br>
  *
- * @param {object} config configuration settings for the filters:<br/>
- * <ul style='list-style-type: none'>
- * <li>.fields          - (Array) List of filterable fields containing:
+ * @param {array} fields List of filterable fields containing:
  * <ul style='list-style-type: none'>
  * <li>.id          - (String) Optional unique Id for the filter field, useful for comparisons
  * <li>.title       - (String) The title to display for the filter field
@@ -17,65 +15,70 @@
  * <li>.filterType  - (String) The filter input field type (any html input type, or 'select' for a select box)
  * <li>.filterValues - (Array) List of valid select values used when filterType is 'select'
  * </ul>
- * <li>.appliedFilters - (Array) List of the currently applied filters
- * </ul>
+ * @param {string} currentFieldId Id of the field to show for filter entry
+ * @param {array} appliedFilters List of the currently applied filters
  *
  */
 angular.module('patternfly.filters').component('pfFilterFields', {
   bindings: {
-    config: '=',
+    fields: '<',
+    currentFieldId: '@',
+    appliedFilters: '<?',
     addFilterFn: '<'
   },
   templateUrl: 'filters/filter-fields.html',
-  controller: function ($scope) {
+  controller: function () {
     'use strict';
 
     var ctrl = this;
 
+    if (angular.isUndefined(ctrl.currentFieldId)) {
+      ctrl.currentFieldId = ctrl.fields[0].id;
+    }
+
+    if (angular.isUndefined(ctrl.appliedFilters)) {
+      ctrl.appliedFilters = [];
+    }
+
     ctrl.$onInit = function () {
       angular.extend(ctrl, {
+        currentField: getCurrentField (),
+        currentValue: null,
         selectField: selectField,
         selectValue: selectValue,
         onValueKeyPress: onValueKeyPress
       });
     };
 
-    ctrl.$postLink = function () {
-      $scope.$watch('config', function () {
-        setupConfig();
-      }, true);
-    };
+    function getCurrentField () {
+      var found = undefined;
+
+      angular.forEach(ctrl.fields, function (nextField) {
+        if (nextField.id === ctrl.currentFieldId) {
+          found = nextField;
+        }
+      });
+
+      return found;
+    }
 
     function selectField (item) {
       ctrl.currentField = item;
-      ctrl.config.currentValue = null;
+      ctrl.currentFieldId = item.id;
+      ctrl.currentValue = null;
     }
 
     function selectValue (filterValue) {
       if (angular.isDefined(filterValue)) {
-        ctrl.addFilterFn(scope.currentField, filterValue);
-        ctrl.config.currentValue = null;
+        ctrl.addFilterFn(ctrl.currentField, filterValue);
+        ctrl.currentValue = null;
       }
     }
 
     function onValueKeyPress (keyEvent) {
       if (keyEvent.which === 13) {
-        ctrl.addFilterFn(ctrl.currentField, ctrl.config.currentValue);
-        ctrl.config.currentValue = undefined;
-      }
-    }
-
-    function setupConfig () {
-      if (ctrl.fields === undefined) {
-        ctrl.fields = [];
-      }
-      if (!ctrl.currentField) {
-        ctrl.currentField = ctrl.config.fields[0];
-        ctrl.config.currentValue = null;
-      }
-
-      if (ctrl.config.currentValue === undefined) {
-        ctrl.config.currentValue = null;
+        ctrl.addFilterFn(ctrl.currentField, ctrl.currentValue);
+        ctrl.currentValue = null;
       }
     }
   }

--- a/src/filters/filter-fields.html
+++ b/src/filters/filter-fields.html
@@ -6,7 +6,7 @@
         <span class="caret"></span>
       </button>
       <ul uib-dropdown-menu>
-        <li ng-repeat="item in $ctrl.config.fields">
+        <li ng-repeat="item in $ctrl.fields">
           <a class="filter-field" role="menuitem" tabindex="-1" ng-click="$ctrl.selectField(item)">
             {{item.title}}
           </a>
@@ -14,14 +14,14 @@
       </ul>
     </div>
     <div ng-if="$ctrl.currentField.filterType !== 'select'">
-      <input class="form-control" type="{{$ctrl.currentField.filterType}}" ng-model="$ctrl.config.currentValue"
+      <input class="form-control" type="{{$ctrl.currentField.filterType}}" ng-model="$ctrl.currentValue"
              placeholder="{{$ctrl.currentField.placeholder}}"
              ng-keypress="$ctrl.onValueKeyPress($event)"/>
     </div>
     <div ng-if="$ctrl.currentField.filterType === 'select'">
       <div class="btn-group bootstrap-select form-control filter-select" uib-dropdown >
         <button type="button" uib-dropdown-toggle class="btn btn-default dropdown-toggle">
-          <span class="filter-option pull-left">{{$ctrl.config.currentValue || $ctrl.currentField.placeholder}}</span>
+          <span class="filter-option pull-left">{{$ctrl.currentValue || $ctrl.currentField.placeholder}}</span>
           <span class="caret"></span>
         </button>
         <ul uib-dropdown-menu class="dropdown-menu-right" role="menu">
@@ -30,7 +30,7 @@
               {{$ctrl.currentField.placeholder}}
             </a>
           </li>
-          <li ng-repeat="filterValue in $ctrl.currentField.filterValues" ng-class="{'selected': filterValue === $ctrl.config.currentValue}">
+          <li ng-repeat="filterValue in $ctrl.currentField.filterValues" ng-class="{'selected': filterValue === $ctrl.currentValue}">
             <a role="menuitem" tabindex="-1" ng-click="$ctrl.selectValue(filterValue)">
               {{filterValue}}
             </a>

--- a/src/filters/filter-results-component.js
+++ b/src/filters/filter-results-component.js
@@ -7,73 +7,58 @@
  *   Component for the filter results
  *   <br><br>
  *
- * @param {object} config configuration settings for the filter results:<br/>
+ * @param {Array} appliedFilters List of the currently applied filters
  * <ul style='list-style-type: none'>
- * <li>.fields          - (Array) List of filterable fields containing:
- * <ul style='list-style-type: none'>
- * <li>.id          - (String) Optional unique Id for the filter field, useful for comparisons
- * <li>.title       - (String) The title to display for the filter field
- * <li>.placeholder - (String) Text to display when no filter value has been entered
- * <li>.filterType  - (String) The filter input field type (any html input type, or 'select' for a select box)
- * <li>.filterValues - (Array) List of valid select values used when filterType is 'select'
+ * <li>.title - (String) The title to display for the filter field
+ * <li>.value - (String) value for the filter'
  * </ul>
- * <li>.appliedFilters - (Array) List of the currently applied filters
- * <li>.resultsCount   - (int) The number of results returned after the current applied filters have been applied
- * <li>.onFilterChange - ( function(array of filters) ) Function to call when the applied filters list changes
- * </ul>
+ * @param {int} resultsCount The number of results returned after the current applied filters have been applied
+ * @param {function} onFilterChange ( function(array of filters) ) Function to call when filters are removed
  *
  */
 angular.module('patternfly.filters').component('pfFilterResults', {
   bindings: {
-    config: '='
+    appliedFilters: '<?',
+    resultsCount: '@',
+    onFilterChange: '<?'
+
   },
   templateUrl: 'filters/filter-results.html',
-  controller: function ($scope) {
+  controller: function () {
     'use strict';
 
     var ctrl = this;
 
     ctrl.$onInit = function () {
+      if (!ctrl.appliedFilters) {
+        ctrl.appliedFilters = [];
+      }
+
       angular.extend(ctrl, {
         clearFilter: clearFilter,
         clearAllFilters: clearAllFilters
       });
     };
 
-    ctrl.$postLink = function () {
-      $scope.$watch('config', function () {
-        setupConfig();
-      }, true);
-    };
-
-    function setupConfig () {
-      if (!ctrl.config.appliedFilters) {
-        ctrl.config.appliedFilters = [];
-      }
-      if (ctrl.config.resultsCount === undefined) {
-        ctrl.config.resultsCount = 0;
-      }
-    }
-
     function clearFilter (item) {
       var newFilters = [];
-      ctrl.config.appliedFilters.forEach(function (filter) {
+      ctrl.appliedFilters.forEach(function (filter) {
         if (item.title !== filter.title || item.value !== filter.value) {
           newFilters.push(filter);
         }
       });
-      ctrl.config.appliedFilters = newFilters;
+      ctrl.appliedFilters = newFilters;
 
-      if (ctrl.config.onFilterChange) {
-        ctrl.config.onFilterChange(ctrl.config.appliedFilters);
+      if (angular.isFunction(ctrl.onFilterChange)) {
+        ctrl.onFilterChange(ctrl.appliedFilters);
       }
     }
 
     function clearAllFilters () {
-      ctrl.config.appliedFilters = [];
+      ctrl.appliedFilters = [];
 
-      if (ctrl.config.onFilterChange) {
-        ctrl.config.onFilterChange(ctrl.config.appliedFilters);
+      if (angular.isFunction(ctrl.onFilterChange)) {
+        ctrl.onFilterChange(ctrl.appliedFilters);
       }
     }
   }

--- a/src/filters/filter-results.html
+++ b/src/filters/filter-results.html
@@ -1,17 +1,17 @@
 <div class="filter-pf">
   <div class="row toolbar-pf-results">
     <div class="col-sm-12">
-      <h5>{{$ctrl.config.resultsCount}} Results</h5>
-      <p ng-if="$ctrl.config.appliedFilters.length > 0">Active filters:</p>
+      <h5 ng-if="$ctrl.resultsCount !== undefined">{{$ctrl.resultsCount}} Results</h5>
+      <p ng-if="$ctrl.appliedFilters.length > 0">Active filters:</p>
       <ul class="list-inline">
-        <li ng-repeat="filter in $ctrl.config.appliedFilters">
+        <li ng-repeat="filter in $ctrl.appliedFilters">
           <span class="active-filter label label-info">
             {{filter.title}}: {{filter.value}}
             <a><span class="pficon pficon-close" ng-click="$ctrl.clearFilter(filter)"></span></a>
           </span>
         </li>
       </ul>
-      <p><a class="clear-filters" ng-click="$ctrl.clearAllFilters()" ng-if="$ctrl.config.appliedFilters.length > 0">Clear All Filters</a></p>
+      <p><a class="clear-filters" ng-click="$ctrl.clearAllFilters()" ng-if="$ctrl.appliedFilters.length > 0">Clear All Filters</a></p>
     </div><!-- /col -->
   </div><!-- /row -->
 </div>

--- a/src/filters/filter.html
+++ b/src/filters/filter.html
@@ -1,4 +1,4 @@
 <div class="filter-pf">
-  <pf-filter-fields config="$ctrl.config" add-filter-fn="$ctrl.addFilter"></pf-filter-fields>
-  <pf-filter-results config="$ctrl.config"></pf-filter-results>
+  <pf-filter-fields fields="$ctrl.fields" add-filter-fn="$ctrl.addFilter"></pf-filter-fields>
+  <pf-filter-results applied-filters="$ctrl.appliedFilters" results-count="{{$ctrl.resultsCount}}" on-filter-change="$ctrl.resultsFilterChange"></pf-filter-results>
 </div>

--- a/src/sort/examples/sort.js
+++ b/src/sort/examples/sort.js
@@ -7,25 +7,22 @@
  *   Sort component
  *   <br><br>
  *
- * @param {object} config configuration settings for the sort:<br/>
- * <ul style='list-style-type: none'>
- * <li>.fields          - (Array) List of sortable fields containing:
+ * @param {array} fields List of sortable fields containing:<br/>
  * <ul style='list-style-type: none'>
  * <li>.id          - (String) Unique Id for the sort field
  * <li>.title       - (String) The title to display for the sort field
  * <li>.sortType    - (String) The sort type, 'alpha' or 'numeric'
  * </ul>
- * <li>.currentField   - (Object) Currently selected field
- * <li>.isAscending - (boolean) Current sort direction is ascending. True for ascending, False for descending
- * <li>.onSortChange - ( function(sortId, sortDirection ) Function to call when the current sort params change
- * </ul>
+ * @param {String} currentField - Id of the currently selected field
+ * @param {boolean} isAscending - Current sort direction is ascending. True for ascending, False for descending
+ * @param {function} onSortChange - ( function(sortId, sortDirection ) Function to call when the current sort params change
  *
  * @example
 <example module="patternfly.sort">
   <file name="index.html">
     <div ng-controller="ViewCtrl" class="row example-container">
       <div class="col-md-12">
-        <pf-sort id="exampleSort" config="sortConfig"></pf-sort>
+        <pf-sort id="exampleSort" fields="sortFields" on-sort-change="sortChange"></pf-sort>
       </div>
       <hr class="col-md-12">
       <div class="col-md-12">
@@ -100,47 +97,47 @@
           }
         ];
 
-        var compareFn = function(item1, item2) {
-          var compValue = 0;
-          if ($scope.sortConfig.currentField.id === 'name') {
-            compValue = item1.name.localeCompare(item2.name);
-          } else if ($scope.sortConfig.currentField.id === 'count') {
-              compValue = item1.count - item2.count;
-          } else if ($scope.sortConfig.currentField.id === 'description') {
-            compValue = item1.description.localeCompare(item2.description);
-          }
+        $scope.sortChange = function (sortId, isAscending) {
 
-          if (!$scope.sortConfig.isAscending) {
-            compValue = compValue * -1;
-          }
-
-          return compValue;
-        };
-
-        var sortChange = function (sortId, isAscending) {
           $scope.items.sort(compareFn);
+
+          function compareFn (item1, item2) {
+            var compValue = 0;
+            if (sortId === 'name') {
+              compValue = item1.name.localeCompare(item2.name);
+            } else if (sortId === 'count') {
+                compValue = item1.count - item2.count;
+            } else if (sortId === 'description') {
+              compValue = item1.description.localeCompare(item2.description);
+            }
+
+            if (!isAscending) {
+              compValue = compValue * -1;
+            }
+
+            return compValue;
+          };
         };
 
-        $scope.sortConfig = {
-          fields: [
-            {
-              id: 'name',
-              title:  'Name',
-              sortType: 'alpha'
-            },
-            {
-              id: 'count',
-              title:  'Count',
-              sortType: 'numeric'
-            },
-            {
-              id: 'description',
-              title:  'Description',
-              sortType: 'alpha'
-            }
-          ],
-          onSortChange: sortChange
-        };
+        $scope.sortFields = [
+          {
+            id: 'name',
+            title:  'Name',
+            sortType: 'alpha'
+          },
+          {
+            id: 'count',
+            title:  'Count',
+            sortType: 'numeric'
+          },
+          {
+            id: 'description',
+            title:  'Description',
+            sortType: 'alpha'
+          }
+        ];
+
+        $scope.sortChange('name', true);
       }
     ]);
   </file>

--- a/src/sort/sort-component.js
+++ b/src/sort/sort-component.js
@@ -1,80 +1,77 @@
 angular.module('patternfly.sort').component('pfSort', {
   bindings: {
-    config: '='
+    fields: '=',
+    currentSortId: '<?',
+    isAscending: '<?',
+    onSortChange: '<?'
+
   },
   templateUrl: 'sort/sort.html',
-  controller: function ($scope) {
+  controller: function ($timeout) {
     'use strict';
 
     var ctrl = this;
 
     ctrl.$onInit = function () {
+
+      if (angular.isUndefined(ctrl.currentSortId)) {
+        ctrl.currentSortId = ctrl.fields[0].id;
+      }
+
+      if (angular.isUndefined(ctrl.isAscending)) {
+        ctrl.isAscending = true;
+      }
+
       angular.extend(ctrl, {
+        currentField: getCurrentField(),
         selectField: selectField,
         changeDirection: changeDirection,
         getSortIconClass: getSortIconClass
       });
-
-      setupConfig();
-
     };
 
-    ctrl.$postLink = function () {
-      $scope.$watch('config', function () {
-        setupConfig();
-      }, true);
-    };
+    function getCurrentField () {
+      var found = undefined;
 
-    function setupConfig () {
-      var updated = false;
-
-      if (ctrl.config.fields === undefined) {
-        ctrl.config.fields = [];
-      }
-
-      if (ctrl.config.fields.length > 0) {
-        if (ctrl.config.currentField === undefined) {
-          ctrl.config.currentField = ctrl.config.fields[0];
-          updated = true;
+      angular.forEach(ctrl.fields, function (nextField) {
+        if (nextField.id === ctrl.currentSortId) {
+          found = nextField;
         }
-        if (ctrl.config.isAscending === undefined) {
-          ctrl.config.isAscending = true;
-          updated = true;
-        }
-      }
+      });
 
-      if (updated === true && ctrl.config.onSortChange) {
-        ctrl.config.onSortChange(ctrl.config.currentField, ctrl.config.isAscending);
+      return found;
+    }
+
+    function notifySortChange () {
+      if (angular.isFunction(ctrl.onSortChange)) {
+        ctrl.onSortChange(ctrl.currentSortId, ctrl.isAscending);
       }
     }
 
     function selectField (field) {
-      ctrl.config.currentField = field;
+      ctrl.currentField = field;
+      ctrl.currentSortId = field.id;
 
-      if (ctrl.config.onSortChange) {
-        ctrl.config.onSortChange(ctrl.config.currentField, ctrl.config.isAscending);
-      }
+      notifySortChange();
     }
 
     function changeDirection () {
-      ctrl.config.isAscending = !ctrl.config.isAscending;
+      ctrl.isAscending = !ctrl.isAscending;
 
-      if (ctrl.config.onSortChange) {
-        ctrl.config.onSortChange(ctrl.config.currentField, ctrl.config.isAscending);
-      }
+      notifySortChange();
     }
 
     function getSortIconClass () {
       var iconClass;
 
-      if (ctrl.config.currentField.sortType === 'numeric') {
-        if (ctrl.config.isAscending) {
+      if (ctrl.currentField.sortType === 'numeric') {
+        if (ctrl.isAscending) {
           iconClass = 'fa fa-sort-numeric-asc';
         } else {
           iconClass = 'fa fa-sort-numeric-desc';
         }
       } else {
-        if (ctrl.config.isAscending) {
+        if (ctrl.isAscending) {
           iconClass = 'fa fa-sort-alpha-asc';
         } else {
           iconClass = 'fa fa-sort-alpha-desc';

--- a/src/sort/sort.html
+++ b/src/sort/sort.html
@@ -1,11 +1,11 @@
 <div class="sort-pf">
   <div uib-dropdown class="btn-group">
     <button uib-dropdown-toggle type="button" class="btn btn-default">
-      {{$ctrl.config.currentField.title}}
+      {{$ctrl.currentField.title}}
       <span class="caret"></span>
     </button>
     <ul uib-dropdown-menu>
-      <li ng-repeat="item in $ctrl.config.fields" ng-class="{'selected': item === $ctrl.config.currentField}">
+      <li ng-repeat="item in $ctrl.fields" ng-class="{'selected': item === $ctrl.currentField}">
         <a href="javascript:void(0);" class="sort-field" role="menuitem" tabindex="-1" ng-click="$ctrl.selectField(item)">
           {{item.title}}
         </a>

--- a/src/toolbars/examples/toolbar.js
+++ b/src/toolbars/examples/toolbar.js
@@ -4,53 +4,74 @@
  * @restrict E
  *
  * @description
- *   Standard toolbar component. Includes filtering and view selection capabilities
+ *   Standard toolbar component. Includes filtering, sorting, actions, and view selection capabilities
  *   <br><br>
  *
- * @param {object} config configuration settings for the toolbar:<br/>
- *   <ul style='list-style-type: none'>
- *     <li>.filterConfig  - (Object) Optional filter config. If undefined, no filtering capabilities are shown.
- *                          See pfSimpleFilter for filter config options.
- *     <li>.sortConfig  - (Object) Optional sort config. If undefined, no sort capabilities are shown.
- *                          See pfSort for sort config options.
- *     <li>.viewsConfig  - (Object) Optional configuration settings for view type selection
- *       <ul style='list-style-type: none'>
- *         <li>.views       - (Array) List of available views for selection. See pfViewUtils for standard available views
- *           <ul style='list-style-type: none'>
- *             <li>.id - (String) Unique id for the view, used for comparisons
- *             <li>.title - (String) Optional title, uses as a tooltip for the view selector
- *             <li>.iconClass - (String) Icon class to use for the view selector
- *           </ul>
- *         <li>.onViewSelect - ( function(view) ) Function to call when a view is selected
- *         <li>.currentView - the id of the currently selected view
- *       </ul>
- *     <li>.actionsConfig  - (Object) Optional configuration settings for toolbar actions
- *       <ul style='list-style-type: none'>
- *         <li>.primaryActions  - (Array) List of primary actions to display on the toolbar
- *           <ul style='list-style-type: none'>
- *             <li>.name - (String) The name of the action, displayed on the button
- *             <li>.title - (String) Optional title, used for the tooltip
- *             <li>.actionFn - (function(action)) Function to invoke when the action selected
- *             <li>.isDisabled - (Boolean) set to true to disable the action
- *           </ul>
- *         <li>.moreActions  - (Array) List of secondary actions to display on the toolbar action pulldown menu
- *           <ul style='list-style-type: none'>
- *             <li>.name - (String) The name of the action, displayed on the button
- *             <li>.title - (String) Optional title, used for the tooltip
- *             <li>.actionFn - (function(action)) Function to invoke when the action selected
- *             <li>.isDisabled - (Boolean) set to true to disable the action
- *             <li>.isSeparator - (Boolean) set to true if this is a placehodler for a separator rather than an action
- *           </ul>
- *         <li>.actionsInclude  - (Boolean) set to true if using the actions transclude to add custom action buttons (only available if using Angular 1.5 or later)
- *       </ul>
- *   </ul>
+ * @param {array} filterFields List of filterable fields containing:
+ * <ul style='list-style-type: none'>
+ * <li>.id          - (String) Optional unique Id for the filter field, useful for comparisons
+ * <li>.title       - (String) The title to display for the filter field
+ * <li>.placeholder - (String) Text to display when no filter value has been entered
+ * <li>.filterType  - (String) The filter input field type (any html input type, or 'select' for a single select box)
+ * <li>.filterValues - (Array) List of valid select values used when filterType is 'select'
+ * </ul>
+ * @param {array} appliedFilters List of the currently applied filters
+ * @param {int} resultsCount The number of results returned after the current applied filters have been applied
+ * @param {function} onFilterChange function(array of filters) ) Function to call when the applied filters list changes
+ * @param {array} sortFields List of sortable fields containing:<br/>
+ * <ul style='list-style-type: none'>
+ * <li>.id          - (String) Unique Id for the sort field
+ * <li>.title       - (String) The title to display for the sort field
+ * <li>.sortType    - (String) The sort type, 'alpha' or 'numeric'
+ * </ul>
+ * @param {String} currentSortField - Id of the currently selected field
+ * @param {boolean} isSortAscending - Current sort direction is ascending. True for ascending, False for descending
+ * @param {function} onSortChange - ( function(sortId, sortDirection ) Function to call when the current sort params change
+ * @param {array} views List of available views for selection. See pfViewUtils for standard available views
+ * <ul style='list-style-type: none'>
+ *   <li>.id - (String) Unique id for the view, used for comparisons
+ *   <li>.title - (String) Optional title, uses as a tooltip for the view selector
+ *   <li>.iconClass - (String) Icon class to use for the view selector
+ * </ul>
+ * @param {string} currentView - the id of the currently selected view
+ * @param {function} onViewSelect  function(view) ) Function to call when a view is selected
+ * @param {array} primaryActions List of primary actions to display on the toolbar
+ * <ul style='list-style-type: none'>
+ *   <li>.name - (String) The name of the action, displayed on the button
+ *   <li>.title - (String) Optional title, used for the tooltip
+ *   <li>.actionFn - (function(action)) Function to invoke when the action selected
+ *   <li>.isDisabled - (Boolean) set to true to disable the action
+ * </ul>
+ * @param {array} moreActions List of secondary actions to display on the toolbar action pulldown menu
+ * <ul style='list-style-type: none'>
+ *   <li>.name - (String) The name of the action, displayed on the button
+ *   <li>.title - (String) Optional title, used for the tooltip
+ *   <li>.actionFn - (function(action)) Function to invoke when the action selected
+ *   <li>.isDisabled - (Boolean) set to true to disable the action
+ *   <li>.isSeparator - (Boolean) set to true if this is a placehodler for a separator rather than an action
+ * </ul>
+ * @param {boolean} actionsInclude  set to true if using the actions transclude to add custom action buttons (only available if using Angular 1.5 or later)
  *
  * @example
 <example module="patternfly.toolbars">
   <file name="index.html">
     <div ng-controller="ViewCtrl" class="row example-container">
       <div class="col-md-12">
-        <pf-toolbar id="exampleToolbar" config="toolbarConfig">
+        <pf-toolbar id="exampleToolbar"
+                    filter-fields="filterFields"
+                    applied-filters="appliedFilters"
+                    results-count="{{resultsCount}}"
+                    on-filter-change="onFilterChange"
+                    sort-fields="sortFields"
+                    current-sort-field="currentSortId"
+                    is-sort-ascending="sortAscending"
+                    on-sort-change="onSortChange"
+                    views="views"
+                    current-view="currentView"
+                    on-view-select="onViewSelect"
+                    primary-actions="primaryActions"
+                    more-actions="moreActions"
+                    actions-include="actionsInclude">
          <actions>
            <span class="dropdown primary-action" uib-dropdown>
              <button class="btn btn-default dropdown-toggle" uib-dropdown-toggle type="button">
@@ -83,7 +104,7 @@
       <div class="col-md-12">
         <label class="events-label">Valid Items: </label>
       </div>
-      <div class="col-md-12 list-view-container" ng-if="viewType == 'listView'">
+      <div class="col-md-12 list-view-container" ng-if="currentView == 'listView'">
         <pf-list-view config="listConfig" items="items">
           <div class="list-view-pf-description">
             <div class="list-group-item-heading">
@@ -103,7 +124,7 @@
           </div>
         </pf-list-view>
       </div>
-      <div class="col-md-12 card-view-container" ng-if="viewType == 'cardView'">
+      <div class="col-md-12 card-view-container" ng-if="currentView == 'cardView'">
         <pf-card-view config="vm.listConfig" items="items">
           <div class="col-md-12">
             <span>{{item.name}}</span>
@@ -134,41 +155,27 @@
   <file name="script.js">
   angular.module('patternfly.toolbars').controller('ViewCtrl', ['$scope', 'pfViewUtils',
     function ($scope, pfViewUtils) {
-      $scope.filtersText = '';
 
-      $scope.allItems = [
-        {
-          name: "Fred Flintstone",
-          age: 57,
-          address: "20 Dinosaur Way, Bedrock, Washingstone",
-          birthMonth: 'February'
-        },
-        {
-          name: "John Smith",
-          age: 23,
-          address: "415 East Main Street, Norfolk, Virginia",
-          birthMonth: 'October'
-        },
-        {
-          name: "Frank Livingston",
-          age: 71,
-          address: "234 Elm Street, Pittsburgh, Pennsylvania",
-          birthMonth: 'March'
-        },
-        {
-          name: "Judy Green",
-          age: 21,
-          address: "2 Apple Boulevard, Cincinatti, Ohio",
-          birthMonth: 'December'
-        },
-        {
-          name: "Pat Thomas",
-          age: 19,
-          address: "50 Second Street, New York, New York",
-          birthMonth: 'February'
-        }
-      ];
-      $scope.items = $scope.allItems;
+      angular.extend($scope, {
+        filtersText: '',
+        filterFields: getFilterFields(),
+        appliedFilters: [],
+        resultsCount: 0,
+        onFilterChange: onFilterChange,
+        sortFields: getSortFields(),
+        currentSortId: 'name',
+        isAscending: true,
+        onSortChange: onSortChange,
+        views: getViews(),
+        currentView: pfViewUtils.getListView().id,
+        onViewSelect: onViewSelect,
+        primaryActions: getPrimaryActions(),
+        moreActions: getMoreActions(),
+        actionsInclude: true,
+      });
+      $scope.currentSortId = $scope.sortFields[0].id;
+
+      initializeListItems();
 
       var matchesFilter = function (item, filter) {
         var match = true;
@@ -197,7 +204,7 @@
         return matches;
       };
 
-      var applyFilters = function (filters) {
+      function applyFilters (filters) {
         $scope.items = [];
         if (filters && filters.length > 0) {
           $scope.allItems.forEach(function (item) {
@@ -208,19 +215,26 @@
         } else {
           $scope.items = $scope.allItems;
         }
-      };
+      }
 
-      var filterChange = function (filters) {
-      $scope.filtersText = "";
-        filters.forEach(function (filter) {
+      function applyCurrentFilters () {
+        $scope.filtersText = "";
+        $scope.appliedFilters.forEach(function (filter) {
           $scope.filtersText += filter.title + " : " + filter.value + "\n";
         });
-        applyFilters(filters);
-        $scope.toolbarConfig.filterConfig.resultsCount = $scope.items.length;
-      };
 
-      $scope.filterConfig = {
-        fields: [
+        applyFilters($scope.appliedFilters);
+
+        $scope.resultsCount = $scope.items.length;
+      }
+
+      function onFilterChange (filters) {
+        $scope.appliedFilters = filters;
+        applyCurrentFilters();
+      }
+
+      function getFilterFields () {
+        return [
           {
             id: 'name',
             title:  'Name',
@@ -246,22 +260,8 @@
             filterType: 'select',
             filterValues: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
           }
-        ],
-        resultsCount: $scope.items.length,
-        appliedFilters: [],
-        onFilterChange: filterChange
-      };
-
-      var viewSelected = function(viewId) {
-        $scope.viewType = viewId
-      };
-
-      $scope.viewsConfig = {
-        views: [pfViewUtils.getListView(), pfViewUtils.getCardView()],
-        onViewSelect: viewSelected
-      };
-      $scope.viewsConfig.currentView = $scope.viewsConfig.views[0].id;
-      $scope.viewType = $scope.viewsConfig.currentView;
+        ];
+      }
 
       var monthVals = {
         'January': 1,
@@ -279,29 +279,32 @@
       };
       var compareFn = function(item1, item2) {
         var compValue = 0;
-        if ($scope.sortConfig.currentField.id === 'name') {
+        if ($scope.currentSortId === 'name') {
           compValue = item1.name.localeCompare(item2.name);
-        } else if ($scope.sortConfig.currentField.id === 'age') {
+        } else if ($scope.currentSortId === 'age') {
             compValue = item1.age - item2.age;
-        } else if ($scope.sortConfig.currentField.id === 'address') {
+        } else if ($scope.currentSortId === 'address') {
           compValue = item1.address.localeCompare(item2.address);
-        } else if ($scope.sortConfig.currentField.id === 'birthMonth') {
+        } else if ($scope.currentSortId === 'birthMonth') {
           compValue = monthVals[item1.birthMonth] - monthVals[item2.birthMonth];
         }
 
-        if (!$scope.sortConfig.isAscending) {
+        if (!$scope.isAscending) {
           compValue = compValue * -1;
         }
 
         return compValue;
       };
 
-      var sortChange = function (sortId, isAscending) {
+      function onSortChange (sortId, isAscending) {
+      console.log("Sort: " + sortId + " ascending: " + isAscending);
+        $scope.currentSortId = sortId;
+        $scope.isAscending = isAscending;
         $scope.items.sort(compareFn);
-      };
+      }
 
-      $scope.sortConfig = {
-        fields: [
+      function getSortFields () {
+        return [
           {
             id: 'name',
             title:  'Name',
@@ -322,17 +325,24 @@
             title:  'Birth Month',
             sortType: 'alpha'
           }
-        ],
-        onSortChange: sortChange
+        ];
+      }
+
+      function onViewSelect (viewId) {
+        $scope.currentView = viewId
+      }
+
+      function getViews () {
+        return [pfViewUtils.getListView(), pfViewUtils.getCardView()];
       };
 
       $scope.actionsText = "";
-      var performAction = function (action) {
+      function performAction (action) {
         $scope.actionsText = action.name + "\n" + $scope.actionsText;
       };
 
-      $scope.actionsConfig = {
-        primaryActions: [
+      function getPrimaryActions () {
+        return [
           {
             name: 'Action 1',
             title: 'Do the first thing',
@@ -343,8 +353,11 @@
             title: 'Do something else',
             actionFn: performAction
           }
-        ],
-        moreActions: [
+        ];
+      }
+
+      function getMoreActions () {
+        return [
           {
             name: 'Action',
             title: 'Perform an action',
@@ -379,21 +392,53 @@
             title: 'Do something similar',
             actionFn: performAction
           }
-        ],
-        actionsInclude: true
-      };
+        ];
+      }
 
-      $scope.toolbarConfig = {
-        viewsConfig: $scope.viewsConfig,
-        filterConfig: $scope.filterConfig,
-        sortConfig: $scope.sortConfig,
-        actionsConfig: $scope.actionsConfig
-      };
+      function initializeListItems () {
+        $scope.listConfig = {
+          selectionMatchProp: 'name',
+          checkDisabled: false
+        };
+        $scope.allItems = getAllItems();
 
-      $scope.listConfig = {
-        selectionMatchProp: 'name',
-        checkDisabled: false
-      };
+        applyCurrentFilters();
+      }
+
+      function getAllItems () {
+        return [
+          {
+            name: "Fred Flintstone",
+            age: 57,
+            address: "20 Dinosaur Way, Bedrock, Washingstone",
+            birthMonth: 'February'
+          },
+          {
+            name: "John Smith",
+            age: 23,
+            address: "415 East Main Street, Norfolk, Virginia",
+            birthMonth: 'October'
+          },
+          {
+            name: "Frank Livingston",
+            age: 71,
+            address: "234 Elm Street, Pittsburgh, Pennsylvania",
+            birthMonth: 'March'
+          },
+          {
+            name: "Judy Green",
+            age: 21,
+            address: "2 Apple Boulevard, Cincinatti, Ohio",
+            birthMonth: 'December'
+          },
+          {
+            name: "Pat Thomas",
+            age: 19,
+            address: "50 Second Street, New York, New York",
+            birthMonth: 'February'
+          }
+        ];
+       };
 
       $scope.doAdd = function () {
         $scope.actionsText = "Add Action\n" + $scope.actionsText;

--- a/src/toolbars/toolbar.html
+++ b/src/toolbars/toolbar.html
@@ -1,31 +1,36 @@
 <div class="container-fluid">
   <div class="row toolbar-pf">
     <div class="col-sm-12">
-      <form class="toolbar-pf-actions" ng-class="{'no-filter-results': !$ctrl.config.filterConfig}">
+      <form class="toolbar-pf-actions" ng-class="{'no-filter-results': !ctrl.showFilters}">
         <div class="form-group toolbar-apf-filter">
-          <pf-filter-fields config="$ctrl.config.filterConfig" ng-if="$ctrl.config.filterConfig" add-filter-fn="$ctrl.addFilter"></pf-filter-fields>
+          <pf-filter-fields ng-if="$ctrl.showFilters"
+                            fields="$ctrl.filterFields"
+                            add-filter-fn="$ctrl.addFilter">
+          </pf-filter-fields>
         </div>
         <div class="form-group">
-          <pf-sort config="$ctrl.config.sortConfig" ng-if="$ctrl.config.sortConfig"></pf-sort>
+          <pf-sort ng-if="$ctrl.showSort"
+                   fields="$ctrl.sortFields"
+                   current-sort-id="$ctrl.currentSortField"
+                   is-ascending="$ctrl.isSortAscending"
+                   on-sort-change="$ctrl.onSortChange">
+          </pf-sort>
         </div>
         <div class="form-group toolbar-actions"
-             ng-if="$ctrl.config.actionsConfig &&
-                   (($ctrl.config.actionsConfig.primaryActions && $ctrl.config.actionsConfig.primaryActions.length > 0) ||
-                    ($ctrl.config.actionsConfig.moreActions && $ctrl.config.actionsConfig.moreActions.length > 0) ||
-                    $ctrl.config.actionsConfig.actionsInclude)">
-          <button class="btn btn-default primary-action" type="button" ng-repeat="action in $ctrl.config.actionsConfig.primaryActions"
+             ng-if="$ctrl.showPrimaryActions || $ctrl.showMoreActions || $ctrl.actionsInclude">
+          <button class="btn btn-default primary-action" type="button" ng-repeat="action in $ctrl.primaryActions"
                   title="{{action.title}}"
                   ng-click="$ctrl.handleAction(action)"
                   ng-disabled="action.isDisabled === true">
             {{action.name}}
           </button>
-          <div ng-if="$ctrl.config.actionsConfig.actionsInclude" pf-transclude class="toolbar-pf-include-actions" ng-tranclude="actions"></div>
-          <div uib-dropdown class="dropdown-kebab-pf" ng-if="$ctrl.config.actionsConfig.moreActions && $ctrl.config.actionsConfig.moreActions.length > 0">
+          <div ng-if="$ctrl.actionsInclude" pf-transclude class="toolbar-pf-include-actions" ng-tranclude="actions"></div>
+          <div uib-dropdown class="dropdown-kebab-pf" ng-if="$ctrl.showMoreActions">
             <button uib-dropdown-toggle class="btn btn-link" type="button">
               <span class="fa fa-ellipsis-v"></span>
             </button>
             <ul uib-dropdown-menu aria-labelledby="dropdownKebab">
-              <li ng-repeat="action in $ctrl.config.actionsConfig.moreActions"
+              <li ng-repeat="action in $ctrl.moreActions"
                   role="{{action.isSeparator === true ? 'separator' : 'menuitem'}}"
                   ng-class="{'divider': action.isSeparator === true, 'disabled': action.isDisabled === true}">
                 <a ng-if="action.isSeparator !== true"
@@ -39,16 +44,19 @@
           </div>
         </div>
         <div class="toolbar-pf-action-right">
-          <div class="form-group toolbar-pf-view-selector" ng-if="$ctrl.config.viewsConfig && $ctrl.config.viewsConfig.views">
-            <button ng-repeat="view in $ctrl.config.viewsConfig.viewsList" class="btn btn-link"
-                    ng-class="{'active': $ctrl.isViewSelected(view.id), 'disabled': $ctrl.checkViewDisabled(view)}"
+          <div class="form-group toolbar-pf-view-selector" ng-if="$ctrl.showViews">
+            <button ng-repeat="view in $ctrl.views" class="btn btn-link"
+                    ng-class="{'active': $ctrl.isViewSelected(view.id), 'disabled': $ctrl.isViewDisabled(view)}"
                     title={{view.title}}  ng-click="$ctrl.viewSelected(view.id)">
               <i class="{{view.iconClass}}"></i>
             </button>
           </div>
         </div>
       </form>
-      <pf-filter-results config="$ctrl.config.filterConfig" ng-if="$ctrl.config.filterConfig"></pf-filter-results>
+      <pf-filter-results ng-if="$ctrl.showFilters"
+                         applied-filters="$ctrl.appliedFilters"
+                         results-count="{{$ctrl.resultsCount}}"
+                         on-filter-change="$ctrl.onFilterChange"></pf-filter-results>
     </div>
   </div>
 </div>

--- a/test/filters/filter.spec.js
+++ b/test/filters/filter.spec.js
@@ -21,33 +21,31 @@ describe('Directive:  pfFilter', function () {
   };
 
   beforeEach(function () {
-    $scope.filterConfig = {
-      fields: [
-        {
-          id: 'name',
-          title:  'Name',
-          placeholder: 'Filter by Name',
-          filterType: 'text'
-        },
-        {
-          id: 'address',
-          title:  'Address',
-          placeholder: 'Filter by Address',
-          filterType: 'text'
-        },
-        {
-          id: 'birthMonth',
-          title:  'Birth Month',
-          placeholder: 'Filter by Birth Month',
-          filterType: 'select',
-          filterValues: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
-        }
-      ],
-      resultsCount: 5,
-      appliedFilters: []
-    };
+    $scope.fields = [
+      {
+        id: 'name',
+        title:  'Name',
+        placeholder: 'Filter by Name',
+        filterType: 'text'
+      },
+      {
+        id: 'address',
+        title:  'Address',
+        placeholder: 'Filter by Address',
+        filterType: 'text'
+      },
+      {
+        id: 'birthMonth',
+        title:  'Birth Month',
+        placeholder: 'Filter by Birth Month',
+        filterType: 'select',
+        filterValues: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+      }
+    ];
+    $scope.resultsCount = 5;
+    $scope.appliedFilters = [];
 
-    var htmlTmp = '<pf-filter config="filterConfig"></pf-filter>';
+    var htmlTmp = '<pf-filter fields="fields" results-count="{{resultsCount}}" applied-filters="appliedFilters" ></pf-filter>';
 
     compileHTML(htmlTmp, $scope);
   });
@@ -62,7 +60,7 @@ describe('Directive:  pfFilter', function () {
     expect(results.length).toBe(1);
     expect(results.html()).toBe("5 Results");
 
-    $scope.filterConfig.resultsCount = 10;
+    $scope.resultsCount = 10;
 
     $scope.$digest();
 
@@ -76,7 +74,7 @@ describe('Directive:  pfFilter', function () {
     expect(activeFilters.length).toBe(0);
     expect(element.find('.clear-filters').length).toBe(0);
 
-    $scope.filterConfig.appliedFilters = [
+    $scope.appliedFilters = [
       {
         id: 'address',
         title: 'Address',
@@ -101,7 +99,7 @@ describe('Directive:  pfFilter', function () {
     expect(filterSelect.length).toBe(1);
 
     var items = filterSelect.find('li');
-    expect(items.length).toBe($scope.filterConfig.fields[2].filterValues.length + 1); // +1 for the null value
+    expect(items.length).toBe($scope.fields[2].filterValues.length + 1); // +1 for the null value
   });
 
   it ('should clear a filter when the close button is clicked', function () {
@@ -110,7 +108,7 @@ describe('Directive:  pfFilter', function () {
     closeButtons = element.find('.pficon-close');
     expect(closeButtons.length).toBe(0);
 
-    $scope.filterConfig.appliedFilters = [
+    $scope.appliedFilters = [
       {
         id: 'address',
         title: 'Address',
@@ -135,7 +133,7 @@ describe('Directive:  pfFilter', function () {
     expect(activeFilters.length).toBe(0);
     expect(clearButtons.length).toBe(0);
 
-    $scope.filterConfig.appliedFilters = [
+    $scope.appliedFilters = [
       {
         id: 'address',
         title: 'Address',

--- a/test/sort/sort.spec.js
+++ b/test/sort/sort.spec.js
@@ -1,6 +1,7 @@
 describe('Directive:  pfSort', function () {
   var $scope;
   var $compile;
+  var $timeout;
   var element;
 
   // load the controller's module
@@ -8,9 +9,10 @@ describe('Directive:  pfSort', function () {
     module('patternfly.sort', 'sort/sort.html');
   });
 
-  beforeEach(inject(function (_$compile_, _$rootScope_) {
+  beforeEach(inject(function (_$compile_, _$rootScope_, _$timeout_) {
     $compile = _$compile_;
     $scope = _$rootScope_;
+    $timeout = _$timeout_;
   }));
 
   var compileHTML = function (markup, scope) {
@@ -21,27 +23,25 @@ describe('Directive:  pfSort', function () {
   };
 
   beforeEach(function () {
-    $scope.sortConfig = {
-      fields: [
-        {
-          id: 'name',
-          title:  'Name',
-          sortType: 'alpha'
-        },
-        {
-          id: 'count',
-          title:  'Count',
-          sortType: 'numeric'
-        },
-        {
-          id: 'description',
-          title:  'Description',
-          sortType: 'alpha'
-        }
-      ]
-    };
+    $scope.fields = [
+      {
+        id: 'name',
+        title:  'Name',
+        sortType: 'alpha'
+      },
+      {
+        id: 'count',
+        title:  'Count',
+        sortType: 'numeric'
+      },
+      {
+        id: 'description',
+        title:  'Description',
+        sortType: 'alpha'
+      }
+    ];
 
-    var htmlTmp = '<pf-sort config="sortConfig"></pf-sort>';
+    var htmlTmp = '<pf-sort fields="fields"></pf-sort>';
 
     compileHTML(htmlTmp, $scope);
   });
@@ -114,56 +114,64 @@ describe('Directive:  pfSort', function () {
 
   it ('should notify when a new sort field is chosen', function() {
     var notified = false;
-    var chosenField = '';
+    var chosenId = '';
     var chosenDir = '';
-    var fields = element.find('.sort-pf .sort-field');
 
-    var watchForNotify = function (sortField, isAscending) {
+    $scope.watchForNotify = function (sortId, isAscending) {
       notified = true;
-      chosenField = sortField;
+      chosenId = sortId;
       chosenDir = isAscending;
     };
 
-    $scope.sortConfig.onSortChange = watchForNotify;
+    var htmlTmp = '<pf-sort fields="fields" on-sort-change="watchForNotify" current-sort-id="currentSortId" is-ascending="isAscending"></pf-sort>';
+    compileHTML(htmlTmp, $scope);
 
-
+    var fields = element.find('.sort-pf .sort-field');
     expect(fields.length).toBe(3);
 
     eventFire(fields[2], 'click');
     $scope.$digest();
+    $timeout.flush();
 
     expect(notified).toBeTruthy();
-    expect(chosenField).toBe($scope.sortConfig.fields[2]);
+    expect(chosenId).toBe($scope.fields[2].id);
     expect(chosenDir).toBeTruthy();
   });
 
   it ('should notify when the sort direction changes', function() {
     var notified = false;
-    var chosenField = '';
+    var chosenId = '';
     var chosenDir = '';
-    var sortButton = element.find('.sort-pf .btn.btn-link');
 
-    var watchForNotify = function (sortField, isAscending) {
+    $scope.watchForNotify = function (sortId, isAscending) {
       notified = true;
-      chosenField = sortField;
+      chosenId = sortId;
       chosenDir = isAscending;
     };
 
-    $scope.sortConfig.onSortChange = watchForNotify;
+    var htmlTmp = '<pf-sort fields="fields" on-sort-change="watchForNotify" current-sort-id="currentSortId" is-ascending="isAscending"></pf-sort>';
+    compileHTML(htmlTmp, $scope);
+
+    var sortButton = element.find('.sort-pf .btn.btn-link');
 
     expect(sortButton.length).toBe(1);
 
     eventFire(sortButton[0], 'click');
     $scope.$digest();
+    $timeout.flush();
 
     expect(notified).toBeTruthy();
-    expect(chosenField).toBe($scope.sortConfig.fields[0]);
+    expect(chosenId).toBe($scope.fields[0].id);
     expect(chosenDir).toBeFalsy();
   });
+
   it ('should return appropriate icons for current sort type and direction', function () {
-    $scope.sortConfig.currentField = $scope.sortConfig.fields[0];
-    $scope.sortConfig.isAscending = true;
-    $scope.$digest();
+    $scope.currentSortId = $scope.fields[0].id;
+    $scope.isAscending = true;
+
+    var htmlTmp = '<pf-sort fields="fields" current-sort-id="currentSortId" is-ascending="isAscending"></pf-sort>';
+    compileHTML(htmlTmp, $scope);
+
     var alphaSortAsc = element.find('.fa.fa-sort-alpha-asc');
     var alphaSortDesc = element.find('.fa.fa-sort-alpha-desc');
     var numericSortAsc = element.find('.fa.fa-sort-numeric-asc');
@@ -173,9 +181,11 @@ describe('Directive:  pfSort', function () {
     expect(numericSortAsc.length).toBe(0);
     expect(numericSortDesc.length).toBe(0);
 
-    $scope.sortConfig.currentField = $scope.sortConfig.fields[0];
-    $scope.sortConfig.isAscending = false;
-    $scope.$digest();
+    $scope.currentSortId = $scope.fields[0].id;
+    $scope.isAscending = false;
+    var htmlTmp = '<pf-sort fields="fields" current-sort-id="currentSortId" is-ascending="isAscending"></pf-sort>';
+    compileHTML(htmlTmp, $scope);
+
     alphaSortAsc = element.find('.fa.fa-sort-alpha-asc');
     alphaSortDesc = element.find('.fa.fa-sort-alpha-desc');
     numericSortAsc = element.find('.fa.fa-sort-numeric-asc');
@@ -185,9 +195,10 @@ describe('Directive:  pfSort', function () {
     expect(numericSortAsc.length).toBe(0);
     expect(numericSortDesc.length).toBe(0);
 
-    $scope.sortConfig.currentField = $scope.sortConfig.fields[1];
-    $scope.sortConfig.isAscending = true;
-    $scope.$digest();
+    $scope.currentSortId = $scope.fields[1].id;
+    $scope.isAscending = true;
+    var htmlTmp = '<pf-sort fields="fields" current-sort-id="currentSortId" is-ascending="isAscending"></pf-sort>';
+    compileHTML(htmlTmp, $scope);
     alphaSortAsc = element.find('.fa.fa-sort-alpha-asc');
     alphaSortDesc = element.find('.fa.fa-sort-alpha-desc');
     numericSortAsc = element.find('.fa.fa-sort-numeric-asc');
@@ -197,9 +208,10 @@ describe('Directive:  pfSort', function () {
     expect(numericSortAsc.length).toBe(1);
     expect(numericSortDesc.length).toBe(0);
 
-    $scope.sortConfig.currentField = $scope.sortConfig.fields[1];
-    $scope.sortConfig.isAscending = false;
-    $scope.$digest();
+    $scope.currentSortId = $scope.fields[1].id;
+    $scope.isAscending = false;
+    var htmlTmp = '<pf-sort fields="fields" current-sort-id="currentSortId" is-ascending="isAscending"></pf-sort>';
+    compileHTML(htmlTmp, $scope);
     alphaSortAsc = element.find('.fa.fa-sort-alpha-asc');
     alphaSortDesc = element.find('.fa.fa-sort-alpha-desc');
     numericSortAsc = element.find('.fa.fa-sort-numeric-asc');

--- a/test/toolbars/toolbar.spec.js
+++ b/test/toolbars/toolbar.spec.js
@@ -4,6 +4,10 @@ describe('Directive:  pfToolbar', function () {
   var element;
   var $pfViewUtils;
   var performedAction;
+  var htmlTmp;
+  var sortChangeNotify = false;
+  var sortChosenField;
+  var sortChosenDir;
 
   // load the controller's module
   beforeEach(function () {
@@ -32,107 +36,139 @@ describe('Directive:  pfToolbar', function () {
       performedAction = action;
     };
 
-    $scope.config = {
-      viewsConfig: {
-        views: [$pfViewUtils.getDashboardView(), $pfViewUtils.getListView(), $pfViewUtils.getCardView(), $pfViewUtils.getTableView(), $pfViewUtils.getTopologyView()]
+    $scope.contentViews = [$pfViewUtils.getDashboardView(), $pfViewUtils.getListView(), $pfViewUtils.getCardView(), $pfViewUtils.getTableView(), $pfViewUtils.getTopologyView()];
+    $scope.sortFields = [
+      {
+        id: 'name',
+        title:  'Name',
+        sortType: 'alpha'
       },
-      sortConfig: {
-        fields: [
-          {
-            id: 'name',
-            title:  'Name',
-            sortType: 'alpha'
-          },
-          {
-            id: 'age',
-            title:  'Age',
-            sortType: 'numeric'
-          },
-          {
-            id: 'address',
-            title:  'Address',
-            sortType: 'alpha'
-          }
-        ]
+      {
+        id: 'age',
+        title:  'Age',
+        sortType: 'numeric'
       },
-      filterConfig: {
-        fields: [
-          {
-            id: 'name',
-            title:  'Name',
-            placeholder: 'Filter by Name',
-            filterType: 'text'
-          },
-          {
-            id: 'address',
-            title:  'Address',
-            placeholder: 'Filter by Address',
-            filterType: 'text'
-          },
-          {
-            id: 'birthMonth',
-            title:  'Birth Month',
-            placeholder: 'Filter by Birth Month',
-            filterType: 'select',
-            filterValues: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
-          }
-        ],
-        resultsCount: 5,
-        appliedFilters: []
-      },
-      actionsConfig: {
-        primaryActions: [
-          {
-            name: 'Action 1',
-            title: 'Do the first thing',
-            actionFn: performAction
-          },
-          {
-            name: 'Action 2',
-            title: 'Do something else',
-            actionFn: performAction
-          }
-        ],
-        moreActions: [
-          {
-            name: 'Action',
-            title: 'Perform an action',
-            actionFn: performAction
-          },
-          {
-            name: 'Another Action',
-            title: 'Do something else',
-            actionFn: performAction
-          },
-          {
-            name: 'Disabled Action',
-            title: 'Unavailable action',
-            actionFn: performAction,
-            isDisabled: true
-          },
-          {
-            name: 'Something Else',
-            title: '',
-            actionFn: performAction
-          },
-          {
-            isSeparator: true
-          },
-          {
-            name: 'Grouped Action 1',
-            title: 'Do something',
-            actionFn: performAction
-          },
-          {
-            name: 'Grouped Action 2',
-            title: 'Do something similar',
-            actionFn: performAction
-          }
-        ]
+      {
+        id: 'address',
+        title:  'Address',
+        sortType: 'alpha'
       }
+    ];
+    $scope.filterFields = [
+      {
+        id: 'name',
+        title:  'Name',
+        placeholder: 'Filter by Name',
+        filterType: 'text'
+      },
+      {
+        id: 'address',
+        title:  'Address',
+        placeholder: 'Filter by Address',
+        filterType: 'text'
+      },
+      {
+        id: 'birthMonth',
+        title:  'Birth Month',
+        placeholder: 'Filter by Birth Month',
+        filterType: 'select',
+        filterValues: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+      }
+    ];
+    $scope.resultsCount = 5;
+    $scope.appliedFilters = [];
+    $scope.primaryActions = [
+      {
+        name: 'Action 1',
+        title: 'Do the first thing',
+        actionFn: performAction
+      },
+      {
+        name: 'Action 2',
+        title: 'Do something else',
+        actionFn: performAction
+      }
+    ];
+    $scope.moreActions = [
+      {
+        name: 'Action',
+        title: 'Perform an action',
+        actionFn: performAction
+      },
+      {
+        name: 'Another Action',
+        title: 'Do something else',
+        actionFn: performAction
+      },
+      {
+        name: 'Disabled Action',
+        title: 'Unavailable action',
+        actionFn: performAction,
+        isDisabled: true
+      },
+      {
+        name: 'Something Else',
+        title: '',
+        actionFn: performAction
+      },
+      {
+        isSeparator: true
+      },
+      {
+        name: 'Grouped Action 1',
+        title: 'Do something',
+        actionFn: performAction
+      },
+      {
+        name: 'Grouped Action 2',
+        title: 'Do something similar',
+        actionFn: performAction
+      }
+    ];
+
+    $scope.onSortChange = function (sortField, isAscending) {
+      sortChangeNotify = true;
+      sortChosenField = sortField;
+      sortChosenDir = isAscending;
     };
 
-    var htmlTmp = '<pf-toolbar config="config"></pf-toolbar>';
+
+    $scope.currentView = $scope.contentViews[0].id;
+    $scope.onViewSelect = function(viewId) {
+      $scope.currentView = viewId;
+    };
+/*
+    <pf-toolbar id="exampleToolbar"
+    filter-fields="filterFields"
+    applied-filters="appliedFilters"
+    results-count="{{resultsCount}}"
+    on-filter-change="onFilterChange"
+    sort-fields="sortFields"
+    current-sort-field="currentSortId"
+    is-sort-ascending="sortAscending"
+    on-sort-change="onSortChange"
+    views="views"
+    current-view="currentView"
+    on-view-select="onViewSelect"
+    primary-actions="primaryActions"
+    more-actions="moreActions"
+    actions-include="actionsInclude">
+
+*/
+
+    htmlTmp = '' +
+      '<pf-toolbar filter-fields="filterFields"' +
+      '            applied-filters="appliedFilters"' +
+      '            results-count="{{resultsCount}}"' +
+      '            sort-fields="sortFields"' +
+      '            on-sort-change="onSortChange"' +
+      '            views="contentViews"' +
+      '            current-view="currentView"' +
+      '            on-view-select="onViewSelect"' +
+      '            primary-actions="primaryActions"' +
+      '            more-actions="moreActions"' +
+      '            actions-include="actionsInclude"' +
+      '</pf-toolbar>';
 
     compileHTML(htmlTmp, $scope);
   });
@@ -147,7 +183,7 @@ describe('Directive:  pfToolbar', function () {
     expect(results.length).toBe(1);
     expect(results.html()).toBe("5 Results");
 
-    $scope.config.filterConfig.resultsCount = 10;
+    $scope.resultsCount = 10;
 
     $scope.$digest();
 
@@ -161,7 +197,7 @@ describe('Directive:  pfToolbar', function () {
     expect(activeFilters.length).toBe(0);
     expect(element.find('.clear-filters').length).toBe(0);
 
-    $scope.config.filterConfig.appliedFilters = [
+    $scope.appliedFilters = [
       {
         id: 'address',
         title: 'Address',
@@ -189,7 +225,7 @@ describe('Directive:  pfToolbar', function () {
     expect(filterSelect.length).toBe(1);
 
     var items = filterSelect.find('li');
-    expect(items.length).toBe($scope.config.filterConfig.fields[2].filterValues.length + 1); // +1 for the null value
+    expect(items.length).toBe($scope.filterFields[2].filterValues.length + 1); // +1 for the null value
   });
 
   it ('should clear a filter when the close button is clicked', function () {
@@ -198,7 +234,7 @@ describe('Directive:  pfToolbar', function () {
     closeButtons = element.find('.pficon-close');
     expect(closeButtons.length).toBe(0);
 
-    $scope.config.filterConfig.appliedFilters = [
+    $scope.appliedFilters = [
       {
         id: 'address',
         title: 'Address',
@@ -223,7 +259,7 @@ describe('Directive:  pfToolbar', function () {
     expect(activeFilters.length).toBe(0);
     expect(clearButtons.length).toBe(0);
 
-    $scope.config.filterConfig.appliedFilters = [
+    $scope.appliedFilters = [
       {
         id: 'address',
         title: 'Address',
@@ -248,19 +284,12 @@ describe('Directive:  pfToolbar', function () {
     expect(clearButtons.length).toBe(0);
   });
 
-  it ('should not show filters when a filter config is not supplied', function () {
+  it ('should not show filters when filter fields are not supplied', function () {
     var filter = element.find('.filter-pf');
     expect(filter.length).toBe(2);
 
-    $scope.config = {
-      viewsConfig: {
-        views: [$pfViewUtils.getListView(), $pfViewUtils.getCardView()]
-      }
-    };
-
-    var htmlTmp = '<pf-toolbar config="config"></pf-toolbar>';
-
-    compileHTML(htmlTmp, $scope);
+    $scope.filterFields = undefined;
+    $scope.$digest();
 
     filter = element.find('.filter-pf');
     expect(filter.length).toBe(0);
@@ -279,58 +308,50 @@ describe('Directive:  pfToolbar', function () {
 
   it ('should show the currently selected view', function () {
     var viewSelector = element.find('.toolbar-pf-view-selector');
-    var active = element.find('.active');
+    var activeDashboard = element.find('.active .fa.fa-dashboard');
+    var activeList = element.find('.active .fa.fa-th-list');
 
     expect(viewSelector.length).toBe(1);
-    expect(active.length).toBe(0);
+    expect(activeDashboard.length).toBe(1);
+    expect(activeList.length).toBe(0);
 
-    $scope.config.viewsConfig.currentView = $scope.config.viewsConfig.views[0].id;
+    $scope.currentView = $scope.contentViews[1].id;
     $scope.$apply();
 
-    active = element.find('.active');
-    expect(active.length).toBe(1);
+    activeDashboard = element.find('.active .fa.fa-dashboard');
+    activeList = element.find('.active .fa.fa-th-list');
+
+    expect(activeDashboard.length).toBe(0);
+    expect(activeList.length).toBe(1);
   });
 
   it ('should update the currently selected view when a view selector clicked', function () {
     var viewSelector = element.find('.toolbar-pf-view-selector');
-    var active = element.find('.active');
+    var activeDashboard = element.find('.active .fa.fa-dashboard');
+    var activeList = element.find('.active .fa.fa-th-list');
     var listSelector = element.find('.toolbar-pf-view-selector .btn-link');
 
     expect(viewSelector.length).toBe(1);
-    expect(active.length).toBe(0);
+    expect(activeDashboard.length).toBe(1);
+    expect(activeList.length).toBe(0);
     expect(listSelector.length).toBe(5);
 
-    eventFire(listSelector[0], 'click');
+    eventFire(listSelector[1], 'click');
     $scope.$apply();
 
-    active = element.find('.active');
-    expect(active.length).toBe(1);
-  });
+    activeDashboard = element.find('.active .fa.fa-dashboard');
+    activeList = element.find('.active .fa.fa-th-list');
 
-  it ('should call the callback function when a view selector clicked', function () {
-    var listSelector = element.find('.toolbar-pf-view-selector .btn-link');
-    var functionCalled = false;
-
-    var onViewSelect = function () {
-      functionCalled = true;
-    };
-
-    $scope.config.viewsConfig.onViewSelect = onViewSelect;
-    expect(functionCalled).toBeFalsy();
-    expect(listSelector.length).toBe(5);
-
-    eventFire(listSelector[0], 'click');
-    $scope.$apply();
-
-    expect(functionCalled).toBeTruthy();
+    expect(activeDashboard.length).toBe(0);
+    expect(activeList.length).toBe(1);
   });
 
   it ('should not show view selectors when no viewsConfig is supplied', function () {
     var viewSelector = element.find('.toolbar-pf-view-selector');
     expect(viewSelector.length).toBe(1);
 
-    $scope.config.viewsConfig = undefined;
-    $scope.$digest();
+    $scope.contentViews = undefined;
+    $scope.$apply();
 
     viewSelector = element.find('.toolbar-pf-view-selector');
     expect(viewSelector.length).toBe(0);
@@ -403,65 +424,36 @@ describe('Directive:  pfToolbar', function () {
   });
 
   it ('should notify when a new sort field is chosen', function() {
-    var notified = false;
-    var chosenField = '';
-    var chosenDir = '';
     var fields = element.find('.sort-pf .sort-field');
-
-    var watchForNotify = function (sortField, isAscending) {
-      notified = true;
-      chosenField = sortField;
-      chosenDir = isAscending;
-    };
-
-    $scope.config.sortConfig.onSortChange = watchForNotify;
-
 
     expect(fields.length).toBe(3);
 
     eventFire(fields[2], 'click');
     $scope.$digest();
 
-    expect(notified).toBeTruthy();
-    expect(chosenField).toBe($scope.config.sortConfig.fields[2]);
-    expect(chosenDir).toBeTruthy();
+    expect(sortChangeNotify).toBeTruthy();
+    expect(sortChosenField).toBe($scope.sortFields[2].id);
+    expect(sortChosenDir).toBeTruthy();
   });
 
   it ('should notify when the sort direction changes', function() {
-    var notified = false;
-    var chosenField = '';
-    var chosenDir = '';
     var sortButton = element.find('.sort-pf .btn.btn-link');
-
-    var watchForNotify = function (sortField, isAscending) {
-      notified = true;
-      chosenField = sortField;
-      chosenDir = isAscending;
-    };
-
-    $scope.config.sortConfig.onSortChange = watchForNotify;
-
     expect(sortButton.length).toBe(1);
 
     eventFire(sortButton[0], 'click');
     $scope.$digest();
 
-    expect(notified).toBeTruthy();
-    expect(chosenField).toBe($scope.config.sortConfig.fields[0]);
-    expect(chosenDir).toBeFalsy();
+    expect(sortChangeNotify).toBeTruthy();
+    expect(sortChosenField).toBe($scope.sortFields[0].id);
+    expect(sortChosenDir).toBeFalsy();
   });
 
-  it ('should not show sort components when a sort config is not supplied', function () {
+  it ('should not show sort components when sort fields are not supplied', function () {
     var filter = element.find('.sort-pf');
     expect(filter.length).toBe(1);
 
-    $scope.config = {
-      viewsConfig: {
-        views: [$pfViewUtils.getListView(), $pfViewUtils.getCardView()]
-      }
-    };
-
-    var htmlTmp = '<pf-toolbar config="config"></pf-toolbar>';
+    $scope.sortFields = undefined;
+    $scope.$digest();
 
     compileHTML(htmlTmp, $scope);
 
@@ -493,7 +485,7 @@ describe('Directive:  pfToolbar', function () {
     var menus = element.find('.fa-ellipsis-v');
     expect(menus.length).toBe(1);
 
-    $scope.config.actionsConfig.moreActions = undefined;
+    $scope.moreActions = undefined;
     $scope.$digest();
 
     menus = element.find('.toolbar-pf-actions .fa-ellipsis-v');
@@ -534,7 +526,7 @@ describe('Directive:  pfToolbar', function () {
     expect(performedAction.name).toBe('Action 2');
 
     performedAction = undefined;
-    $scope.config.actionsConfig.primaryActions[1].isDisabled = true;
+    $scope.primaryActions[1].isDisabled = true;
     $scope.$digest();
 
     eventFire(primaryActions[1], 'click');
@@ -543,19 +535,14 @@ describe('Directive:  pfToolbar', function () {
     expect(performedAction).toBe(undefined);
   });
 
-  it ('should not show action components when an action config is not supplied', function () {
+  it ('should not show action components when actions not supplied', function () {
     var filter = element.find('.toolbar-actions');
     expect(filter.length).toBe(1);
 
-    $scope.config = {
-      viewsConfig: {
-        views: [$pfViewUtils.getListView(), $pfViewUtils.getCardView()]
-      }
-    };
+    $scope.primaryActions = undefined;
+    $scope.moreActions = undefined;
 
-    var htmlTmp = '<pf-toolbar config="config"></pf-toolbar>';
-
-    compileHTML(htmlTmp, $scope);
+    $scope.$digest();
 
     filter = element.find('.toolbar-actions');
     expect(filter.length).toBe(0);
@@ -568,10 +555,25 @@ describe('Directive:  pfToolbar', function () {
     var includeActions = actionBar.find('.toolbar-pf-include-actions');
     expect(includeActions.length).toBe(0);
 
-    $scope.config.actionsConfig.actionsInclude = true;
+    $scope.actionsInclude = true;
+    var htmlTmp = '' +
+      '<pf-toolbar filter-fields="filterFields"' +
+      '            applied-filters="appliedFilters"' +
+      '            results-count="{{resultsCount}}"' +
+      '            sort-fields="sortFields"' +
+      '            on-sort-change="onSortChange"' +
+      '            views="contentViews"' +
+      '            current-view="currentView"' +
+      '            on-view-select="onViewSelect"' +
+      '            primary-actions="primaryActions"' +
+      '            more-actions="moreActions"' +
+      '            actions-include="actionsInclude"' +
+      '  <actions><button class="btn btn-default add-action" type="button">Add Action</button></actions>' +
+      '</pf-toolbar>';
 
-    var includeHtml = '<pf-toolbar config="config"><actions><button class="btn btn-default add-action" type="button">Add Action</button></actions></pf-toolbar>';
-    compileHTML(includeHtml, $scope);
+    compileHTML(htmlTmp, $scope);
+
+    $scope.$digest();
 
     actionBar = element.find('.toolbar-actions');
     expect(actionBar.length).toBe(1);


### PR DESCRIPTION
Changed from one big config parameter to individual parameters. This
allows for not doing a $watch on the config parameter and removes the
dependency on $scope. This will help with the future transition to
Angular 2.

*Migration Instructions

** Sort
- Change from config parameter to:
-- fields
-- currentSortId
-- isAscending
-- onSortChange parameters
- Leaving out currentSortId will default to the first sort field (no change here)
- Leaving out isAscending will default to true (no change here as well)

** Filter
- Change from config parameter to:
-- fields
-- appliedFilters - required, must be updated on call to onFilterChange
-- resultsCount
-- onFilterChange - required, must update appliedFilters bound variable

** Toolbar
- Change from config parameter to:
-- filterFields
-- appliedFilters - required if including filters, must be updated on call to onFilterChange
-- resultsCount
-- onFilterChange - required if including filters, must update appliedFilters bound variable
-- sortFields
-- currentSortField
-- isSortAscending
-- onSortChange
-- views
-- currentView
-- onViewSelect
-- primaryActions
-- moreActions
-- actionsInclude