### PR TITLE
Fix #502 - pfTableView: does not work with items retrieved via AJAX call

### DIFF
--- a/src/table/tableview/examples/table-view-basic.js
+++ b/src/table/tableview/examples/table-view-basic.js
@@ -34,180 +34,201 @@
   *   </ul>
   * @param {object} emptyStateConfig Optional configuration settings for the empty state component.  See the {@link patternfly.views.component:pfEmptyState Empty State} component
   * @example
- <example module="patternfly.tableview.demo">
- <file name="index.html">
- <div ng-controller="TableCtrl" class="row example-container">
-   <div class="col-md-12">
-     <pf-table-view id="exampleTableView"
-          config="config"
-          empty-state-config="emptyStateConfig"
-          dt-options="dtOptions"
-          columns="columns"
-          items="items"
-          action-buttons="actionButtons"
-          menu-actions="menuActions">
-     </pf-table-view>
-   </div>
-   <div class="col-md-12" style="padding-top: 12px;">
-     <div class="form-group">
-       <label class="checkbox-inline">
-         <input type="checkbox" ng-model="config.itemsAvailable">Items Available</input>
-       </label>
-     </div>
-   </div>
-   <hr class="col-md-12">
-   <div class="col-md-12">
-         <div class="col-md-12" style="padding-top: 12px;">
-           <label style="font-weight:normal;vertical-align:center;">Events: </label>
-         </div>
-         <div class="col-md-12">
-           <textarea rows="10" class="col-md-12">{{eventText}}</textarea>
-         </div>
-   </div>
- </file>
-
- <file name="modules.js">
-   angular.module('patternfly.tableview.demo', ['patternfly.views','patternfly.table']);
- </file>
-
- <file name="script.js">
- angular.module('patternfly.tableview.demo').controller('TableCtrl', ['$scope',
- function ($scope) {
-        $scope.dtOptions = {
-          order: [[2, "asc"]],
-        };
-
-        $scope.columns = [
-          { header: "Name", itemField: "name" },
-          { header: "Address", itemField: "address"},
-          { header: "City", itemField: "city" },
-          { header: "State", itemField: "state"}
-        ];
-
-        $scope.items = [
-          {
-            name: "Fred Flintstone",
-            address: "20 Dinosaur Way",
-            city: "Bedrock",
-            state: "Washingstone"
-          },
-          {
-            name: "John Smith",
-            address: "415 East Main Street",
-            city: "Norfolk",
-            state: "Virginia",
-          },
-          {
-            name: "Frank Livingston",
-            address: "234 Elm Street",
-            city: "Pittsburgh",
-            state: "Pennsylvania"
-          },
-          {
-            name: "Linda McGovern",
-            address: "22 Oak Street",
-            city: "Denver",
-            state: "Colorado"
-          },
-          {
-            name: "Jim Brown",
-            address: "72 Bourbon Way",
-            city: "Nashville",
-            state: "Tennessee"
-          },
-          {
-            name: "Holly Nichols",
-            address: "21 Jump Street",
-            city: "Hollywood",
-            state: "California"
-          },
-          {
-            name: "Marie Edwards",
-            address: "17 Cross Street",
-            city: "Boston",
-            state: "Massachusetts"
-          },
-          {
-            name: "Pat Thomas",
-            address: "50 Second Street",
-            city: "New York",
-            state: "New York"
-          },
-        ];
-
-        $scope.eventText = "";
-
-        $scope.config = {
-          onCheckBoxChange: handleCheckBoxChange,
-          selectionMatchProp: "name",
-          itemsAvailable: true
-        };
-
-        $scope.emptyStateConfig = {
-          icon: 'pficon-warning-triangle-o',
-          title: 'No Items Available',
-          info: "This is the Empty State component. The goal of a empty state pattern is to provide a good first impression that helps users to achieve their goals. It should be used when a view is empty because no objects exists and you want to guide the user to perform specific actions.",
-          helpLink: {
-             label: 'For more information please see',
-             urlLabel: 'pfExample',
-             url : '#/api/patternfly.views.component:pfEmptyState'
-          }
-        };
-
-        function handleCheckBoxChange (item) {
-          $scope.eventText = item.name + ' checked: ' + item.selected + '\r\n' + $scope.eventText;
-        };
-
-        var performAction = function (action, item) {
-          $scope.eventText = item.name + " : " + action.name + "\r\n" + $scope.eventText;
-        };
-
-        $scope.actionButtons = [
-          {
-            name: 'Action',
-            title: 'Perform an action',
-            actionFn: performAction
-          }
-        ];
-
-        $scope.menuActions = [
-          {
-            name: 'Action',
-            title: 'Perform an action',
-            actionFn: performAction
-          },
-          {
-            name: 'Another Action',
-            title: 'Do something else',
-            actionFn: performAction
-          },
-          {
-            name: 'Disabled Action',
-            title: 'Unavailable action',
-            actionFn: performAction,
-            isDisabled: true
-          },
-          {
-            name: 'Something Else',
-            title: '',
-            actionFn: performAction
-          },
-          {
-            isSeparator: true
-          },
-          {
-            name: 'Grouped Action 1',
-            title: 'Do something',
-            actionFn: performAction
-          },
-          {
-            name: 'Grouped Action 2',
-            title: 'Do something similar',
-            actionFn: performAction
-          }
-        ];
-      }
-    ]);
+  <example module="patternfly.tableview.demo">
+  <file name="index.html">
+  <div ng-controller="TableCtrl" class="row example-container">
+    <div class="col-md-12">
+      <pf-table-view id="exampleTableView"
+            config="config"
+            empty-state-config="emptyStateConfig"
+            dt-options="dtOptions"
+            columns="columns"
+            items="items"
+            action-buttons="actionButtons"
+            menu-actions="menuActions">
+      </pf-table-view>
+    </div>
+    <div class="col-md-12" style="padding-top: 12px;">
+      <div class="form-group">
+        <label class="checkbox-inline">
+          <input type="checkbox" ng-model="config.itemsAvailable">Items Available</input>
+        </label>
+      </div>
+    </div>
+    <hr class="col-md-12">
+    <div class="col-md-12">
+          <div class="col-md-12" style="padding-top: 12px;">
+            <label style="font-weight:normal;vertical-align:center;">Events: </label>
+          </div>
+          <div class="col-md-12">
+            <textarea rows="10" class="col-md-12">{{eventText}}</textarea>
+          </div>
+    </div>
   </file>
