### PR TITLE
Fix list view drop direction updates

### DIFF
--- a/src/views/listview/list-view-directive.js
+++ b/src/views/listview/list-view-directive.js
@@ -559,7 +559,7 @@ angular.module('patternfly.views').directive('pfListView', function ($timeout, $
               }
               nextElement = nextElement.parentElement;
             }
-          });
+          }, 100);
         };
       },
 

--- a/src/views/listview/list-view-directive.js
+++ b/src/views/listview/list-view-directive.js
@@ -419,7 +419,7 @@
   </file>
 </example>
  */
-angular.module('patternfly.views').directive('pfListView', function ($timeout, $window, pfUtils) {
+angular.module('patternfly.views').directive('pfListView', function ($window, pfUtils) {
   'use strict';
   return {
     restrict: 'A',
@@ -545,7 +545,7 @@ angular.module('patternfly.views').directive('pfListView', function ($timeout, $
           // update the actions based on the current item
           $scope.updateActions(item);
 
-          $timeout(function () {
+          $window.requestAnimationFrame(function () {
             var parentDiv = undefined;
             var nextElement;
 
@@ -559,7 +559,7 @@ angular.module('patternfly.views').directive('pfListView', function ($timeout, $
               }
               nextElement = nextElement.parentElement;
             }
-          }, 100);
+          });
         };
       },
 


### PR DESCRIPTION
In #setDropMenuLocation, the bounding rectangle for the menu was being
calculated before it was rendered causing the height to be 0.

For some reason the $timeout was not waiting for the digest cycle to
complete, however, adding a 100 ms delay consistently drops the menu in
the proper direction.

Fixes #399