### PR TITLE
Prevents clipping of filter tooltip

### DIFF
--- a/src/filters/filter-fields.html
+++ b/src/filters/filter-fields.html
@@ -1,7 +1,8 @@
 <div class="filter-pf filter-fields">
   <div class="input-group form-group">
     <div uib-dropdown class="input-group-btn">
-      <button uib-dropdown-toggle type="button" class="btn btn-default filter-fields" uib-tooltip="Filter by" tooltip-placement="top">
+      <button uib-dropdown-toggle type="button" class="btn btn-default filter-fields"
+              uib-tooltip="Filter by" tooltip-placement="top" tooltip-append-to-body="true">
         {{currentField.title}}
         <span class="caret"></span>
       </button>


### PR DESCRIPTION
Appends filter tooltip to body, this change will benefit any instance when the filter input group is placed on the edges of a view. 

### (an example) After, top left toolbar
![screenshot from 2017-04-28 12-01-17](https://cloud.githubusercontent.com/assets/6640236/25536993/bace526e-2c0a-11e7-86dc-fb75da917d7a.png)

### (an example) Before, top left toolbar
![screenshot from 2017-04-28 12-02-38](https://cloud.githubusercontent.com/assets/6640236/25536996/c1b88086-2c0a-11e7-99e8-1bfa9c3366f8.png)
