### PR TITLE
Added require for angular-drag-and-drop-lists in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ require('angular-animate');
 require('angular-sanitize');
 require('angular-ui-bootstrap');
 require('lodash');
+require('angular-drag-and-drop-lists');
 require('patternfly/dist/js/patternfly.min');
 require('./dist/angular-patternfly');
 module.exports = 'angular-patternfly';


### PR DESCRIPTION
Hi all,

This PR simply adds the dependency on `angular-drag-and-drop-lists` in index.js, needed when using `angular-patternfly` with Webpack