### PR TITLE
Wizard Enhancements

### DIFF
--- a/misc/examples.css
+++ b/misc/examples.css
@@ -130,3 +130,14 @@ hr {
 .dropdown-kebab-pf.red .btn-link {
   color: red;
 }
+
+.example-wizard-sidebar {
+  height: 500px;
+  max-height: 500px;
+  overflow-y: auto;
+}
+.example-wizard-step {
+  height: 500px;
+  max-height: 500px;
+  overflow-y: auto;
+}

--- a/src/wizard/wizard-buttons.js
+++ b/src/wizard/wizard-buttons.js
@@ -5,17 +5,32 @@
       .directive(action, function () {
         return {
           restrict: 'A',
-          require: '^pf-wizard',
           scope: {
             callback: "=?"
           },
-          link: function ($scope, $element, $attrs, wizard) {
+          controller: function ($scope) {
+            var findWizard = function (scope) {
+              var wizard;
+
+              if (scope) {
+                if (angular.isDefined(scope.wizard)) {
+                  wizard = scope.wizard;
+                } else {
+                  wizard = findWizard(scope.$parent);
+                }
+              }
+
+              return wizard;
+            };
+            $scope.wizard = findWizard($scope);
+          },
+          link: function ($scope, $element, $attrs) {
             $element.on("click", function (e) {
               e.preventDefault();
               $scope.$apply(function () {
                 // scope apply in button module
                 $scope.$eval($attrs[action]);
-                wizard[action.replace("pfWiz", "").toLowerCase()]($scope.callback);
+                $scope.wizard[action.replace("pfWiz", "").toLowerCase()]($scope.callback);
               });
             });
           }

--- a/src/wizard/wizard-directive.js
+++ b/src/wizard/wizard-directive.js
@@ -20,6 +20,12 @@
   *
   * @param {string} title The wizard title displayed in the header
   * @param {boolean=} hideIndicators  Hides the step indicators in the header of the wizard
+  * @param {boolean=} hideSidebar  Hides page navigation sidebar on the wizard pages
+  * @param {boolean=} hideHeader Optional value to hide the title bar. Default is false.
+  * @param {boolean=} hideBackButton Optional value to hide the back button, useful in 2 step wizards. Default is false.
+  * @param {string=} stepClass Optional CSS class to be given to the steps page container. Used for the sidebar panel as well unless a sidebarClass is provided.
+  * @param {string=} sidebarClass Optional CSS class to be give to the sidebar panel. Only used if the stepClass is also provided.
+  * @param {string=} contentHeight The height the wizard content should be set to. This is used ONLY if the stepClass is not given. This defaults to 300px if the property is not supplied.
   * @param {string=} currentStep The current step can be changed externally - this is the title of the step to switch the wizard to
   * @param {string=} cancelTitle The text to display on the cancel button
   * @param {string=} backTitle The text to display on the back button
@@ -32,7 +38,6 @@
   * @param {boolean=} wizardDone  Value that is set when the wizard is done
   * @param {string} loadingWizardTitle The text displayed when the wizard is loading
   * @param {string=} loadingSecondaryInformation Secondary descriptive information to display when the wizard is loading
-  * @param {string=} contentHeight The height the wizard content should be set to.  This defaults to 300px if the property is not supplied.
   * @param {boolean=} embedInPage Value that indicates wizard is embedded in a page (not a modal).  This moves the navigation buttons to the left hand side of the footer and removes the close button.
   *
   * @example
@@ -51,7 +56,8 @@
     next-callback="nextCallback"
     back-callback="backCallback"
     wizard-done="deployComplete || deployInProgress"
-    content-height="'600px'"
+    sidebar-class="example-wizard-sidebar"
+    step-class="example-wizard-step"
     loading-secondary-information="secondaryLoadInformation">
       <div pf-wizard-step step-title="First Step" substeps="true" step-id="details" step-priority="0" show-review="true" show-review-details="true">
         <div ng-include="'detail-page.html'">
@@ -305,6 +311,12 @@ angular.module('patternfly.wizard').directive('pfWizard', function ($window) {
     scope: {
       title: '@',
       hideIndicators: '=?',
+      hideSidebar: '@',
+      hideHeader: '@',
+      hideBackButton: '@',
+      sidebarClass: '@',
+      stepClass: '@',
+      contentHeight: '=?',
       currentStep: '=?',
       cancelTitle: '=?',
       backTitle: '=?',
@@ -317,7 +329,6 @@ angular.module('patternfly.wizard').directive('pfWizard', function ($window) {
       wizardDone: '=?',
       loadingWizardTitle: '=?',
       loadingSecondaryInformation: '=?',
-      contentHeight: '=?',
       embedInPage: '=?'
     },
     templateUrl: 'wizard/wizard.html',
@@ -388,21 +399,37 @@ angular.module('patternfly.wizard').directive('pfWizard', function ($window) {
       $scope.steps = [];
       $scope.context = {};
       this.context = $scope.context;
+      $scope.hideHeader = $scope.hideHeader === 'true';
+      this.hideSidebar = $scope.hideSidebar === 'true';
+      $scope.hideBaackButton = $scope.hideBackButton === 'true';
+
+      // If a step class is given use it for all steps
+      if (angular.isDefined($scope.stepClass)) {
+        this.stepClass = $scope.stepClass;
+
+        // If a sidebarClass is given, us it for sidebar panel, if not, apply the stepsClass to the sidebar panel
+        if (angular.isDefined($scope.sidebarClass)) {
+          this.sidebarClass = $scope.sidebarClass;
+        } else {
+          this.sidebarClass = $scope.stepClass;
+        }
+      } else {
+        // No step claass give, setup the content style to allow scrolling and a fixed height
+        if (angular.isUndefined($scope.contentHeight)) {
+          $scope.contentHeight = '300px';
+        }
+        this.contentHeight = $scope.contentHeight;
+        $scope.contentStyle = {
+          'height': $scope.contentHeight,
+          'max-height': $scope.contentHeight,
+          'overflow-y': 'auto'
+        };
+        this.contentStyle = $scope.contentStyle;
+      }
 
       if (angular.isUndefined($scope.wizardReady)) {
         $scope.wizardReady = true;
       }
-
-      if (angular.isUndefined($scope.contentHeight)) {
-        $scope.contentHeight = '300px';
-      }
-      this.contentHeight = $scope.contentHeight;
-      $scope.contentStyle = {
-        'height': $scope.contentHeight,
-        'max-height': $scope.contentHeight,
-        'overflow-y': 'auto'
-      };
-      this.contentStyle = $scope.contentStyle;
 
       $scope.nextEnabled = false;
       $scope.prevEnabled = false;
@@ -513,6 +540,14 @@ angular.module('patternfly.wizard').directive('pfWizard', function ($window) {
         }
       };
 
+      $scope.allowStepIndicatorClick = function (step) {
+        return step.allowClickNav &&
+          !$scope.wizardDone &&
+          $scope.selectedStep.okToNavAway &&
+          ($scope.selectedStep.nextEnabled || (step.stepPriority < $scope.selectedStep.stepPriority)) &&
+          ($scope.selectedStep.prevEnabled || (step.stepPriority > $scope.selectedStep.stepPriority));
+      };
+
       $scope.stepClick = function (step) {
         if (step.allowClickNav) {
           $scope.goTo(step, true);
@@ -602,13 +637,14 @@ angular.module('patternfly.wizard').directive('pfWizard', function ($window) {
         // Check if callback is a function
         if (angular.isFunction(callback)) {
           if (callback($scope.selectedStep)) {
-            if (index === enabledSteps.length - 1) {
-              this.finish();
-            } else {
+            if (index <= enabledSteps.length - 1) {
               // Go to the next step
               if (enabledSteps[index + 1].substeps) {
                 enabledSteps[index + 1].resetNav();
               }
+            } else {
+              this.finish();
+              return;
             }
           } else {
             return;
@@ -645,6 +681,12 @@ angular.module('patternfly.wizard').directive('pfWizard', function ($window) {
               $scope.goTo($scope.getEnabledSteps()[index - 1]);
             }
           }
+        } else {
+          if (index === 0) {
+            throw new Error("Can't go back. It's already in step 0");
+          } else {
+            $scope.goTo($scope.getEnabledSteps()[index - 1]);
+          }
         }
       };
 
@@ -673,6 +715,9 @@ angular.module('patternfly.wizard').directive('pfWizard', function ($window) {
         //go to first step
         this.goTo(0);
       };
+
+      // Provide wizard controls to steps and sub-steps
+      $scope.wizard = this;
     },
     link: function ($scope) {
       $scope.$watch('wizardReady', function () {

--- a/src/wizard/wizard-review-page-directive.js
+++ b/src/wizard/wizard-review-page-directive.js
@@ -17,9 +17,23 @@ angular.module('patternfly.wizard').directive('pfWizardReviewPage', function () 
       shown: '=',
       wizardData: "="
     },
-    require: '^pf-wizard',
     templateUrl: 'wizard/wizard-review-page.html',
     controller: function ($scope) {
+      var findWizard = function (scope) {
+        var wizard;
+        if (scope) {
+          if (angular.isDefined(scope.wizard)) {
+            wizard = scope.wizard;
+          } else {
+            wizard = findWizard(scope.$parent);
+          }
+        }
+
+        return wizard;
+      };
+
+      $scope.wizard = findWizard($scope.$parent);
+
       $scope.toggleShowReviewDetails = function (step) {
         if (step.showReviewDetails === true) {
           step.showReviewDetails = false;
@@ -38,10 +52,10 @@ angular.module('patternfly.wizard').directive('pfWizardReviewPage', function () 
         $scope.reviewSteps = wizard.getReviewSteps();
       };
     },
-    link: function ($scope, $element, $attrs, wizard) {
+    link: function ($scope, $element, $attrs) {
       $scope.$watch('shown', function (value) {
         if (value) {
-          $scope.updateReviewSteps(wizard);
+          $scope.updateReviewSteps($scope.wizard);
         }
       });
     }

--- a/src/wizard/wizard-step-directive.js
+++ b/src/wizard/wizard-step-directive.js
@@ -47,7 +47,6 @@ angular.module('patternfly.wizard').directive('pfWizardStep', function () {
       showReviewDetails: '@?',
       reviewTemplate: '@?'
     },
-    require: '^pf-wizard',
     templateUrl: 'wizard/wizard-step.html',
     controller: function ($scope, $timeout) {
       var firstRun = true;
@@ -113,8 +112,23 @@ angular.module('patternfly.wizard').directive('pfWizardStep', function () {
         return foundStep;
       };
 
+      var findWizard = function (scope) {
+        var wizard;
+        if (scope) {
+          if (angular.isDefined(scope.wizard)) {
+            wizard = scope.wizard;
+          } else {
+            wizard = findWizard(scope.$parent);
+          }
+        }
+
+        return wizard;
+      };
+
       $scope.steps = [];
       $scope.context = {};
+      $scope.wizard = findWizard($scope.$parent);
+      this.wizard = $scope.wizard;
       this.context = $scope.context;
 
       if (angular.isUndefined($scope.nextEnabled)) {
@@ -328,6 +342,9 @@ angular.module('patternfly.wizard').directive('pfWizardStep', function () {
         $scope.goTo(stepTo);
       };
 
+      // Provide wizard step controls to sub-steps
+      $scope.wizardStep = this;
+
       // Method used for next button within step
       $scope.next = function (callback) {
         var enabledSteps = $scope.getEnabledSteps();
@@ -387,14 +404,13 @@ angular.module('patternfly.wizard').directive('pfWizardStep', function () {
         };
       }
     },
-    link: function ($scope, $element, $attrs, wizard) {
+    link: function ($scope, $element, $attrs) {
       $scope.$watch($attrs.ngShow, function (value) {
-        $scope.pageNumber = wizard.getStepNumber($scope);
+        $scope.pageNumber = $scope.wizard.getStepNumber($scope);
       });
       $scope.title =  $scope.stepTitle;
-      $scope.contentStyle = wizard.contentStyle;
-      wizard.addStep($scope);
-      $scope.wizard = wizard;
+      $scope.contentStyle = $scope.wizard.contentStyle;
+      $scope.wizard.addStep($scope);
     }
   };
 });

--- a/src/wizard/wizard-step.html
+++ b/src/wizard/wizard-step.html
@@ -1,5 +1,5 @@
 <section ng-show="selected" ng-class="{current: selected, done: completed}">
-  <div class="wizard-pf-sidebar" ng-style="contentStyle" ng-if="substeps === true">
+  <div ng-if="!wizard.hideSidebar" class="wizard-pf-sidebar" ng-style="contentStyle"  ng-class="wizard.sidebarClass" ng-if="substeps === true">
     <ul class="list-group">
       <li class="list-group-item" ng-class="{active: step.selected}" ng-repeat="step in getEnabledSteps()">
         <a ng-click="stepClick(step)">
@@ -9,7 +9,7 @@
       </li>
     </ul>
   </div>
-  <div class="wizard-pf-main" ng-class="{'wizard-pf-singlestep': !substeps}" ng-style="contentStyle">
+  <div class="wizard-pf-main {{wizard.stepClass}}" ng-style="contentStyle"  ng-class="{'wizard-pf-singlestep': !substeps || wizard.hideSidebar}">
     <div class="wizard-pf-contents" ng-transclude></div>
   </div>
 </section>

--- a/src/wizard/wizard-substep-directive.js
+++ b/src/wizard/wizard-substep-directive.js
@@ -39,9 +39,24 @@ angular.module('patternfly.wizard').directive('pfWizardSubstep', function () {
       showReviewDetails: '@?',
       reviewTemplate: '@?'
     },
-    require: '^pf-wizard-step',
     templateUrl: 'wizard/wizard-substep.html',
     controller: function ($scope) {
+      var findWizardStep = function (scope) {
+        var wizardStep;
+
+        if (scope) {
+          if (angular.isDefined(scope.wizardStep)) {
+            wizardStep = scope.wizardStep;
+          } else {
+            wizardStep = findWizardStep(scope.$parent);
+          }
+        }
+
+        return wizardStep;
+      };
+
+      $scope.wizardStep = findWizardStep($scope);
+
       if (angular.isUndefined($scope.nextEnabled)) {
         $scope.nextEnabled = true;
       }
@@ -74,9 +89,9 @@ angular.module('patternfly.wizard').directive('pfWizardSubstep', function () {
       };
 
     },
-    link: function ($scope, $element, $attrs, step) {
+    link: function ($scope, $element, $attrs) {
       $scope.title = $scope.stepTitle;
-      step.addStep($scope);
+      $scope.wizardStep.addStep($scope);
     }
   };
 });

--- a/src/wizard/wizard.html
+++ b/src/wizard/wizard.html
@@ -1,5 +1,5 @@
 <div>
-  <div class="modal-header">
+  <div class="modal-header" ng-if="!hideHeader">
     <button type="button" class="close wizard-pf-dismiss" aria-label="Close" ng-click="onCancel()" ng-if="!embedInPage">
       <span aria-hidden="true">&times;</span>
     </button>
@@ -10,7 +10,10 @@
     <div class="wizard-pf-steps" ng-class="{'invisible': !wizardReady}">
       <ul class="wizard-pf-steps-indicator" ng-if="!hideIndicators" ng-class="{'invisible': !wizardReady}">
         <li class="wizard-pf-step" ng-class="{active: step.selected}" ng-repeat="step in getEnabledSteps()" data-tabgroup="{{$index }}">
-          <a ng-click="stepClick(step)"><span class="wizard-pf-step-number">{{$index + 1}}</span><span class="wizard-pf-step-title">{{step.title}}</span></a>
+          <a ng-click="stepClick(step)" ng-class="{'disabled': !allowStepIndicatorClick(step)}">
+            <span class="wizard-pf-step-number">{{$index + 1}}</span>
+            <span class="wizard-pf-step-title">{{step.title}}</span>
+          </a>
         </li>
       </ul>
     </div>
@@ -27,7 +30,7 @@
   </div>
   <div class="modal-footer wizard-pf-footer wizard-pf-position-override" ng-class="{'wizard-pf-footer-inline': embedInPage}">
     <button pf-wiz-cancel class="btn btn-default btn-cancel wizard-pf-cancel" ng-disabled="wizardDone" ng-click="onCancel()" ng-if="!embedInPage">{{cancelTitle}}</button>
-    <div class="tooltip-wrapper" uib-tooltip="{{prevTooltip}}" tooltip-placement="left">
+    <div ng-if="!hideBackButton" class="tooltip-wrapper" uib-tooltip="{{prevTooltip}}" tooltip-placement="left">
       <button id="backButton" pf-wiz-previous class="btn btn-default" ng-disabled="!wizardReady || wizardDone || !prevEnabled || firstStep"
               callback="backCallback">
         <span class="i fa fa-angular-left"></span>

--- a/styles/angular-patternfly.css
+++ b/styles/angular-patternfly.css
@@ -470,3 +470,13 @@ accordion > .panel-group .panel-open .panel-title > a:before {
 .pf-expand-placeholder {
   margin-right: 15px;
 }
+
+.wizard-pf-steps-indicator li a.disabled {
+  cursor: default;
+}
+
+.wizard-pf-steps-indicator li a.disabled:hover .wizard-pf-step-number {
+  background-color: #fff;
+  border-color: #bbb;
+  color: #bbb;
+}

--- a/test/wizard/wizard-container-hidden.html
+++ b/test/wizard/wizard-container-hidden.html
@@ -7,6 +7,8 @@
   back-callback="backCallback"
   current-step="currentStep"
   hide-indicators="hideIndicators"
+  hide-sidebar="true"
+  hide-header="true"
   wizard-done="deployComplete || deployInProgress"
   loading-secondary-information="secondaryLoadInformation">
   <div ng-include="'test/wizard/wizard-test-steps.html'"></div>

--- a/test/wizard/wizard-container-hide-back.html
+++ b/test/wizard/wizard-container-hide-back.html
@@ -1,4 +1,5 @@
 <div pf-wizard title="Wizard Title"
+  step-class="test-step-class"
   wizard-ready="deployReady"
   on-finish="finishedWizard()"
   on-cancel="cancelDeploymentWizard()"
@@ -6,7 +7,7 @@
   next-callback="nextCallback"
   back-callback="backCallback"
   current-step="currentStep"
-  hide-indicators="hideIndicators"
+  hide-back-button="true"
   wizard-done="deployComplete || deployInProgress"
   loading-secondary-information="secondaryLoadInformation">
   <div ng-include="'test/wizard/wizard-test-steps.html'"></div>

--- a/test/wizard/wizard-container-step-class.html
+++ b/test/wizard/wizard-container-step-class.html
@@ -1,4 +1,5 @@
 <div pf-wizard title="Wizard Title"
+  step-class="test-step-class"
   wizard-ready="deployReady"
   on-finish="finishedWizard()"
   on-cancel="cancelDeploymentWizard()"

--- a/test/wizard/wizard-container-step-side-class.html
+++ b/test/wizard/wizard-container-step-side-class.html
@@ -1,4 +1,6 @@
 <div pf-wizard title="Wizard Title"
+  step-class="test-step-class"
+  sidebar-class="test-sidebar-class"
   wizard-ready="deployReady"
   on-finish="finishedWizard()"
   on-cancel="cancelDeploymentWizard()"

--- a/test/wizard/wizard-test-steps.html
+++ b/test/wizard/wizard-test-steps.html
@@ -1,0 +1,28 @@
+<div pf-wizard-step step-title="First Step" substeps="true" step-id="details" step-priority="0" show-review="true" show-review-details="true">
+  <div ng-include="'test/wizard/detail-page.html'">
+  </div>
+  <div pf-wizard-substep step-title="Details - Extra" next-enabled="true" step-id="details-extra" step-priority="1" show-review="true" show-review-details="true" review-template="test/wizard/review-second-template.html">
+    <form class="form-horizontal">
+      <div pf-form-group pf-label="Lorem" required>
+        <input id="new-lorem" name="lorem" ng-model="data.lorem" type="text" required/>
+      </div>
+      <div pf-form-group pf-label="Ipsum">
+        <input id="new-ipsum" name="ipsum" ng-model="data.ipsum" type="text" />
+      </div>
+    </form>
+  </div>
+</div>
+<div pf-wizard-step step-title="Second Step" substeps="false" step-id="configuration" step-priority="1" show-review="true" review-template="test/wizard/review-second-template.html" >
+  <form class="form-horizontal">
+    <div pf-form-group pf-label="Lorem">
+      <input id="new-lorem" name="lorem" ng-model="data.lorem" type="text"/>
+    </div>
+    <div pf-form-group pf-label="Ipsum">
+      <input id="new-ipsum" name="ipsum" ng-model="data.ipsum" type="text" />
+    </div>
+  </form>
+</div>
+<div pf-wizard-step step-title="Review" substeps="true" step-id="review" step-priority="2">
+  <div ng-include="'test/wizard/summary.html'"></div>
+  <div ng-include="'test/wizard/deployment.html'"></div>
+</div>

--- a/test/wizard/wizard.spec.js
+++ b/test/wizard/wizard.spec.js
@@ -15,12 +15,17 @@ describe('Directive:  pfWizard', function () {
     'wizard/wizard-review-page.html',
     'wizard/wizard.html',
     'form/form-group/form-group.html',
+    'test/wizard/wizard-test-steps.html',
     'test/wizard/deployment.html',
     'test/wizard/detail-page.html',
     'test/wizard/review-second-template.html',
     'test/wizard/review-template.html',
     'test/wizard/summary.html',
-    'test/wizard/wizard-container.html'
+    'test/wizard/wizard-container.html',
+    'test/wizard/wizard-container-hidden.html',
+    'test/wizard/wizard-container-step-class.html',
+    'test/wizard/wizard-container-step-side-class.html',
+    'test/wizard/wizard-container-hide-back.html'
   ));
 
   beforeEach(inject(function (_$compile_, _$rootScope_, _$httpBackend_, _$templateCache_, _$timeout_) {
@@ -92,18 +97,21 @@ describe('Directive:  pfWizard', function () {
     initializeWizard();
   };
 
-  beforeEach(function () {
+  var setupWizard = function(wizardHtml) {
     setupWizardScope();
-    var modalHtml = $templateCache.get('test/wizard/wizard-container.html');
+
+    var modalHtml = $templateCache.get(wizardHtml);
     element = compileHtml(modalHtml, $scope);
     $scope.$digest();
 
     // there are two dependent timeouts in the wizard that need to be flushed
-    $timeout.flush();
-    $timeout.flush();
-  });
+//    $timeout.flush();
+//    $timeout.flush();
+  };
 
   it('should dispatch the cancel event on the close button click', function () {
+    setupWizard('test/wizard/wizard-container.html');
+
     var closeButton = element.find('.close');
     spyOn($rootScope, '$emit');
     eventFire(closeButton[0], 'click');
@@ -112,11 +120,13 @@ describe('Directive:  pfWizard', function () {
   });
 
   it('should have three step indicators in the header', function () {
+    setupWizard('test/wizard/wizard-container.html');
     var stepsIndicator = element.find('.wizard-pf-steps .wizard-pf-step');
     expect(stepsIndicator.length).toBe(3);
   });
 
   it('should have two sections in the left-hand pane', function () {
+    setupWizard('test/wizard/wizard-container.html');
     var stepsIndicator = element.find('.wizard-pf-sidebar .list-group-item');
     var hiddenStepsIndicator = element.find('section.ng-hide .wizard-pf-sidebar .list-group-item');
 
@@ -125,11 +135,17 @@ describe('Directive:  pfWizard', function () {
   });
 
   it('should have disabled the next button', function () {
+    setupWizard('test/wizard/wizard-container.html');
+    $timeout.flush();
+    $timeout.flush();
     var checkDisabled = element.find('.wizard-pf-next').attr('disabled');
     expect(checkDisabled).toBe('disabled');
   });
 
   it('should have enabled the next button after input and allowed navigation', function () {
+    setupWizard('test/wizard/wizard-container.html');
+    $timeout.flush();
+    $timeout.flush();
     var nextButton = element.find('.wizard-pf-next');
     var nameBox = element.find('#new-name');
     nameBox.val('test').triggerHandler('input');
@@ -139,7 +155,10 @@ describe('Directive:  pfWizard', function () {
   });
 
   it('should have allowed moving back to first page after input and allowed navigation', function () {
-    var nextButton = element.find('.wizard-pf-next');
+    setupWizard('test/wizard/wizard-container.html');
+    $timeout.flush();
+    $timeout.flush();
+     var nextButton = element.find('.wizard-pf-next');
     var nameBox = element.find('#new-name');
     nameBox.val('test').triggerHandler('input');
     eventFire(nextButton[0], 'click');
@@ -153,6 +172,7 @@ describe('Directive:  pfWizard', function () {
   });
 
   it('should have allowed navigation to review page', function () {
+    setupWizard('test/wizard/wizard-container.html');
     var nextButton = element.find('.wizard-pf-next');
     var nameBox = element.find('#new-name');
     nameBox.val('test').triggerHandler('input');
@@ -168,8 +188,8 @@ describe('Directive:  pfWizard', function () {
   });
 
   it('should hide indicators if the property is set', function () {
-    var modalHtml = $templateCache.get('test/wizard/wizard-container.html');
-    element = compileHtml(modalHtml, $scope);
+    setupWizard('test/wizard/wizard-container.html');
+
     $scope.hideIndicators = true;
     $scope.$digest();
     var indicators = element.find('.wizard-pf-steps');
@@ -183,6 +203,7 @@ describe('Directive:  pfWizard', function () {
   });
 
   it('clicking indicators should navigate wizard', function () {
+    setupWizard('test/wizard/wizard-container.html');
     var indicator = element.find('.wizard-pf-steps .wizard-pf-step a');
     var nameBox = element.find('#new-name');
     nameBox.val('test').triggerHandler('input');
@@ -195,11 +216,59 @@ describe('Directive:  pfWizard', function () {
   });
 
   it('clicking indicators should not navigate wizard if prevented from doing so', function () {
+    setupWizard('test/wizard/wizard-container.html');
     var indicator = element.find('.wizard-pf-steps .wizard-pf-step a');
     eventFire(indicator[1], 'click');
     $scope.$digest();
 
     var selectedSectionTitle = element.find('.wizard-pf-row section.current').attr("step-title");
     expect(selectedSectionTitle).not.toBe('Second Step');
+  });
+
+  it('should hide the sidebar when set', function () {
+    setupWizard('test/wizard/wizard-container-hidden.html');
+
+    var sidebar = element.find('.wizard-pf-sidebar');
+
+    expect(sidebar.length).toBe(0);
+  });
+
+  it('should hide the header when set', function () {
+    setupWizard('test/wizard/wizard-container-hidden.html');
+    var header = element.find('.modal-header');
+
+    expect(header.length).toBe(0);
+  });
+
+  it('should set the step class when given', function () {
+    setupWizard('test/wizard/wizard-container-step-class.html');
+
+    var mainStepPanel = element.find('.wizard-pf-main');
+    expect(mainStepPanel.length).toBe(3);
+
+    var sidebarPanel = element.find('.wizard-pf-sidebar.test-step-class');
+    expect(sidebarPanel.length).toBe(3);
+  });
+
+  it('should set the sidebar class when given', function () {
+    setupWizard('test/wizard/wizard-container-step-side-class.html');
+
+    var mainStepPanel = element.find('.wizard-pf-main');
+    expect(mainStepPanel.length).toBe(3);
+
+    var sidebarPanel = element.find('.wizard-pf-sidebar.test-step-class');
+    expect(sidebarPanel.length).toBe(0);
+
+    var sidebarPanel = element.find('.wizard-pf-sidebar.test-sidebar-class');
+    expect(sidebarPanel.length).toBe(3);
+  });
+
+  it('should hide the back button when specified', function () {
+    setupWizard('test/wizard/wizard-container-hide-back.html');
+    $timeout.flush();
+    $timeout.flush();
+
+    var backButton = element.find('.wizard-pf-footer #backButton');
+    expect(backButton.length).toBe(0);
   });
 });


### PR DESCRIPTION
- allow hiding header
- allow hiding the sidebar navigation panel
- allow hiding the back button (useful in 2 page wizards)
- add disabled class to step indicators when disabled
- allow adding a class to the sidebar and step panels rather than setting a height
- allow use of the wizard from typescript bases applications:
  The use of require ^ fails when being included in typescript so that has been removed and replaced by using scope to find the required Wizard/WizardStep controllers.

@jwforres @spadgett @rhamilto 