### PR TITLE
Hides selected filter results unless selected&totalCount !== undefined

### DIFF
--- a/src/filters/filter-results-component.js
+++ b/src/filters/filter-results-component.js
@@ -63,12 +63,6 @@ angular.module('patternfly.filters').component('pfFilterResults', {
       if (ctrl.config.resultsCount === undefined) {
         ctrl.config.resultsCount = 0;
       }
-      if (ctrl.config.selectedCount === undefined) {
-        ctrl.config.selectedCount = 0;
-      }
-      if (ctrl.config.totalCount === undefined) {
-        ctrl.config.totalCount = 0;
-      }
     }
 
     function clearFilter (item) {

--- a/src/filters/filter-results.html
+++ b/src/filters/filter-results.html
@@ -12,7 +12,7 @@
         </li>
       </ul>
       <p><a class="clear-filters" ng-click="$ctrl.clearAllFilters()" ng-if="$ctrl.config.appliedFilters.length > 0">Clear All Filters</a></p>
-      <div ng-if="$ctrl.config.totalCount !== 0" class="pf-table-view-selected-label">
+      <div ng-if="$ctrl.config.selectedCount !== undefined && $ctrl.config.totalCount !== undefined" class="pf-table-view-selected-label">
         <strong>{{$ctrl.config.selectedCount}}</strong> of <strong>{{$ctrl.config.totalCount}}</strong> selected
       </div>
     </div><!-- /col -->

--- a/test/filters/filter.spec.js
+++ b/test/filters/filter.spec.js
@@ -159,4 +159,20 @@ describe('Directive:  pfFilter', function () {
     expect(activeFilters.length).toBe(0);
     expect(clearButtons.length).toBe(0);
   });
-})
+
+  it('should not show selected results when selectedCount and totalCount are undefined', function() {
+    $scope.filterConfig.selectedCount = undefined;
+    $scope.filterConfig.totalCount = undefined;
+    $scope.$digest();
+
+    expect(element.find('.pf-table-view-selected-label').length).toBe(0);
+  });
+
+  it('should show selected results and totalCount are defined', function() {
+    $scope.filterConfig.selectedCount = 0;
+    $scope.filterConfig.totalCount = 10;
+    $scope.$digest();
+
+    expect(element.find('.pf-table-view-selected-label').text()).toContain('0 of 10 selected');
+  });
+});


### PR DESCRIPTION
Unless selectedcount and total count are explicitly defined, will not display the "x of x selected" filter results text.  Prevents unwanted text for instance, when there is no items to select

This changes behavior from being shown by default, to being shown when explicitly invoked, aligns closer with pf 3.x behavior

closes #480