### PR TITLE
Fix #494 - pfTableView: Need to be able to not show checkboxes

### DIFF
--- a/src/table/tableview/examples/table-view-basic.js
+++ b/src/table/tableview/examples/table-view-basic.js
@@ -12,6 +12,7 @@
   *   <li>.selectionMatchProp  - (string) Property of the items to use for determining matching, default is 'uuid'
   *   <li>.onCheckBoxChange    - ( function(item) ) Called to notify when a checkbox selection changes, default is none
   *   <li>.itemsAvailable      - (boolean) If 'false', displays the {@link patternfly.views.component:pfEmptyState Empty State} component.
+  *   <li>.showCheckboxes      - (boolean) Show checkboxes for row selection, default is true
   * </ul>
   * @param {object} dtOptions Optional angular-datatables DTOptionsBuilder configuration object.  See {@link http://l-lin.github.io/angular-datatables/archives/#/api angular-datatables: DTOptionsBuilder}
   * @param {array} items Array of items to display in the table view.
@@ -37,7 +38,7 @@
   <example module="patternfly.tableview.demo">
   <file name="index.html">
   <div ng-controller="TableCtrl" class="row example-container">
-    <div class="col-md-12">
+    <div class="col-md-12" ng-if="showComponent">
       <pf-table-view id="exampleTableView"
             config="config"
             empty-state-config="emptyStateConfig"
@@ -52,6 +53,11 @@
       <div class="form-group">
         <label class="checkbox-inline">
           <input type="checkbox" ng-model="config.itemsAvailable">Items Available</input>
+        </label>
+      </div>
+      <div class="form-group">
+        <label class="checkbox-inline">
+          <input type="checkbox" ng-model="config.showCheckboxes" ng-change="addNewComponentToDOM()">Show Checkboxes</input>
         </label>
       </div>
     </div>
@@ -71,8 +77,8 @@
   </file>
 
   <file name="controller.js">
-  angular.module('patternfly.tableview.demo').controller('TableCtrl', ['$scope', 'itemsService',
-  function ($scope, itemsService) {
+  angular.module('patternfly.tableview.demo').controller('TableCtrl', ['$scope', '$timeout', 'itemsService',
+  function ($scope, $timeout, itemsService) {
           $scope.dtOptions = {
             order: [[2, "asc"]],
           };
@@ -91,7 +97,8 @@
           $scope.config = {
             onCheckBoxChange: handleCheckBoxChange,
             selectionMatchProp: "name",
-            itemsAvailable: true
+            itemsAvailable: true,
+            showCheckboxes: true
           };
 
           $scope.emptyStateConfig = {
@@ -157,6 +164,13 @@
               actionFn: performAction
             }
           ];
+
+          $scope.showComponent = true;
+
+          $scope.addNewComponentToDOM = function () {
+            $scope.showComponent = false;
+            $timeout(() => $scope.showComponent = true);
+          };
 
           (function init() {
             itemsService.getItems()

--- a/src/table/tableview/examples/table-view-with-toolbar.js
+++ b/src/table/tableview/examples/table-view-with-toolbar.js
@@ -11,7 +11,8 @@
  *   <li>.selectionMatchProp  - (string) Property of the items to use for determining matching, default is 'uuid'
  *   <li>.onCheckBoxChange    - ( function(item) ) Called to notify when a checkbox selection changes, default is none
  *   <li>.itemsAvailable      - (boolean) If 'false', displays the {@link patternfly.views.component:pfEmptyState Empty State} component.
- * </ul>
+ *   <li>.showCheckboxes      - (boolean) Show checkboxes for row selection, default is true
+* </ul>
  * @param {object} dtOptions Optional angular-datatables DTOptionsBuilder configuration object.  See {@link http://l-lin.github.io/angular-datatables/archives/#/api angular-datatables: DTOptionsBuilder}
  * @param {array} items Array of items to display in the table view.
  * @param {array} columns Array of table column information to display in the table's header row
@@ -39,7 +40,7 @@
       <div class="col-md-12">
         <pf-toolbar id="exampleToolbar" config="toolbarConfig"></pf-toolbar>
       </div>
-      <div class="col-md-12">
+      <div class="col-md-12" ng-if="showComponent">
         <pf-table-view config="tableConfig"
                        empty-state-config="emptyStateConfig"
                        dt-options="dtOptions"
@@ -62,6 +63,11 @@
               <input ng-model="dtOptions.displayLength" ng-disabled="!usePagination" style="width: 24px; padding-left: 6px;"> # Rows Per Page</input>
             </label> --!>
         </div>
+        <div class="form-group">
+          <label class="checkbox-inline">
+            <input type="checkbox" ng-model="tableConfig.showCheckboxes" ng-change="addNewComponentToDOM()">Show Checkboxes</input>
+          </label>
+        </div>
       </div>
       <hr class="col-md-12">
       <div class="col-md-12">
@@ -78,8 +84,8 @@
   </file>
 
   <file name="script.js">
-  angular.module('patternfly.tableview.demo').controller('ViewCtrl', ['$scope', 'pfViewUtils', '$filter',
-    function ($scope, pfViewUtils, $filter) {
+  angular.module('patternfly.tableview.demo').controller('ViewCtrl', ['$scope', '$timeout', 'pfViewUtils', '$filter',
+    function ($scope, $timeout, pfViewUtils, $filter) {
       $scope.actionsText = "";
 
       $scope.columns = [
@@ -388,7 +394,8 @@
       $scope.tableConfig = {
         onCheckBoxChange: handleCheckBoxChange,
         selectionMatchProp: "name",
-        itemsAvailable: true
+        itemsAvailable: true,
+        showCheckboxes: true
       };
 
       $scope.emptyStateConfig = {
@@ -457,6 +464,13 @@
           $scope.toolbarConfig.filterConfig.totalCount = $scope.allItems.length;
           handleCheckBoxChange();
         }
+      };
+
+      $scope.showComponent = true;
+
+      $scope.addNewComponentToDOM = function () {
+        $scope.showComponent = false;
+        $timeout(() => $scope.showComponent = true);
       };
     }
   ]);

--- a/src/table/tableview/table-view.component.js
+++ b/src/table/tableview/table-view.component.js
@@ -33,7 +33,8 @@ angular.module('patternfly.table').component('pfTableView', {
 
     ctrl.defaultConfig = {
       selectionMatchProp: 'uuid',
-      onCheckBoxChange: null
+      onCheckBoxChange: null,
+      showCheckboxes: true
     };
 
     ctrl.$onInit = function () {
@@ -160,18 +161,22 @@ angular.module('patternfly.table').component('pfTableView', {
 
     function setColumnDefs () {
       var i = 0, actnBtns = 1;
-      var item, prop;
+      var item, prop, offset;
+      ctrl.dtColumnDefs = [];
 
       // add checkbox col, not sortable
-      ctrl.dtColumnDefs = [ DTColumnDefBuilder.newColumnDef(i++).notSortable() ];
+      if (ctrl.config.showCheckboxes) {
+        ctrl.dtColumnDefs.push(DTColumnDefBuilder.newColumnDef(i++).notSortable());
+      }
 
       // add column definitions
       _.forEach(ctrl.columns, function (column) {
         ctrl.dtColumnDefs.push(DTColumnDefBuilder.newColumnDef(i++));
       });
 
-      // Determine selectionMatchProp column number (add 1 due to the checkbox column)
-      ctrl.selectionMatchPropColNum = _.findIndex(ctrl.columns, ['itemField', ctrl.config.selectionMatchProp]) + 1;
+      // Determine selectionMatchProp column number (add offset due to the checkbox column)
+      offset = ctrl.config.showCheckboxes ? 1 : 0;
+      ctrl.selectionMatchPropColNum = _.findIndex(ctrl.columns, ['itemField', ctrl.config.selectionMatchProp]) + offset;
 
       // add actions col.
       if (ctrl.actionButtons && ctrl.actionButtons.length > 0) {
@@ -234,43 +239,45 @@ angular.module('patternfly.table').component('pfTableView', {
     }
 
     function selectRowsByChecked () {
-      $timeout(function () {
-        var oTable, rows, checked;
+      if (ctrl.config.showCheckboxes) {
+        $timeout(function () {
+          var oTable, rows, checked;
 
-        oTable = ctrl.dtInstance.DataTable;
+          oTable = ctrl.dtInstance.DataTable;
 
-        if (ctrl.debug) {
-          $log.debug("  selectRowsByChecked");
-        }
+          if (ctrl.debug) {
+            $log.debug("  selectRowsByChecked");
+          }
 
-        if (angular.isUndefined(oTable)) {
-          return;
-        }
+          if (angular.isUndefined(oTable)) {
+            return;
+          }
 
-        if (ctrl.debug) {
-          $log.debug("  ...oTable defined");
-        }
+          if (ctrl.debug) {
+            $log.debug("  ...oTable defined");
+          }
 
-        // deselect all
-        rows = oTable.rows();
-        rows.deselect();
+          // deselect all
+          rows = oTable.rows();
+          rows.deselect();
 
-        // select those with checked checkboxes
-        rows = oTable.rows( function ( idx, data, node ) {
-          //         row      td     input type=checkbox
-          checked = node.children[0].children[0].checked;
-          return checked;
+          // select those with checked checkboxes
+          rows = oTable.rows( function ( idx, data, node ) {
+            //         row      td     input type=checkbox
+            checked = node.children[0].children[0].checked;
+            return checked;
+          });
+
+          if (ctrl.debug) {
+            $log.debug("   ... #checkedRows = " + rows[0].length);
+          }
+
+          if (rows[0].length > 0) {
+            rows.select();
+          }
+          setSelectAllCheckbox();
         });
-
-        if (ctrl.debug) {
-          $log.debug("   ... #checkedRows = " + rows[0].length);
-        }
-
-        if (rows[0].length > 0) {
-          rows.select();
-        }
-        setSelectAllCheckbox();
-      });
+      }
     }
 
     function setSelectAllCheckbox () {

--- a/src/table/tableview/table-view.html
+++ b/src/table/tableview/table-view.html
@@ -4,14 +4,16 @@
          class="table-view-container table table-striped table-bordered table-hover dataTable">
     <thead>
       <tr role="row">
-        <th class="table-view-pf-select"><input type="checkbox" value="$ctrl.selectAll" ng-model="$ctrl.selectAll" ng-change="$ctrl.toggleAll()"/></th>
+        <th class="table-view-pf-select" ng-if="$ctrl.config.showCheckboxes">
+          <input type="checkbox" value="$ctrl.selectAll" ng-model="$ctrl.selectAll" ng-change="$ctrl.toggleAll()"/>
+        </th>
         <th ng-repeat="col in $ctrl.columns">{{col.header}}</th>
         <th ng-if="$ctrl.areActions()" colspan="{{$ctrl.calcActionsColspan()}}">Actions</th>
       </tr>
     </thead>
     <tbody>
     <tr role="row" ng-repeat="item in $ctrl.items track by $index">
-      <td class="table-view-pf-select">
+      <td class="table-view-pf-select" ng-if="$ctrl.config.showCheckboxes">
         <input type="checkbox" value="item.selected" ng-model="item.selected" ng-change="$ctrl.toggleOne(item)"/>
       </td>
       <td ng-repeat="(key, value) in item" ng-if="$ctrl.isColItemFld(key)">{{ value }}</td>

--- a/test/table/tableview/table-view.spec.js
+++ b/test/table/tableview/table-view.spec.js
@@ -68,7 +68,23 @@ describe('Component: pfTableView', function () {
 
   it('should show the correct number of items', function () {
     var rows = element.find('.table > tbody > tr');
-    expect(rows.length).toBe(5);
+    expect(rows.length).toBe($scope.items.length);
+  });
+
+  it('should show checkboxes for row selection', function () {
+    var headerCheckbox = element.find('.table > thead > tr > th > input[type="checkbox"]');
+    var bodyCheckboxes = element.find('.table > tbody > tr > td > input[type="checkbox"]');
+    expect(headerCheckbox.length).toBe(1);
+    expect(bodyCheckboxes.length).toBe($scope.items.length);
+  });
+
+  it('should not show checkboxes for row selection when "showCheckboxes" is false', function () {
+    $scope.config.showCheckboxes = false;
+    $scope.$digest();
+    var headerCheckbox = element.find('.table > thead > tr > th > input[type="checkbox"]');
+    var bodyCheckboxes = element.find('.table > tbody > tr > td > input[type="checkbox"]');
+    expect(headerCheckbox.length).toBe(0);
+    expect(bodyCheckboxes.length).toBe(0);
   });
 
 });


### PR DESCRIPTION
Added a new configuration property called `showCheckboxes` to show/hide the column with checkboxes. The default is true.