### PR TITLE
Feature Application Launcher 4x

### DIFF
--- a/src/navigation/application-launcher.component.js
+++ b/src/navigation/application-launcher.component.js
@@ -1,0 +1,90 @@
+/**
+ * @ngdoc directive
+ * @name patternfly.navigation.component:pfApplicationLauncher
+ * @restrict E
+ *
+ * @description
+ * Component for rendering application launcher dropdown.
+ *
+ * @param {string=} label Use a custom label for the launcher, default: Application Launcher
+ * @param {boolean=} isDisabled Disable the application launcher button, default: false
+ * @param {boolean=} isList Display items as a list instead of a grid, default: false
+ * @param {boolean=} hiddenIcons Flag to not show icons on the launcher, default: false
+ * @param {array} items List of navigation items
+ * <ul style='list-style-type: none'>
+ * <li>.title        - (string) Name of item to be displayed on the menu
+ * <li>.iconClass    - (string) Classes for icon to be shown on the menu (ex. "fa fa-dashboard")
+ * <li>.href         - (string) href link to navigate to on click
+ * <li>.tooltip      - (string) Tooltip to display for the badge
+ * </ul>
+ * @example
+ <example module="patternfly.navigation">
+ <file name="index.html">
+   <div ng-controller="applicationLauncherController" class="row">
+     <div class="col-xs-12 pre-demo-text">
+       <label>Click the launcher indicator to show the Application Launcher Dropdown:</label>
+     </div>
+     <nav class="navbar navbar-pf navbar-collapse">
+       <ul class="nav navbar-left">
+         <li>
+           <pf-application-launcher items="navigationItems" label="{{label}}" is-disabled="isDisabled" is-list="isList" hidden-icons="hiddenIcons"></pf-application-launcher>
+         </li>
+       </ul>
+     </nav>
+   </div>
+ </file>
+ <file name="script.js">
+   angular.module('patternfly.navigation').controller('applicationLauncherController', ['$scope',
+     function ($scope) {
+       $scope.navigationItems = [
+         {
+           title: "Recteque",
+           href: "#/ipsum/intellegam/recteque",
+           tooltip: "Launch the Function User Interface",
+           iconClass: "pficon-storage-domain"
+         },
+         {
+           title: "Suavitate",
+           href: "#/ipsum/intellegam/suavitate",
+           tooltip: "Launch the Function User Interface",
+           iconClass: "pficon-build"
+         },
+         {
+           title: "Lorem",
+           href: "#/ipsum/intellegam/lorem",
+           tooltip: "Launch the Function User Interface",
+           iconClass: "pficon-domain"
+         },
+         {
+           title: "Home",
+           href: "#/ipsum/intellegam/home",
+           tooltip: "Launch the Function User Interface",
+           iconClass: "pficon-home"
+         }
+       ];
+
+       $scope.label = 'Application Launcher';
+       $scope.isDisabled = false;
+       $scope.isList = false;
+       $scope.hiddenIcons = false;
+     }]);
+ </file>
+ </example>
+ */
+angular.module('patternfly.navigation').component('pfApplicationLauncher', {
+  bindings: {
+    items: '<',
+    label: '@?',
+    isDisabled: '<?',
+    isList: '<?',
+    hiddenIcons: '<?'
+  },
+  templateUrl: 'navigation/application-launcher.html',
+  controller: function ($scope) {
+    'use strict';
+    var ctrl = this;
+
+    ctrl.$id = $scope.$id;
+  }
+});
+

--- a/src/navigation/application-launcher.html
+++ b/src/navigation/application-launcher.html
@@ -1,0 +1,25 @@
+<div>
+  <div class="applauncher-pf dropdown dropdown-kebab-pf" ng-class="{'applauncher-pf-block-list': !$ctrl.isList}"
+       uib-dropdown
+       uib-keyboard-nav="true">
+    <a id="domain-switcher-{{$ctrl.$id}}" class="dropdown-toggle drawer-pf-trigger-icon" uib-dropdown-toggle ng-class="{'disabled': $ctrl.isDisabled || !$ctrl.items.length}" href>
+      <i class="fa fa-th applauncher-pf-icon" aria-hidden="true"></i>
+      <span class="applauncher-pf-title">
+        {{$ctrl.label || 'Application Launcher'}}
+        <span class="caret" aria-hidden="true"></span>
+      </span>
+    </a>
+    <ul class="dropdown-menu dropdown-menu-right"
+        uib-dropdown-menu
+        role="menu"
+        aria-labelledby="domain-switcher-{{$ctrl.$id}}">
+      <li class="applauncher-pf-item" role="menuitem" ng-repeat="item in $ctrl.items">
+        <a class="applauncher-pf-link" ng-href="{{item.href}}" target="{{item.target || '_blank'}}" title="{{item.tooltip}}">
+          <i class="applauncher-pf-link-icon pficon" ng-class="item.iconClass" ng-if="!$ctrl.hiddenIcons" aria-hidden="true"></i>
+          <span class="applauncher-pf-link-title">{{item.title}}</span>
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+

