### PR TITLE
Build Package Update... Again, Greater than Equal To Patternfly Reference

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -47,7 +47,7 @@
     "datatables.net": "^1.10.12",
     "datatables.net-select": "~1.2.0",
     "lodash": "4.x",
-    "patternfly": "^3.25.1"
+    "patternfly": ">=3.25.1"
   },
   "devDependencies": {
     "angular-mocks": "1.5.*",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "angular-ui-bootstrap": "2.3.x",
     "angular-svg-base-fix": "2.0.0",
     "lodash": "4.x",
-    "patternfly": "^3.25.1"
+    "patternfly": ">=3.25.1"
   },
   "devDependencies": {
     "angular-dragdrop": "1.0.13",


### PR DESCRIPTION
After additional review it appears may have not been cautious enough. Updating the build to use "greater than equal to" instead of "caret" gives the additional check of not allowing a minor or patch version below the reference to pass, example:

### Consider we want to reference PatternFly 3.25.1 or greater

- If "^" (caret) was used, a consumer could potentially have a reference to 3.25.0 up to 3.[ANY MINOR &/Or PATCH VERSION] 
  - where there could be a potential minor and/or patch version difference below the intended increment. 
- However if ">=" (greater than or equal to) was used, a consumer could only have a reference to 
 3.25.1 or greater taking into account minor and patch versions


Props to @bleathem for noting this behavior, and reference to merged PR #503 