### PR TITLE
Fixes #385 - filter input causes a toolbar view change.

### DIFF
--- a/src/filters/filter-fields-directive.js
+++ b/src/filters/filter-fields-directive.js
@@ -62,6 +62,7 @@ angular.module('patternfly.filters').directive('pfFilterFields', function () {
 
       scope.onValueKeyPress = function (keyEvent) {
         if (keyEvent.which === 13) {
+          keyEvent.preventDefault();
           scope.addFilterFn(scope.currentField, scope.config.currentValue);
           scope.config.currentValue = undefined;
         }


### PR DESCRIPTION
Entering a value into the pf-toolbar filter input box causes the toolbar viewConfig.viewSelected() handler to be invoked.  

This causes the view to change if a filter is keyed in while in any other view.

This appears to happen because the return keypress is also interpreted as a click event, which triggers the ng-click handler for the view selection button.