### PR TITLE
Set line chart data instead of updating it

### DIFF
--- a/src/charts/line/line-chart.directive.js
+++ b/src/charts/line/line-chart.directive.js
@@ -61,6 +61,7 @@
            </div>
            <div class="col-md-3">
                  <button ng-click="addDataPoint()">Add Data Point</button>
+                 <button ng-click="resetData()">Reset Data</button>
            </div>
          </div>
        </div>
@@ -99,8 +100,8 @@
        $scope.data = {
          dataAvailable: true,
          xData: dates,
-         yData0: ['Created', 12, 10,10, 62, 17, 10, 15, 13, 17, 10, 12, 10, 10, 12, 17, 16, 15, 13, 17, 10],
-         yData1: ['Deleted', 10, 17, 76,14, 10, 10, 10, 10, 10, 10, 10, 17, 17, 14, 10, 10, 10, 10, 10, 10]
+         yData0: ['Created', 12, 10, 10, 62, 17, 10, 15, 13, 17, 10, 12, 10, 10, 12, 17, 16, 15, 13, 17, 10],
+         yData1: ['Deleted', 10, 17, 76, 14, 10, 10, 10, 10, 10, 10, 10, 17, 17, 14, 10, 10, 10, 10, 10, 10]
        };
 
        $scope.custShowXAxis = false;
@@ -111,6 +112,14 @@
          $scope.data.xData.push(new Date($scope.data.xData[$scope.data.xData.length - 1].getTime() + (24 * 60 * 60 * 1000)));
          $scope.data.yData0.push(Math.round(Math.random() * 100));
          $scope.data.yData1.push(Math.round(Math.random() * 100));
+       };
+
+       $scope.resetData = function () {
+         $scope.data = {
+           xData: dates,
+           yData0: ['Created', 12, 10, 10, 62],
+           yData1: ['Deleted', 10, 17, 76, 14]
+         };
        };
      });
    </file>
@@ -225,7 +234,7 @@ angular.module('patternfly.charts').directive('pfLineChart', function (pfUtils) 
         scope.chartConfig.data.type = scope.setAreaChart ? "area" : "line";
       });
       scope.$watch('chartData', function () {
-        scope.chartConfig.data = pfUtils.merge(scope.chartConfig.data, scope.getLineData(scope.chartData));
+        scope.chartConfig.data = scope.getLineData(scope.chartData);
       }, true);
     }
   };


### PR DESCRIPTION
**Descriptions**
Currently we can only add new points to the line chart.
In ManageIQ we use the same chart object to show different data, so we need to reset the data.

This PR adds the option to delete old points, and replace them with new ons. This does not break the option to just add points, because we always keep the data in a local variable we can use to repopulate the data.

**Screenshot**
![screenshot-0 0 0 0 8000-2017-02-14-16-25-38](https://cloud.githubusercontent.com/assets/2181522/22932996/c2026302-f2d2-11e6-9512-fac9eb39a126.png)