+
+  <file name="module.js">
+    angular.module('patternfly.tableview.demo', ['patternfly.views','patternfly.table']);
+  </file>
+
+  <file name="controller.js">
+  angular.module('patternfly.tableview.demo').controller('TableCtrl', ['$scope', 'itemsService',
+  function ($scope, itemsService) {
+          $scope.dtOptions = {
+            order: [[2, "asc"]],
+          };
+
+          $scope.columns = [
+            { header: "Name", itemField: "name" },
+            { header: "Address", itemField: "address"},
+            { header: "City", itemField: "city" },
+            { header: "State", itemField: "state"}
+          ];
+
+          $scope.items = null;
+
+          $scope.eventText = "";
+
+          $scope.config = {
+            onCheckBoxChange: handleCheckBoxChange,
+            selectionMatchProp: "name",
+            itemsAvailable: true
+          };
+
+          $scope.emptyStateConfig = {
+            icon: 'pficon-warning-triangle-o',
+            title: 'No Items Available',
+            info: "This is the Empty State component. The goal of a empty state pattern is to provide a good first impression that helps users to achieve their goals. It should be used when a view is empty because no objects exists and you want to guide the user to perform specific actions.",
+            helpLink: {
+              label: 'For more information please see',
+              urlLabel: 'pfExample',
+              url : '#/api/patternfly.views.component:pfEmptyState'
+            }
+          };
+
+          function handleCheckBoxChange (item) {
+            $scope.eventText = item.name + ' checked: ' + item.selected + '\r\n' + $scope.eventText;
+          };
+
+          var performAction = function (action, item) {
+            $scope.eventText = item.name + " : " + action.name + "\r\n" + $scope.eventText;
+          };
+
+          $scope.actionButtons = [
+            {
+              name: 'Action',
+              title: 'Perform an action',
+              actionFn: performAction
+            }
+          ];
+
+          $scope.menuActions = [
+            {
+              name: 'Action',
+              title: 'Perform an action',
+              actionFn: performAction
+            },
+            {
+              name: 'Another Action',
+              title: 'Do something else',
+              actionFn: performAction
+            },
+            {
+              name: 'Disabled Action',
+              title: 'Unavailable action',
+              actionFn: performAction,
+              isDisabled: true
+            },
+            {
+              name: 'Something Else',
+              title: '',
+              actionFn: performAction
+            },
+            {
+              isSeparator: true
+            },
+            {
+              name: 'Grouped Action 1',
+              title: 'Do something',
+              actionFn: performAction
+            },
+            {
+              name: 'Grouped Action 2',
+              title: 'Do something similar',
+              actionFn: performAction
+            }
+          ];
+
+          (function init() {
+            itemsService.getItems()
+              .then(items => $scope.items = items);
+          })();
+        }
+      ]);
+    </file>
+
+  <file name="service.js">
+    angular.module('patternfly.tableview.demo').service('itemsService', ['$q', function($q) {
+
+      this.getItems = function() {
+        return $q((resolve, reject) => {
+          setTimeout(function() {
+            let items = [
+              {
+              name: "Fred Flintstone",
+              address: "20 Dinosaur Way",
+              city: "Bedrock",
+              state: "Washingstone"
+              },
+              {
+              name: "John Smith",
+              address: "415 East Main Street",
+              city: "Norfolk",
+              state: "Virginia",
+              },
+              {
+              name: "Frank Livingston",
+              address: "234 Elm Street",
+              city: "Pittsburgh",
+              state: "Pennsylvania"
+              },
+              {
+              name: "Linda McGovern",
+              address: "22 Oak Street",
+              city: "Denver",
+              state: "Colorado"
+              },
+              {
+              name: "Jim Brown",
+              address: "72 Bourbon Way",
+              city: "Nashville",
+              state: "Tennessee"
+              },
+              {
+              name: "Holly Nichols",
+              address: "21 Jump Street",
+              city: "Hollywood",
+              state: "California"
+              },
+              {
+              name: "Marie Edwards",
+              address: "17 Cross Street",
+              city: "Boston",
+              state: "Massachusetts"
+              },
+              {
+              name: "Pat Thomas",
+              address: "50 Second Street",
+              city: "New York",
+              state: "New York"
+              },
+            ];
+            resolve(items);
+          }, 10);
+        });
+      }
+
+    }]);
+  </file>
+
 </example>
 */

