### PR TITLE
List View: Expand rows when clicking anywhere in the row.

### DIFF
--- a/src/views/listview/list-view-directive.js
+++ b/src/views/listview/list-view-directive.js
@@ -27,7 +27,7 @@
  * <li>.onCheckBoxChange       - ( function(item) ) Called to notify when a checkbox selection changes, default is none
  * <li>.onSelect               - ( function(item, event) ) Called to notify of item selection, default is none
  * <li>.onSelectionChange      - ( function(items) ) Called to notify when item selections change, default is none
- * <li>.onClick                - ( function(item, event) ) Called to notify when an item is clicked, default is none
+ * <li>.onClick                - ( function(item, event) ) Called to notify when an item is clicked, default is none. Note: row expansion is the default behavior after onClick performed, but user can stop such default behavior by adding the sentence "return false;" to the end of onClick function body
  * <li>.onDblClick             - ( function(item, event) ) Called to notify when an item is double clicked, default is none
  * </ul>
  * @param {array} actionButtons List of action buttons in each row
@@ -578,6 +578,7 @@ angular.module('patternfly.views').directive('pfListView', function ($timeout, $
         var alreadySelected;
         var selectionChanged = false;
         var continueEvent = true;
+        var enableRowExpansion = scope.config && scope.config.useExpandingRows && item && !item.disableRowExpansion;
 
         // Ignore disabled item clicks completely
         if (scope.checkDisabled(item)) {
@@ -620,7 +621,11 @@ angular.module('patternfly.views').directive('pfListView', function ($timeout, $
           }
         }
         if (scope.config.onClick) {
-          scope.config.onClick(item, e);
+          if (scope.config.onClick(item, e) !== false && enableRowExpansion) {
+            scope.toggleItemExpansion(item);
+          }
+        } else if (enableRowExpansion) {
+          scope.toggleItemExpansion(item);
         }
 
         return continueEvent;

--- a/test/views/listview/list-view.spec.js
+++ b/test/views/listview/list-view.spec.js
@@ -514,7 +514,7 @@ describe('Directive:  pfDataList', function () {
     expect(alteredKebab.length).toBe(1);
   });
 
-  it('should allow expanding rows', function () {
+  it('should allow expanding rows by clicking the caret icon', function () {
     var items;
     $scope.listConfig.useExpandingRows = true;
 
@@ -523,6 +523,19 @@ describe('Directive:  pfDataList', function () {
     items = element.find('.list-view-pf-expand .fa-angle-right');
     expect(items.length).toBe(5);
 
+    eventFire(items[0], 'click');
+
+    var openItem = element.find('.list-group-item-container');
+    expect(openItem.length).toBe(1);
+  });
+
+  it('should allow expanding rows by clicking the main-info section', function () {
+    var items;
+    $scope.listConfig.useExpandingRows = true;
+
+    $scope.$digest();
+
+    items = element.find('.list-view-pf-main-info');
     eventFire(items[0], 'click');
 
     var openItem = element.find('.list-group-item-container');


### PR DESCRIPTION
For list views using row expansion, the row will now expand when the user clicks anywhere on the row. Previously the user had to click on the expansion indicator icon. If desired, the application code can prevent the expansion on click of the row by returning false from the config.onClick function.