### PR TITLE
Wizard Enhancements (4.x)

### DIFF
--- a/misc/examples.css
+++ b/misc/examples.css
@@ -138,3 +138,14 @@ hr {
   overflow: auto;
   width: 99%;
 }
+
+.example-wizard-sidebar {
+  height: 500px;
+  max-height: 500px;
+  overflow-y: auto;
+}
+.example-wizard-step {
+  height: 500px;
+  max-height: 500px;
+  overflow-y: auto;
+}

--- a/src/wizard/wizard-buttons.js
+++ b/src/wizard/wizard-buttons.js
@@ -1,31 +1,48 @@
 (function () {
   'use strict';
-  function pfWizardButtonDirective (action) {
+  function pfWizardButtonComponent (action) {
     angular.module('patternfly.wizard')
-      .directive(action, function () {
-        return {
-          restrict: 'A',
-          require: '^pfWizard',
-          scope: {
-            callback: "=?"
-          },
-          link: function ($scope, $element, $attrs, wizard) {
+      .component(action, {
+        bindings: {
+          callback: "=?"
+        },
+        controller: function ($element, $scope) {
+          var ctrl = this;
+
+          var findWizard = function (scope) {
+            var wizard;
+
+            if (scope) {
+              if (angular.isDefined(scope.wizard)) {
+                wizard = scope.wizard;
+              } else {
+                wizard = findWizard(scope.$parent);
+              }
+            }
+
+            return wizard;
+          };
+
+          ctrl.$onInit = function () {
+            $scope.wizard = findWizard($scope);
+          };
+
+          ctrl.$postLink = function () {
             $element.on("click", function (e) {
               e.preventDefault();
               $scope.$apply(function () {
                 // scope apply in button module
-                $scope.$eval($attrs[action]);
-                wizard[action.replace("pfWiz", "").toLowerCase()]($scope.callback);
+                $scope.wizard[action.replace("pfWiz", "").toLowerCase()]($scope.callback);
               });
             });
-          }
-        };
+          };
+        }
       });
   }
 
-  pfWizardButtonDirective('pfWizNext');
-  pfWizardButtonDirective('pfWizPrevious');
-  pfWizardButtonDirective('pfWizFinish');
-  pfWizardButtonDirective('pfWizCancel');
-  pfWizardButtonDirective('pfWizReset');
+  pfWizardButtonComponent('pfWizNext');
+  pfWizardButtonComponent('pfWizPrevious');
+  pfWizardButtonComponent('pfWizFinish');
+  pfWizardButtonComponent('pfWizCancel');
+  pfWizardButtonComponent('pfWizReset');
 })();

--- a/src/wizard/wizard-review-page.component.js
+++ b/src/wizard/wizard-review-page.component.js
@@ -15,16 +15,27 @@ angular.module('patternfly.wizard').component('pfWizardReviewPage', {
     shown: '<',
     wizardData: "<"
   },
-  require: {
-    wizard: '^pfWizard'
-  },
   templateUrl: 'wizard/wizard-review-page.html',
-  controller: function () {
+  controller: function ($scope) {
     'use strict';
     var ctrl = this;
 
+    var findWizard = function (scope) {
+      var wizard;
+      if (scope) {
+        if (angular.isDefined(scope.wizard)) {
+          wizard = scope.wizard;
+        } else {
+          wizard = findWizard(scope.$parent);
+        }
+      }
+
+      return wizard;
+    };
+
     ctrl.$onInit = function () {
       ctrl.reviewSteps = [];
+      ctrl.wizard = findWizard($scope.$parent);
     };
 
     ctrl.$onChanges = function (changesObj) {

--- a/src/wizard/wizard-step.html
+++ b/src/wizard/wizard-step.html
@@ -1,5 +1,5 @@
 <section ng-show="$ctrl.selected" ng-class="{current: $ctrl.selected, done: $ctrl.completed}">
-  <div class="wizard-pf-sidebar" ng-style="$ctrl.contentStyle" ng-if="$ctrl.substeps === true">
+  <div ng-if="!$ctrl.wizard.hideSidebar" class="wizard-pf-sidebar" ng-style="$ctrl.contentStyle"  ng-class="$ctrl.wizard.sidebarClass" ng-if="$ctrl.substeps === true">
     <ul class="list-group">
       <li class="list-group-item" ng-class="{active: step.selected}" ng-repeat="step in $ctrl.getEnabledSteps()">
         <a ng-click="$ctrl.stepClick(step)">
@@ -9,7 +9,7 @@
       </li>
     </ul>
   </div>
-  <div class="wizard-pf-main" ng-class="{'wizard-pf-singlestep': !$ctrl.substeps}" ng-style="$ctrl.contentStyle">
+  <div class="wizard-pf-main {{$ctrl.wizard.stepClass}}" ng-class="{'wizard-pf-singlestep': !$ctrl.substeps || $ctrl.wizard.hideSidebar}" ng-style="$ctrl.contentStyle">
     <div class="wizard-pf-contents" ng-transclude></div>
   </div>
 </section>

--- a/src/wizard/wizard-substep.component.js
+++ b/src/wizard/wizard-substep.component.js
@@ -36,15 +36,28 @@ angular.module('patternfly.wizard').component('pfWizardSubstep', {
     showReviewDetails: '@?',
     reviewTemplate: '@?'
   },
-  require: {
-    step: '^pfWizardStep'
-  },
   templateUrl: 'wizard/wizard-substep.html',
-  controller: function () {
+  controller: function ($scope) {
     'use strict';
     var ctrl = this;
 
     ctrl.$onInit = function () {
+      var findWizardStep = function (scope) {
+        var wizardStep;
+
+        if (scope) {
+          if (angular.isDefined(scope.wizardStep)) {
+            wizardStep = scope.wizardStep;
+          } else {
+            wizardStep = findWizardStep(scope.$parent);
+          }
+        }
+
+        return wizardStep;
+      };
+
+      ctrl.step = findWizardStep($scope);
+
       if (angular.isUndefined(ctrl.nextEnabled)) {
         ctrl.nextEnabled = true;
       }
@@ -66,11 +79,21 @@ angular.module('patternfly.wizard').component('pfWizardSubstep', {
         ctrl.allowClickNav = true;
       }
 
+
+      ctrl.step.nextEnabled = ctrl.nextEnabled;
+      ctrl.step.prevEnabled = ctrl.prevEnabled;
+      ctrl.step.okToNavAway = ctrl.okToNavAway;
+      ctrl.step.allowClickNav = ctrl.allowClickNav;
+
       ctrl.title = ctrl.stepTitle;
       ctrl.step.addStep(ctrl);
     };
 
     ctrl.$onChanges = function (changesObj) {
+      if (!ctrl.step) {
+        return;
+      }
+
       if (changesObj.nextEnabled) {
         ctrl.step.nextEnabled = changesObj.nextEnabled.currentValue;
       }

--- a/src/wizard/wizard.html
+++ b/src/wizard/wizard.html
@@ -1,5 +1,5 @@
 <div>
-  <div class="modal-header">
+  <div class="modal-header" ng-if="!$ctrl.hideHeader">
     <button type="button" class="close wizard-pf-dismiss" aria-label="Close" ng-click="$ctrl.onCancel()" ng-if="!$ctrl.embedInPage">
       <span aria-hidden="true">&times;</span>
     </button>
@@ -10,11 +10,13 @@
     <div class="wizard-pf-steps" ng-class="{'invisible': !$ctrl.wizardReady}">
       <ul class="wizard-pf-steps-indicator" ng-if="!$ctrl.hideIndicators" ng-class="{'invisible': !$ctrl.wizardReady}">
         <li class="wizard-pf-step" ng-class="{active: step.selected}" ng-repeat="step in $ctrl.getEnabledSteps()" data-tabgroup="{{$index }}">
-          <a ng-click="$ctrl.stepClick(step)"><span class="wizard-pf-step-number">{{$index + 1}}</span><span class="wizard-pf-step-title">{{step.title}}</span></a>
+          <a ng-click="$ctrl.stepClick(step)" ng-class="{'disabled': !$ctrl.allowStepIndicatorClick(step)}">
+            <span class="wizard-pf-step-number">{{$index + 1}}</span>
+            <span class="wizard-pf-step-title">{{step.title}}</span>
+          </a>
         </li>
       </ul>
     </div>
-
     <!-- loading wizard placeholder -->
     <div ng-if="!$ctrl.wizardReady" class="wizard-pf-main" style="margin-left: 0px">
       <div class="wizard-pf-loading blank-slate-pf">
@@ -26,21 +28,21 @@
     <div class="wizard-pf-position-override" ng-transclude ></div>
   </div>
   <div class="modal-footer wizard-pf-footer wizard-pf-position-override" ng-class="{'wizard-pf-footer-inline': $ctrl.embedInPage}">
-    <button pf-wiz-cancel class="btn btn-default btn-cancel wizard-pf-cancel" ng-disabled="$ctrl.wizardDone" ng-click="$ctrl.onCancel()" ng-if="!$ctrl.embedInPage">{{$ctrl.cancelTitle}}</button>
-    <div class="tooltip-wrapper" uib-tooltip="{{$ctrl.prevTooltip}}" tooltip-placement="left">
-      <button id="backButton" pf-wiz-previous class="btn btn-default" ng-disabled="!$ctrl.wizardReady || $ctrl.wizardDone || !$ctrl.selectedStep.prevEnabled || $ctrl.firstStep"
+    <pf-wiz-cancel class="btn btn-default btn-cancel wizard-pf-cancel" ng-disabled="$ctrl.wizardDone" ng-click="$ctrl.onCancel()" ng-if="!$ctrl.embedInPage">{{$ctrl.cancelTitle}}</pf-wiz-cancel>
+    <div ng-if="!$ctrl.hideBackButton" class="tooltip-wrapper" uib-tooltip="{{$ctrl.prevTooltip}}" tooltip-placement="left">
+      <pf-wiz-previous id="backButton" class="btn btn-default" ng-disabled="!$ctrl.wizardReady || $ctrl.wizardDone || !$ctrl.selectedStep.prevEnabled || $ctrl.firstStep"
               callback="$ctrl.backCallback">
         <span class="i fa fa-angular-left"></span>
         {{$ctrl.backTitle}}
-      </button>
+      </pf-wiz-previous>
     </div>
     <div class="tooltip-wrapper" uib-tooltip="{{$ctrl.nextTooltip}}" tooltip-placement="left">
-      <button id="nextButton" pf-wiz-next class="btn btn-primary wizard-pf-next" ng-disabled="!$ctrl.wizardReady || !$ctrl.selectedStep.nextEnabled"
+      <pf-wiz-next id="nextButton" class="btn btn-primary wizard-pf-next" ng-disabled="!$ctrl.wizardReady || !$ctrl.selectedStep.nextEnabled"
               callback="$ctrl.nextCallback">
         {{$ctrl.nextTitle}}
         <span class="i fa fa-angular-right"></span>
-      </button>
+      </pf-wiz-next>
     </div>
-    <button pf-wiz-cancel class="btn btn-default btn-cancel wizard-pf-cancel wizard-pf-cancel-inline" ng-disabled="$ctrl.wizardDone" ng-click="$ctrl.onCancel()" ng-if="$ctrl.embedInPage">{{$ctrl.cancelTitle}}</button>
+    <pf-wiz-cancel class="btn btn-default btn-cancel wizard-pf-cancel wizard-pf-cancel-inline" ng-disabled="$ctrl.wizardDone" ng-click="$ctrl.onCancel()" ng-if="$ctrl.embedInPage">{{$ctrl.cancelTitle}}</pf-wiz-cancel>
   </div>
 </div>

--- a/src/wizard/wizard.less
+++ b/src/wizard/wizard.less
@@ -23,3 +23,14 @@
 .wizard-pf-cancel-inline {
   margin-left: 25px;
 }
+
+.wizard-pf-steps-indicator li a.disabled {
+  cursor: default;
+  &:hover {
+    .wizard-pf-step-number {
+      background-color: @color-pf-white;
+      border-color: @color-pf-black-400;
+      color: @color-pf-black-400;
+    }
+  }
+}

--- a/test/wizard/wizard-container-hidden.html
+++ b/test/wizard/wizard-container-hidden.html
@@ -7,7 +7,9 @@
   back-callback="backCallback"
   current-step="currentStep"
   hide-indicators="hideIndicators"
+  hide-sidebar="true"
+  hide-header="true"
   wizard-done="deployComplete || deployInProgress"
   loading-secondary-information="secondaryLoadInformation">
   <div ng-include="'test/wizard/wizard-test-steps.html'"></div>
- </div>
+ </pf-wizard>

--- a/test/wizard/wizard-container-hide-back.html
+++ b/test/wizard/wizard-container-hide-back.html
@@ -1,4 +1,5 @@
 <pf-wizard title="Wizard Title"
+  step-class="test-step-class"
   wizard-ready="deployReady"
   on-finish="finishedWizard()"
   on-cancel="cancelDeploymentWizard()"
@@ -6,8 +7,8 @@
   next-callback="nextCallback"
   back-callback="backCallback"
   current-step="currentStep"
-  hide-indicators="hideIndicators"
+  hide-back-button="true"
   wizard-done="deployComplete || deployInProgress"
   loading-secondary-information="secondaryLoadInformation">
   <div ng-include="'test/wizard/wizard-test-steps.html'"></div>
- </div>
+ </pf-wizard>

--- a/test/wizard/wizard-container-step-class.html
+++ b/test/wizard/wizard-container-step-class.html
@@ -1,4 +1,5 @@
 <pf-wizard title="Wizard Title"
+  step-class="test-step-class"
   wizard-ready="deployReady"
   on-finish="finishedWizard()"
   on-cancel="cancelDeploymentWizard()"
@@ -10,4 +11,4 @@
   wizard-done="deployComplete || deployInProgress"
   loading-secondary-information="secondaryLoadInformation">
   <div ng-include="'test/wizard/wizard-test-steps.html'"></div>
- </div>
+ </pf-wizard>>

--- a/test/wizard/wizard-container-step-side-class.html
+++ b/test/wizard/wizard-container-step-side-class.html
@@ -1,4 +1,6 @@
 <pf-wizard title="Wizard Title"
+  step-class="test-step-class"
+  sidebar-class="test-sidebar-class"
   wizard-ready="deployReady"
   on-finish="finishedWizard()"
   on-cancel="cancelDeploymentWizard()"
@@ -10,4 +12,4 @@
   wizard-done="deployComplete || deployInProgress"
   loading-secondary-information="secondaryLoadInformation">
   <div ng-include="'test/wizard/wizard-test-steps.html'"></div>
- </div>
+ </pf-wizard>

--- a/test/wizard/wizard-test-steps.html
+++ b/test/wizard/wizard-test-steps.html
@@ -1,0 +1,28 @@
+<pf-wizard-step step-title="First Step" substeps="true" step-id="details" step-priority="0" show-review="true" show-review-details="true">
+  <div ng-include="'test/wizard/detail-page.html'">
+  </div>
+  <pf-wizard-substep step-title="Details - Extra" next-enabled="true" step-id="details-extra" step-priority="1" show-review="true" show-review-details="true" review-template="test/wizard/review-second-template.html">
+    <form class="form-horizontal">
+      <div pf-form-group pf-label="Lorem" required>
+        <input id="new-lorem" name="lorem" ng-model="data.lorem" type="text" required/>
+      </div>
+      <div pf-form-group pf-label="Ipsum">
+        <input id="new-ipsum" name="ipsum" ng-model="data.ipsum" type="text" />
+      </div>
+    </form>
+  </pf-wizard-substep>
+</pf-wizard-step>
+<pf-wizard-step step-title="Second Step" substeps="false" step-id="configuration" step-priority="1" show-review="true" review-template="test/wizard/review-second-template.html" >
+  <form class="form-horizontal">
+    <div pf-form-group pf-label="Lorem">
+      <input id="new-lorem" name="lorem" ng-model="data.lorem" type="text"/>
+    </div>
+    <div pf-form-group pf-label="Ipsum">
+      <input id="new-ipsum" name="ipsum" ng-model="data.ipsum" type="text" />
+    </div>
+  </form>
+</pf-wizard-step>
+<pf-wizard-step step-title="Review" substeps="true" step-id="review" step-priority="2">
+  <div ng-include="'test/wizard/summary.html'"></div>
+  <div ng-include="'test/wizard/deployment.html'"></div>
+</pf-wizard-step>

--- a/test/wizard/wizard.spec.js
+++ b/test/wizard/wizard.spec.js
@@ -15,12 +15,17 @@ describe('Component:  pfWizard', function () {
     'wizard/wizard-review-page.html',
     'wizard/wizard.html',
     'form/form-group/form-group.html',
+    'test/wizard/wizard-test-steps.html',
     'test/wizard/deployment.html',
     'test/wizard/detail-page.html',
     'test/wizard/review-second-template.html',
     'test/wizard/review-template.html',
     'test/wizard/summary.html',
-    'test/wizard/wizard-container.html'
+    'test/wizard/wizard-container.html',
+    'test/wizard/wizard-container-hidden.html',
+    'test/wizard/wizard-container-step-class.html',
+    'test/wizard/wizard-container-step-side-class.html',
+    'test/wizard/wizard-container-hide-back.html'
   ));
 
   beforeEach(inject(function (_$compile_, _$rootScope_, _$httpBackend_, _$templateCache_, _$timeout_) {
@@ -92,18 +97,21 @@ describe('Component:  pfWizard', function () {
     initializeWizard();
   };
 
-  beforeEach(function () {
+  var setupWizard = function(wizardHtml) {
     setupWizardScope();
-    var modalHtml = $templateCache.get('test/wizard/wizard-container.html');
+
+    var modalHtml = $templateCache.get(wizardHtml);
     element = compileHtml(modalHtml, $scope);
     $scope.$digest();
 
     // there are two dependent timeouts in the wizard that need to be flushed
     $timeout.flush();
     $timeout.flush();
-  });
+  };
 
   it('should dispatch the cancel event on the close button click', function () {
+    setupWizard('test/wizard/wizard-container.html');
+
     var closeButton = element.find('.close');
     spyOn($rootScope, '$emit');
     eventFire(closeButton[0], 'click');
@@ -112,11 +120,13 @@ describe('Component:  pfWizard', function () {
   });
 
   it('should have three step indicators in the header', function () {
+    setupWizard('test/wizard/wizard-container.html');
     var stepsIndicator = element.find('.wizard-pf-steps .wizard-pf-step');
     expect(stepsIndicator.length).toBe(3);
   });
 
   it('should have two sections in the left-hand pane', function () {
+    setupWizard('test/wizard/wizard-container.html');
     var stepsIndicator = element.find('.wizard-pf-sidebar .list-group-item');
     var hiddenStepsIndicator = element.find('section.ng-hide .wizard-pf-sidebar .list-group-item');
 
@@ -125,11 +135,13 @@ describe('Component:  pfWizard', function () {
   });
 
   it('should have disabled the next button', function () {
+    setupWizard('test/wizard/wizard-container.html');
     var checkDisabled = element.find('.wizard-pf-next').attr('disabled');
     expect(checkDisabled).toBe('disabled');
   });
 
   it('should have enabled the next button after input and allowed navigation', function () {
+    setupWizard('test/wizard/wizard-container.html');
     var nextButton = element.find('.wizard-pf-next');
     var nameBox = element.find('#new-name');
     nameBox.val('test').triggerHandler('input');
@@ -139,6 +151,7 @@ describe('Component:  pfWizard', function () {
   });
 
   it('should have allowed moving back to first page after input and allowed navigation', function () {
+    setupWizard('test/wizard/wizard-container.html');
     var nextButton = element.find('.wizard-pf-next');
     var nameBox = element.find('#new-name');
     nameBox.val('test').triggerHandler('input');
@@ -153,13 +166,16 @@ describe('Component:  pfWizard', function () {
   });
 
   it('should have allowed navigation to review page', function () {
-    var nextButton = element.find('.wizard-pf-next');
+    setupWizard('test/wizard/wizard-container.html');
+
     var nameBox = element.find('#new-name');
     nameBox.val('test').triggerHandler('input');
     $scope.$digest();
 
     $scope.currentStep = 'Review';
     $scope.$digest();
+
+    // Two timeouts occur when navigating to a specified page (one to get the wizard setup, one to allow for the step.onShow function).
     $timeout.flush();
     $timeout.flush();
 
@@ -168,8 +184,8 @@ describe('Component:  pfWizard', function () {
   });
 
   it('should hide indicators if the property is set', function () {
-    var modalHtml = $templateCache.get('test/wizard/wizard-container.html');
-    element = compileHtml(modalHtml, $scope);
+    setupWizard('test/wizard/wizard-container.html');
+
     $scope.hideIndicators = true;
     $scope.$digest();
     var indicators = element.find('.wizard-pf-steps');
@@ -183,6 +199,7 @@ describe('Component:  pfWizard', function () {
   });
 
   it('clicking indicators should navigate wizard', function () {
+    setupWizard('test/wizard/wizard-container.html');
     var indicator = element.find('.wizard-pf-steps .wizard-pf-step a');
     var nameBox = element.find('#new-name');
     nameBox.val('test').triggerHandler('input');
@@ -195,11 +212,57 @@ describe('Component:  pfWizard', function () {
   });
 
   it('clicking indicators should not navigate wizard if prevented from doing so', function () {
+    setupWizard('test/wizard/wizard-container.html');
     var indicator = element.find('.wizard-pf-steps .wizard-pf-step a');
     eventFire(indicator[1], 'click');
     $scope.$digest();
 
     var selectedSectionTitle = element.find('.wizard-pf-row section.current').attr("step-title");
     expect(selectedSectionTitle).not.toBe('Second Step');
+  });
+
+  it('should hide the sidebar when set', function () {
+    setupWizard('test/wizard/wizard-container-hidden.html');
+
+    var sidebar = element.find('.wizard-pf-sidebar');
+
+    expect(sidebar.length).toBe(0);
+  });
+
+  it('should hide the header when set', function () {
+    setupWizard('test/wizard/wizard-container-hidden.html');
+    var header = element.find('.modal-header');
+
+    expect(header.length).toBe(0);
+  });
+
+  it('should set the step class when given', function () {
+    setupWizard('test/wizard/wizard-container-step-class.html');
+
+    var mainStepPanel = element.find('.wizard-pf-main');
+    expect(mainStepPanel.length).toBe(3);
+
+    var sidebarPanel = element.find('.wizard-pf-sidebar.test-step-class');
+    expect(sidebarPanel.length).toBe(3);
+  });
+
+  it('should set the sidebar class when given', function () {
+    setupWizard('test/wizard/wizard-container-step-side-class.html');
+
+    var mainStepPanel = element.find('.wizard-pf-main');
+    expect(mainStepPanel.length).toBe(3);
+
+    var sidebarPanel = element.find('.wizard-pf-sidebar.test-step-class');
+    expect(sidebarPanel.length).toBe(0);
+
+    var sidebarPanel = element.find('.wizard-pf-sidebar.test-sidebar-class');
+    expect(sidebarPanel.length).toBe(3);
+  });
+
+  it('should hide the back button when specified', function () {
+    setupWizard('test/wizard/wizard-container-hide-back.html');
+
+    var backButton = element.find('.wizard-pf-footer #backButton');
+    expect(backButton.length).toBe(0);
   });
 });


### PR DESCRIPTION
- allow hiding header
- allow hiding the sidebar navigation panel
- allow hiding the back button (useful in 2 page wizards)
- add disabled class to step indicators when disabled
- allow adding a class to the sidebar and step panels rather than setting a height
- allow use of the wizard from typescript bases applications:   
  The use of require ^ fails when being included in typescript so that has been removed and replaced by using scope to find the required Wizard/WizardStep controllers.


This is a port of #458 