--- a/test/navigation/application-launcher.spec.js
+++ b/test/navigation/application-launcher.spec.js
@@ -1,0 +1,84 @@
+describe('Component:  pfApplicationLauncher', function () {
+
+  var $scope;
+  var $compile;
+  var element;
+  var isolateScope;
+
+  // load the controller's module
+  beforeEach(function () {
+    module('patternfly.navigation', 'patternfly.utils', 'navigation/application-launcher.html');
+  });
+
+  beforeEach(inject(function (_$compile_, _$rootScope_) {
+    $compile = _$compile_;
+    $scope = _$rootScope_;
+  }));
+
+  var compileHTML = function (markup, scope) {
+    element = angular.element(markup);
+    $compile(element)(scope);
+
+    scope.$digest();
+    isolateScope = element.isolateScope();
+  };
+
+  beforeEach(function () {
+    $scope.sites = [
+      {
+        title: "Recteque",
+        href: "#/ipsum/intellegam/recteque",
+        tooltip: "Total number of error items",
+        iconClass: ""
+      },
+      {
+        title: "Suavitate",
+        href: "#/ipsum/intellegam/suavitate",
+        tooltip: "Total number of items",
+        iconClass: ""
+      }
+    ];
+  });
+
+  it('should have menu items', function () {
+    var htmlTmp = '<pf-application-launcher items="sites" label="" is-disabled="false" is-list="false"></div>';
+    compileHTML(htmlTmp, $scope);
+
+    var content = element.find('[role="menuitem"]');
+    expect(content.length).toBe(2);
+  });
+
+  it('should have a custom label', function () {
+    var htmlTmp = '<pf-application-launcher items="sites" label="Product Launcher" is-disabled="false" is-list="false" hidden-icons="false"></div>';
+    compileHTML(htmlTmp, $scope);
+
+    var content = element.find('[id*="domain-switcher"]').text();
+    expect(content).toContain('Product Launcher');
+  });
+
+  it('should be disabled', function () {
+    var htmlTmp = '<pf-application-launcher items="sites" label="" is-disabled="true" is-list="false" hidden-icons="false"></div>';
+    compileHTML(htmlTmp, $scope);
+
+    var content = element.find('[id*="domain-switcher"].disabled');
+    expect(content.length).toBe(1);
+  });
+
+  it('should be displayed as a list', function () {
+    var htmlTmp = '<pf-application-launcher items="sites" label="" is-disabled="false" is-list="true" hidden-icons="false"></div>';
+    compileHTML(htmlTmp, $scope);
+
+    var content = element.find('.applauncher-pf-block-list');
+    expect(content.length).toBe(0);
+  });
+
+  it('should have hidden application icons', function () {
+    var htmlTmp = '<pf-application-launcher items="sites" label="" is-disabled="false" is-list="true" hidden-icons="true"></div>';
+    compileHTML(htmlTmp, $scope);
+
+    var content = element.find('.applauncher-pf-link-icon');
+    expect(content.length).toBe(0);
+  });
+
+});
+


### PR DESCRIPTION
Application Launcher Component

### Question

Do we need a base PatternFly 4.x styling PR? Regardless, going ahead and porting it over as it's currently making use of CSS/Styling from base PatternFly 3.x, PR pending: 

- https://github.com/patternfly/patternfly/pull/632

Samples

- https://rawgit.com/cdcabrera/patternfly/Feature-AppLauncher-3x-dist/dist/tests/application-launcher-nav.html




@dtaylor113 @jeff-phillips-18 @serenamarie125