### PR TITLE
Fix #448 - pfTableView: conflicting PF and A-PF datatables

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -53,6 +53,18 @@
     "angular-mocks": "1.5.*",
     "angular-ui-router": "^1.0.0-beta.3"
   },
+  "overrides": {
+    "datatables": {
+      "main": [
+        "media/css/jquery.dataTables.css",
+        "media/images/sort_asc.png",
+        "media/images/sort_asc_disabled.png",
+        "media/images/sort_both.png",
+        "media/images/sort_desc.png",
+        "media/images/sort_desc_disabled.png"
+      ]
+    }
+  },
   "resolutions": {
     "jquery": "~2.1.4"
   }


### PR DESCRIPTION
Override the `datatables` main definition in `bower.json` to remove the reference to `jquery.dataTables.js`.
