### PR TITLE
Fix typo in notification-drawer.component.js s/hadler/handler

### DIFF
--- a/src/notification/notification-drawer.component.js
+++ b/src/notification/notification-drawer.component.js
@@ -11,7 +11,7 @@
  *   group must include an array of notifications to be shown for that group, the array MUST be called 'notifications'.
  *   You must provide the source for the heading, sub-heading, and notification body to show the content you desire for each.
  *   Pass a customScope object containing any scope variables/functions you need to access from the included source, access these
- *   via hanlders.<your handler> in your included source.
+ *   via handlers.<your handler> in your included source.
  *   <br><br>
  *
  * @param {boolean} drawerHidden Flag if the drawer is currently hidden


### PR DESCRIPTION
Tiny fix, just noticed a typo.
@jeff-phillips-18 

My grand entrance to contribs to `angular-patternfly` 😄 