### PR TITLE
Add ability to hide sidebar and/or header in pfWizard

### DIFF
--- a/src/wizard/wizard-buttons.js
+++ b/src/wizard/wizard-buttons.js
@@ -5,17 +5,32 @@
       .directive(action, function () {
         return {
           restrict: 'A',
-          require: '^pf-wizard',
           scope: {
             callback: "=?"
           },
-          link: function ($scope, $element, $attrs, wizard) {
+          controller: function ($scope) {
+            var findWizard = function (scope) {
+              var wizard;
+
+              if (scope) {
+                if (angular.isDefined(scope.wizard)) {
+                  wizard = scope.wizard;
+                } else {
+                  wizard = findWizard(scope.$parent);
+                }
+              }
+
+              return wizard;
+            };
+            $scope.wizard = findWizard($scope);
+          },
+          link: function ($scope, $element, $attrs) {
             $element.on("click", function (e) {
               e.preventDefault();
               $scope.$apply(function () {
                 // scope apply in button module
                 $scope.$eval($attrs[action]);
-                wizard[action.replace("pfWiz", "").toLowerCase()]($scope.callback);
+                $scope.wizard[action.replace("pfWiz", "").toLowerCase()]($scope.callback);
               });
             });
           }

--- a/src/wizard/wizard-step-directive.js
+++ b/src/wizard/wizard-step-directive.js
@@ -47,7 +47,6 @@ angular.module('patternfly.wizard').directive('pfWizardStep', function () {
       showReviewDetails: '@?',
       reviewTemplate: '@?'
     },
-    require: '^pf-wizard',
     templateUrl: 'wizard/wizard-step.html',
     controller: function ($scope, $timeout) {
       var firstRun = true;
@@ -113,8 +112,23 @@ angular.module('patternfly.wizard').directive('pfWizardStep', function () {
         return foundStep;
       };
 
+      var findWizard = function (scope) {
+        var wizard;
+        if (scope) {
+          if (angular.isDefined(scope.wizard)) {
+            wizard = scope.wizard;
+          } else {
+            wizard = findWizard(scope.$parent);
+          }
+        }
+
+        return wizard;
+      };
+
       $scope.steps = [];
       $scope.context = {};
+      $scope.wizard = findWizard($scope.$parent);
+      this.wizard = $scope.wizard;
       this.context = $scope.context;
 
       if (angular.isUndefined($scope.nextEnabled)) {
@@ -328,6 +342,9 @@ angular.module('patternfly.wizard').directive('pfWizardStep', function () {
         $scope.goTo(stepTo);
       };
 
+      // Provide wizard step controls to sub-steps
+      $scope.wizardStep = this;
+
       // Method used for next button within step
       $scope.next = function (callback) {
         var enabledSteps = $scope.getEnabledSteps();
@@ -387,14 +404,13 @@ angular.module('patternfly.wizard').directive('pfWizardStep', function () {
         };
       }
     },
-    link: function ($scope, $element, $attrs, wizard) {
+    link: function ($scope, $element, $attrs) {
       $scope.$watch($attrs.ngShow, function (value) {
-        $scope.pageNumber = wizard.getStepNumber($scope);
+        $scope.pageNumber = $scope.wizard.getStepNumber($scope);
       });
       $scope.title =  $scope.stepTitle;
-      $scope.contentStyle = wizard.contentStyle;
-      wizard.addStep($scope);
-      $scope.wizard = wizard;
+      $scope.contentStyle = $scope.wizard.contentStyle;
+      $scope.wizard.addStep($scope);
     }
   };
 });

--- a/src/wizard/wizard-step.html
+++ b/src/wizard/wizard-step.html
@@ -1,5 +1,5 @@
 <section ng-show="selected" ng-class="{current: selected, done: completed}">
-  <div class="wizard-pf-sidebar" ng-style="contentStyle" ng-if="substeps === true">
+  <div ng-if="!wizard.hideSidebar" class="wizard-pf-sidebar" ng-style="contentStyle" ng-if="substeps === true">
     <ul class="list-group">
       <li class="list-group-item" ng-class="{active: step.selected}" ng-repeat="step in getEnabledSteps()">
         <a ng-click="stepClick(step)">
@@ -9,7 +9,7 @@
       </li>
     </ul>
   </div>
-  <div class="wizard-pf-main" ng-class="{'wizard-pf-singlestep': !substeps}" ng-style="contentStyle">
+  <div class="wizard-pf-main" ng-class="{'wizard-pf-singlestep': !substeps || hideSidebar}" ng-style="contentStyle">
     <div class="wizard-pf-contents" ng-transclude></div>
   </div>
 </section>

--- a/src/wizard/wizard-substep-directive.js
+++ b/src/wizard/wizard-substep-directive.js
@@ -39,9 +39,24 @@ angular.module('patternfly.wizard').directive('pfWizardSubstep', function () {
       showReviewDetails: '@?',
       reviewTemplate: '@?'
     },
-    require: '^pf-wizard-step',
     templateUrl: 'wizard/wizard-substep.html',
     controller: function ($scope) {
+      var findWizardStep = function (scope) {
+        var wizardStep;
+
+        if (scope) {
+          if (angular.isDefined(scope.wizardStep)) {
+            wizardStep = scope.wizardStep;
+          } else {
+            wizardStep = findWizardStep(scope.$parent);
+          }
+        }
+
+        return wizardStep;
+      };
+
+      $scope.wizardStep = findWizardStep($scope);
+
       if (angular.isUndefined($scope.nextEnabled)) {
         $scope.nextEnabled = true;
       }
@@ -74,9 +89,9 @@ angular.module('patternfly.wizard').directive('pfWizardSubstep', function () {
       };
 
     },
-    link: function ($scope, $element, $attrs, step) {
+    link: function ($scope, $element, $attrs) {
       $scope.title = $scope.stepTitle;
-      step.addStep($scope);
+      $scope.wizardStep.addStep($scope);
     }
   };
 });

--- a/src/wizard/wizard.html
+++ b/src/wizard/wizard.html
@@ -1,5 +1,5 @@
 <div>
-  <div class="modal-header">
+  <div class="modal-header" ng-if="!hideHeader">
     <button type="button" class="close wizard-pf-dismiss" aria-label="Close" ng-click="onCancel()" ng-if="!embedInPage">
       <span aria-hidden="true">&times;</span>
     </button>
@@ -10,7 +10,10 @@
     <div class="wizard-pf-steps" ng-class="{'invisible': !wizardReady}">
       <ul class="wizard-pf-steps-indicator" ng-if="!hideIndicators" ng-class="{'invisible': !wizardReady}">
         <li class="wizard-pf-step" ng-class="{active: step.selected}" ng-repeat="step in getEnabledSteps()" data-tabgroup="{{$index }}">
-          <a ng-click="stepClick(step)"><span class="wizard-pf-step-number">{{$index + 1}}</span><span class="wizard-pf-step-title">{{step.title}}</span></a>
+          <a ng-click="stepClick(step)" ng-class="{'disabled': !allowStepIndicatorClick(step)}">
+            <span class="wizard-pf-step-number">{{$index + 1}}</span>
+            <span class="wizard-pf-step-title">{{step.title}}</span>
+          </a>
         </li>
       </ul>
     </div>

--- a/test/wizard/wizard-container-hidden.html
+++ b/test/wizard/wizard-container-hidden.html
@@ -1,0 +1,40 @@
+<div pf-wizard title="Wizard Title"
+  wizard-ready="deployReady"
+  on-finish="finishedWizard()"
+  on-cancel="cancelDeploymentWizard()"
+  next-title="nextButtonTitle"
+  next-callback="nextCallback"
+  back-callback="backCallback"
+  current-step="currentStep"
+  hide-indicators="hideIndicators"
+  wizard-done="deployComplete || deployInProgress"
+  loading-secondary-information="secondaryLoadInformation">
+    <div pf-wizard-step step-title="First Step" substeps="true" step-id="details" step-priority="0" show-review="true" show-review-details="true">
+      <div ng-include="'test/wizard/detail-page.html'">
+      </div>
+      <div pf-wizard-substep step-title="Details - Extra" next-enabled="true" step-id="details-extra" step-priority="1" show-review="true" show-review-details="true" review-template="test/wizard/review-second-template.html">
+        <form class="form-horizontal">
+          <div pf-form-group pf-label="Lorem" required>
+            <input id="new-lorem" name="lorem" ng-model="data.lorem" type="text" required/>
+          </div>
+          <div pf-form-group pf-label="Ipsum">
+            <input id="new-ipsum" name="ipsum" ng-model="data.ipsum" type="text" />
+          </div>
+        </form>
+      </div>
+    </div>
+    <div pf-wizard-step step-title="Second Step" substeps="false" step-id="configuration" step-priority="1" show-review="true" review-template="test/wizard/review-second-template.html" >
+      <form class="form-horizontal">
+        <div pf-form-group pf-label="Lorem">
+          <input id="new-lorem" name="lorem" ng-model="data.lorem" type="text"/>
+        </div>
+        <div pf-form-group pf-label="Ipsum">
+          <input id="new-ipsum" name="ipsum" ng-model="data.ipsum" type="text" />
+        </div>
+      </form>
+    </div>
+    <div pf-wizard-step step-title="Review" substeps="true" step-id="review" step-priority="2">
+      <div ng-include="'test/wizard/summary.html'"></div>
+      <div ng-include="'test/wizard/deployment.html'"></div>
+    </div>
+ </div>

--- a/test/wizard/wizard.spec.js
+++ b/test/wizard/wizard.spec.js
@@ -202,4 +202,24 @@ describe('Directive:  pfWizard', function () {
     var selectedSectionTitle = element.find('.wizard-pf-row section.current').attr("step-title");
     expect(selectedSectionTitle).not.toBe('Second Step');
   });
+
+  it('should hide the sidebar when set', function () {
+    var modalHtml = $templateCache.get('test/wizard/wizard-container-hidden.html');
+    element = compileHtml(modalHtml, $scope);
+    $scope.$digest();
+
+    var stepsIndicator = element.find('.wizard-pf-sidebar');
+
+    expect(stepsIndicator.length).toBe(0);
+  });
+
+  it('should hide the header when set', function () {
+    var modalHtml = $templateCache.get('test/wizard/wizard-container-hidden.html');
+    element = compileHtml(modalHtml, $scope);
+    $scope.$digest();
+
+    var header = element.find('.modal-header');
+
+    expect(header.length).toBe(0);
+  });
 });


### PR DESCRIPTION
This PR also:
    
-     Allows the prevCallback not to be set.
-     Adds disabled class to step indicators when the user cannot nav directly to the step
-     Allows the wizard to be included in typescript applications:
         The use of require ^ fails when being included in typescript so that
         has been removed and replaced by using scope to find the required

@cdcabrera