### PR TITLE
pfTableView: Truly turn off pagination by default

### DIFF
--- a/src/table/tableview/examples/table-view-basic.js
+++ b/src/table/tableview/examples/table-view-basic.js
@@ -235,6 +235,30 @@
               city: "New York",
               state: "New York"
               },
+              {
+              name: "Mike Bird",
+              address: "50 Forth Street",
+              city: "New York",
+              state: "New York"
+              },
+              {
+              name: "Cheryl Taylor",
+              address: "2 Main Street",
+              city: "New York",
+              state: "New York"
+              },
+              {
+              name: "Ren DiLorenzo",
+              address: "10 Chase Lane",
+              city: "Boston",
+              state: "Massacusetts"
+              },
+              {
+              name: "Kim Livingston",
+              address: "5 Tree Hill Lane",
+              city: "Boston",
+              state: "Massacusetts"
+              }
             ];
             resolve(items);
           }, 10);

--- a/src/table/tableview/table-view.component.js
+++ b/src/table/tableview/table-view.component.js
@@ -25,6 +25,7 @@ angular.module('patternfly.table').component('pfTableView', {
       destroy: true,
       order: [[1, "asc"]],
       dom: "t",
+      paging: false,
       select: {
         selector: 'td:first-child input[type="checkbox"]',
         style: 'multi'
@@ -46,9 +47,13 @@ angular.module('patternfly.table').component('pfTableView', {
       if (angular.isDefined(ctrl.colummns) && angular.isUndefined(ctrl.columns)) {
         ctrl.columns = ctrl.colummns;
       }
+
       if (angular.isUndefined(ctrl.dtOptions)) {
         ctrl.dtOptions = {};
+      } else if (angular.isDefined(ctrl.dtOptions.paginationType)) {
+        ctrl.dtOptions.paging = true;
       }
+
       if (angular.isUndefined(ctrl.config)) {
         ctrl.config = {};
       }


### PR DESCRIPTION
By default pagination controls are not displayed in the pfTableView.  Unfortunately, items where still being paginated; as a result only the first 10 items would be displayed and with no pagination controls, there was no way to get to the rest of the items.

This PR sets 'pagination=false' in the default dt options, and thus shows all items.

Fixes #513 

This will all go away when we integrate the pfPagination component into pfTableView.
@akieling