### PR TITLE
Add angular-drag-and-drop-lists dependency to bower.json. Fix #401

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,6 +41,7 @@
     "angular-animate": "1.3.0 - 1.5.*",
     "angular-sanitize": "1.3.0 - 1.5.*",
     "angular-bootstrap": "0.14.x",
+    "angular-drag-and-drop-lists": "~2.1.0",
     "lodash": "3.x",
     "patternfly": "~3.19.0"
   },


### PR DESCRIPTION
The angular-drag-and-drop-lists dependency needs to be in bower.json otherwise all projects that use angular-patternfly with bower + wiredep will have to define this angular-patternfly internal dependency.