--- a/test/table/tableview/table-view.spec.js
+++ b/test/table/tableview/table-view.spec.js
@@ -1,0 +1,74 @@
+describe('Component: pfTableView', function () {
+  var $scope;
+  var $compile;
+  var element;
+  var performedAction;
+  var updateCount;
+
+  // load the controller's module
+  beforeEach(function () {
+    module('patternfly.views', 'patternfly.table', 'table/tableview/table-view.html', 'views/empty-state.html');
+  });
+
+  beforeEach(inject(function (_$compile_, _$rootScope_, _$timeout_) {
+    $compile = _$compile_;
+    $scope = _$rootScope_;
+    $timeout = _$timeout_;
+  }));
+
+  var compileHTML = function (markup, scope) {
+    element = angular.element(markup);
+    $compile(element)(scope);
+
+    scope.$digest();
+  };
+
+  beforeEach(function () {
+    $scope.config = {
+      selectionMatchProp: 'uuid'
+    };
+
+    $scope.columns = [
+      {itemField: 'uuid', header: 'ID'},
+      {itemField: 'name', header: 'Name'},
+      {itemField: 'size', header: 'Size'},
+      {itemField: 'capacity', header: 'Capacity'}
+    ];
+
+    $scope.items = [
+      {uuid: '1', name: 'One', size: 291445030, capacity: 8200000000},
+      {uuid: '2', name: 'Two', size: 1986231544, capacity: 8700000000},
+      {uuid: '3', name: 'Three', size: 7864632, capacity: 7800000000},
+      {uuid: '4', name: 'Four', size: 8162410, capacity: 3200000000},
+      {uuid: '5', name: 'Five', size: 6781425410, capacity: 7600000000}
+    ];
+
+    var htmlTmp = '<pf-table-view config="config" columns="columns" items="items"></pf-table-view>';
+
+    compileHTML(htmlTmp, $scope);
+  });
+
+  it('should not show the empty state when items is null', function () {
+    $scope.items = null;
+    $scope.$digest();
+    expect(element.find('#title').text()).toContain('');
+  });
+
+  it('should show the empty state when items is empty', function () {
+    $scope.items = [];
+    $scope.$digest();
+    expect(element.find('#title').text()).toContain('No Items Available');
+  });
+
+  it('should show the empty state when the config property is specified', function () {
+    $scope.config.itemsAvailable = false;
+    $scope.$digest();
+    expect(element.find('#title').text()).toContain('No Items Available');
+  });
+
+  it('should show the correct number of items', function () {
+    var rows = element.find('.table > tbody > tr');
+    expect(rows.length).toBe(5);
+  });
+
+});


### PR DESCRIPTION
Fixed Table View so I can initialize the items array with a null value, fetch the data from an external source, and update the items array with the fetched data. Without this fix, initializing the items array with null throws an error and initializing the items array with empty array works but you see the 'No Items Available' message and updating the items data doesn't remove the message.