### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 This project will provide a set of common AngularJS directives for use with the PatternFly reference implementation.
 
 * Web site: https://www.patternfly.org
-* API Docs: http://angular-patternfly.rhcloud.com/#/api
+* API Docs: http://www.patternfly.org/angular-patternfly/#/api
 * Build Status: https://travis-ci.org/patternfly/angular-patternfly.svg?branch=master
 
 ## Getting started


### PR DESCRIPTION
Update API documentation location

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/patternfly/angular-patternfly/398)
<!-- Reviewable:end -->
