### PR TITLE
Removed the jquery resolution from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -48,8 +48,5 @@
   "devDependencies": {
     "angular-mocks": "1.3.0 - 1.5.*",
     "angular-ui-router": "1.0.0-beta.3"
-  },
-  "resolutions": {
-    "jquery": "~2.1.4"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -43,7 +43,7 @@
     "angular-sanitize": "1.3.0 - 1.5.*",
     "angular-bootstrap": "0.14.x",
     "lodash": "3.x",
-    "patternfly": "~3.23.3"
+    "patternfly": "~3.24.0"
   },
   "devDependencies": {
     "angular-mocks": "1.3.0 - 1.5.*",


### PR DESCRIPTION
This resolution is no longer needed, as patternfly has downgraded the dependency (bootstrap-switch) to a version that no longer brings in this old version of jquery.