### PR TITLE
Build Package Update

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -47,7 +47,7 @@
     "datatables.net": "^1.10.12",
     "datatables.net-select": "~1.2.0",
     "lodash": "4.x",
-    "patternfly": "3.25.0"
+    "patternfly": "^3.25.1"
   },
   "devDependencies": {
     "angular-mocks": "1.5.*",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "angular-ui-bootstrap": "2.3.x",
     "angular-svg-base-fix": "2.0.0",
     "lodash": "4.x",
-    "patternfly": "3.25.0"
+    "patternfly": "^3.25.1"
   },
   "devDependencies": {
     "angular-dragdrop": "1.0.13",


### PR DESCRIPTION
The PatternFly references are now disconnected from the main build process, so they've been updated independently. 

Using the ```caret``` to indicate latest release of PatternFly up to, but not including the next major so we can avoid having to update the references on every release of AngularPF until the next major of PatternFly.