### PR TITLE
Removed the redundant and broken deploy config from the travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,3 @@ script:
 
 after_success:
   - ./scripts/publish-ghpages.sh -t docs
-
-# OpenShift expects its deployment branch to be "master-dist". This can be changed using:
-# rhc app-configure patternfly/angular --deployment-branch master-dist
-deploy:
-  provider: openshift
-  user: "$OPENSHIFT_USER"
-  password: "$OPENSHIFT_PWD"
-  domain: "patternfly"
-  app: angular
-  skip_cleanup: true
-  on: # The branch and repo that triggered the build
-    branch: master
-    condition: $TRAVIS_REPO_SLUG = "patternfly/angular-patternfly"


### PR DESCRIPTION
The travis deploy script is causing the following error:

```
Installing deploy dependencies
Fetching: httpclient-2.4.0.gem (100%)
Successfully installed httpclient-2.4.0
1 gem installed
Fetching: net-ssh-2.9.4.gem (100%)
Successfully installed net-ssh-2.9.4
1 gem installed
Fetching: net-ssh-4.0.1.gem (100%)
Successfully installed net-ssh-4.0.1
Fetching: net-scp-1.2.1.gem (100%)
Successfully installed net-scp-1.2.1
Fetching: net-ssh-gateway-2.0.0.gem (100%)
Successfully installed net-ssh-gateway-2.0.0
Fetching: net-ssh-multi-1.2.1.gem (100%)
Successfully installed net-ssh-multi-1.2.1
Fetching: minitar-0.6.1.gem (100%)
The `minitar` executable is no longer bundled with `minitar`. If you are
expecting this executable, make sure you also install `minitar-cli`.
Successfully installed minitar-0.6.1
Fetching: hashie-3.5.3.gem (100%)
Successfully installed hashie-3.5.3
Fetching: powerbar-1.0.18.gem (100%)
Successfully installed powerbar-1.0.18
Fetching: minitar-cli-0.6.1.gem (100%)
Successfully installed minitar-cli-0.6.1
Fetching: archive-tar-minitar-0.6.1.gem (100%)
'archive-tar-minitar' has been deprecated; just install 'minitar'.
Successfully installed archive-tar-minitar-0.6.1
Fetching: highline-1.6.21.gem (100%)
Successfully installed highline-1.6.21
Fetching: commander-4.2.1.gem (100%)
Successfully installed commander-4.2.1
Fetching: open4-1.3.4.gem (100%)
Successfully installed open4-1.3.4
Fetching: rhc-1.38.7.gem (100%)
===========================================================================
If this is your first time installing the RHC tools, please run 'rhc setup'
===========================================================================
Successfully installed rhc-1.38.7
13 gems installed
/home/travis/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems/specification.rb:2288:in `raise_if_conflicts': Unable to activate net-ssh-gateway-2.0.0, because net-ssh-2.9.4 conflicts with net-ssh (>= 4.0.0) (Gem::ConflictError)
	from /home/travis/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems/specification.rb:1408:in `activate'
	from /home/travis/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems/specification.rb:1442:in `block in activate_dependencies'
	from /home/travis/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems/specification.rb:1428:in `each'
	from /home/travis/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems/specification.rb:1428:in `activate_dependencies'
	from /home/travis/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems/specification.rb:1410:in `activate'
	from /home/travis/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems/specification.rb:1442:in `block in activate_dependencies'
	from /home/travis/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems/specification.rb:1428:in `each'
	from /home/travis/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems/specification.rb:1428:in `activate_dependencies'
	from /home/travis/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems/specification.rb:1410:in `activate'
	from /home/travis/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems.rb:220:in `rescue in try_activate'
	from /home/travis/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems.rb:213:in `try_activate'
	from /home/travis/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:126:in `rescue in require'
	from /home/travis/.rvm/rubies/ruby-2.2.5/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:40:in `require'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/provider.rb:77:in `requires'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/provider/openshift.rb:6:in `<class:Openshift>'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/provider/openshift.rb:3:in `<class:Provider>'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/provider/openshift.rb:2:in `<module:DPL>'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/provider/openshift.rb:1:in `<top (required)>'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/provider.rb:59:in `const_get'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/provider.rb:59:in `block in new'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/cli.rb:41:in `fold'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/provider.rb:56:in `new'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/cli.rb:31:in `run'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/cli.rb:7:in `run'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/bin/dpl:5:in `<top (required)>'
	from /home/travis/.rvm/gems/ruby-2.2.5/bin/dpl:22:in `load'
	from /home/travis/.rvm/gems/ruby-2.2.5/bin/dpl:22:in `<main>'
failed to deploy
```

Since the github pages deployment has been working so well, it is easier to remove the broken config than to fix it.