### PR TITLE
Fix #448 - pfTableView: conflicting PF and A-PF datatables deps

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -48,5 +48,17 @@
   "devDependencies": {
     "angular-mocks": "1.3.0 - 1.5.*",
     "angular-ui-router": "1.0.0-beta.3"
+  },
+  "overrides": {
+    "datatables": {
+      "main": [
+        "media/css/jquery.dataTables.css",
+        "media/images/sort_asc.png",
+        "media/images/sort_asc_disabled.png",
+        "media/images/sort_both.png",
+        "media/images/sort_desc.png",
+        "media/images/sort_desc_disabled.png"
+      ]
+    }
   }
 }


### PR DESCRIPTION
Overrode the datatables's main definition in its bower.json (like the example above) to remove the reference to jquery.dataTables.js