### PR TITLE
Notification Drawer Updates

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -47,7 +47,7 @@
     "datatables.net": "^1.10.12",
     "datatables.net-select": "~1.2.0",
     "lodash": "4.x",
-    "patternfly": ">=3.25.1"
+    "patternfly": ">=3.26.0"
   },
   "devDependencies": {
     "angular-mocks": "1.5.*",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "angular-ui-bootstrap": "2.3.x",
     "angular-svg-base-fix": "2.0.0",
     "lodash": "4.x",
-    "patternfly": ">=3.25.1"
+    "patternfly": ">=3.26.0"
   },
   "devDependencies": {
     "angular-dragdrop": "1.0.13",

--- a/src/notification/examples/notification-drawer.js
+++ b/src/notification/examples/notification-drawer.js
@@ -1,0 +1,457 @@
+/**
+ * @ngdoc directive
+ * @name patternfly.notification.component:pfNotificationDrawer
+ * @restrict E
+ *
+ * @description
+ *   Component for rendering a notification drawer. This provides a common mechanism to handle how the notification
+ *   drawer should look and behave without mandating the look of the notification group heading or notification body.
+ *   <br><br>
+ *   The notification groups must be passed to create each group in the drawer. Each notification
+ *   group must include a collection of notifications to be shown for that group, the collection MUST be called 'notifications'.
+ *   Each notification should have an 'unread' field in order to style unread notifications and hide/show the Mark All Unread button if desired.
+ *   You must provide the source for the heading, sub-heading, and notification body to show the content you desire for each.
+ *   Pass a customScope object containing any scope variables/functions you need to access from the included source, access these
+ *   via handlers.<your handler> in your included source.
+ *
+ *   Each notification group can add a 'noNotificationsText' field to override the text specifically for that group. If not supplied the overall
+ *   text given will be used for the group if that is supplied. Otherwise, the default empty message is displayed.
+ *
+ *   <br><br>
+ *     The pfNotificationDrawer has stylings pre-set from Patternfly (http://www.patternfly.org/) for use within the
+ *     navbar-pf and navbar-pf-vertical containers. If neither is being used, the top and height should be set such that the
+ *     drawer will take up the entire viewport vertically. For instance:<br>
+ *     <p style="margin-left: 20px;">
+ *       .my-nav-container .drawer-pf {<br>
+ *       &nbsp;&nbsp;height: calc(~"100vh - 46px");<br>
+ *       &nbsp;&nbsp;top: 26px;</br>
+ *       }
+ *     </p>
+ *     Note, this should be bottom aligned with the trigger, and leave a 20px at the bottom of the viewport.
+ *   <br><br>
+ *
+ * @param {boolean} drawerHidden Flag if the drawer is currently hidden
+ * @param {boolean} allowExpand Flag if the drawer can be expanded. Optional, default: false
+ * @param {boolean} drawExpanded Flag if the drawer is expanded (only valid if allowExpand is true). Optional, default: false
+ * @param {string}  drawerTitle  Title to display for the drawer (leaving this blank will remove the provided expand capability)
+ * @param {object} notificationGroups Collection notification groups to add to the drawer. Alternatively, a single group object can be given if categorization is not used.
+ * @param {function} onClose function() Callback for the close button. Close button is shown if this callback is supplied. Callback should set drawerHidden to true to close the drawer.
+ * @param {boolean} showMarkAllRead Flag if the mark all read button should be shown, optional, default is false
+ * @param {function} onMarkAllRead function(notificationGroup) Callback method for the mark all read button (Optional)
+ * @param {boolean} showClearAll Flag if the clear all button should be shown, optional, default is false
+ * @param {function} onClearAll function(notificationGroup) Callback method for the clear all button (Optional)
+ * @param {string} actionButtonTitle Text for the lower action button of the drawer (optional, if not specified there will be no action button)
+ * @param {function} actionButtonCallback function(notificationGroup) Callback method for action button for each group, the notificationGroup is passed (Optional)
+ * @param {string} titleInclude Include src for the title area for the notification drawer, use this to customize the drawer title area
+ * @param {string} headingInclude Include src for the heading area for each notification group, access the group via notificationGroup
+ * @param {string} subheadingInclude Include src for the sub-heading area for each notification group, access the group via notificationGroup
+ * @param {string} notificationBodyInclude Include src for the notification body for each notification, access the notification via notification
+ * @param {string} notificationFooterInclude Include src for the notification footer for each notification, access the notification via notification
+ * @param {string} noNotificationsText Text to show when there are no notifications. Optional.
+ * @param {object} customScope Object containing any variables/functions used by the included src, access via $ctrl.customScope.<xxx>
+ *
+ * @example
+ <example module="patternfly.notification.demo" deps="patternfly.utils, patternfly.filters, patternfly.sort, patternfly.views">
+ <file name="index.html">
+   <div ng-controller="DrawerCtrl" class="row example-container">
+     <div class="col-md-12 pre-demo-text">
+       <label>Click the notifications indicator to show the Notification Drawer: </label>
+     </div>
+     <div class="navbar-pf-vertical">
+       <nav class="collapse navbar-collapse">
+         <ul class="nav navbar-nav navbar-left navbar-iconic">
+           <li class="drawer-pf-trigger dropdown" ng-class="{'open': !hideDrawer}">
+             <a class="nav-item-iconic drawer-pf-trigger-icon" ng-click="toggleShowDrawer()">
+               <span class="fa fa-bell" title="Notifications"></span>
+               <span ng-if="unreadNotifications" class="badge"> </span>
+             </a>
+           </li>
+         </ul>
+       </nav>
+     </div>
+     <div class="layout-pf-fixed">
+       <div class="navbar-pf-vertical">
+         <pf-notification-drawer drawer-hidden="hideDrawer" drawer-title="Notifications Drawer" allow-expand="true"
+              notification-groups="groups" on-close="closeDrawer"
+              show-mark-all-read="true" on-mark-all-read="markAllRead"
+              show-clear-all="true" on-clear-all="clearAll"
+              heading-include="heading.html" subheading-include="subheading.html" notification-body-include="notification-body.html"
+              notification-footer-include="notification-footer.html" custom-scope="customScope">
+         </pf-notification-drawer>
+       </div>
+     </div>
+     <div class="col-md-12">
+       <label class="actions-label">Actions: </label>
+     </div>
+     <div class="col-md-12">
+       <textarea rows="3" class="col-md-12">{{actionsText}}</textarea>
+     </div>
+   </div>
+ </file>
+ <file name="heading.html">
+   {{notificationGroup.heading}}
+ </file>
+ <file name="subheading.html">
+   {{notificationGroup.subHeading}}
+ </file>
+ <file name="notification-footer.html">
+ </file>
+ <file name="notification-body.html">
+   <div uib-dropdown class="dropdown pull-right dropdown-kebab-pf" ng-if="notification.actions && notification.actions.length > 0">
+     <button uib-dropdown-toggle class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+       <span class="fa fa-ellipsis-v"></span>
+     </button>
+     <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight">
+       <li ng-repeat="action in notification.actions"
+           role="{{action.isSeparator === true ? 'separator' : 'menuitem'}}"
+           ng-class="{'divider': action.isSeparator === true, 'disabled': action.isDisabled === true}">
+         <a ng-if="action.isSeparator !== true" class="secondary-action" title="{{action.title}}" ng-click="$ctrl.customScope.handleAction(notification, action)">
+           {{action.name}}
+         </a>
+       </li>
+     </ul>
+   </div>
+  <span ng-if="notification.status" class="{{'pull-left ' + $ctrl.customScope.getNotficationStatusIconClass(notification)}}" ng-click="$ctrl.customScope.markRead(notification)"></span>
+   <div class="drawer-pf-notification-content" ng-click="$ctrl.customScope.markRead(notification)">
+     <span class="drawer-pf-notification-message" tooltip-append-to-body="true" tooltip-popup-delay="500" tooltip-placement="bottom" tooltip="{{notification.message}}">
+      {{notification.message}}
+     </span>
+     <div class="drawer-pf-notification-info" ng-click="$ctrl.customScope.markRead(notification)">
+       <span class="date">{{notification.timeStamp | date:'MM/dd/yyyy'}}</span>
+       <span class="time">{{notification.timeStamp | date:'h:mm:ss a'}}</span>
+     </div>
+   </div>
+ </file>
+ <file name="modules.js">
+   angular.module('patternfly.notification.demo', ['patternfly.notification','patternfly.views']);
+ </file>
+
+ <file name="script.js">
+   angular.module('patternfly.notification.demo').controller('DrawerCtrl', ['$scope',
+     function ($scope) {
+       var currentTime = (new Date()).getTime();
+
+       var updateUnreadStatus = function() {
+         $scope.unreadNotifications = _.find($scope.groups, function(group) {
+           return _.find(group.notifications, {unread: true});
+         });
+       };
+
+       $scope.hideDrawer = true;
+       $scope.toggleShowDrawer = function () {
+         $scope.hideDrawer = !$scope.hideDrawer;
+       };
+
+       $scope.closeDrawer = function() {
+         $scope.hideDrawer = true;
+       };
+
+       var menuActions = [
+          {
+            name: 'Action',
+            title: 'Perform an action'
+          },
+          {
+            name: 'Another Action',
+            title: 'Do something else'
+          },
+          {
+            name: 'Disabled Action',
+            title: 'Unavailable action',
+            isDisabled: true
+          },
+          {
+            name: 'Something Else',
+            title: ''
+          },
+          {
+            isSeparator: true
+          },
+          {
+            name: 'Grouped Action 1',
+            title: 'Do something'
+          },
+          {
+            name: 'Grouped Action 2',
+            title: 'Do something similar'
+          }
+        ];
+
+
+       $scope.groups = [
+         {
+           heading: "Notification Tab 1",
+           subHeading: "5 New Events",
+           notifications: [
+             {
+               unread: true,
+               message: "A New Event! Huzzah! Bold.",
+               status: 'info',
+               actions: menuActions,
+               timeStamp: currentTime - (1 * 60 * 60 * 1000)
+             },
+             {
+               unread: true,
+               message: "Another Event Notification",
+               status: 'ok',
+               actions: menuActions,
+               timeStamp: currentTime - (2 * 60 * 60 * 1000)
+             },
+             {
+               unread: false,
+               message: "Another Event Notification",
+               status: 'warning',
+               actions: menuActions,
+               timeStamp: currentTime - (10 * 60 * 60 * 1000)
+             },
+             {
+               unread: false,
+               message: "Another Event Notification",
+               status: 'error',
+               actions: menuActions,
+               timeStamp: currentTime - (12 * 60 * 60 * 1000)
+             },
+             {
+               unread: true,
+               message: "A New Event! Huzzah! Bold",
+               status: 'info',
+               actions: menuActions,
+               timeStamp: currentTime - (1 * 60 * 60 * 1000)
+             },
+             {
+               unread: true,
+               message: "Another Event Notification",
+               status: 'error',
+               actions: menuActions,
+               timeStamp: currentTime - (2 * 60 * 60 * 1000)
+             },
+             {
+               unread: false,
+               message: "Another Event Notification",
+               status: 'ok',
+               actions: menuActions,
+               timeStamp: currentTime - (10 * 60 * 60 * 1000)
+             },
+             {
+               unread: false,
+               message: "Another Event Notification",
+               status: 'warning',
+               actions: menuActions,
+               timeStamp: currentTime - (12 * 60 * 60 * 1000)
+             },
+             {
+               unread: true,
+               message: "Another Event Notification",
+               status: 'info',
+               actions: menuActions,
+               timeStamp: currentTime - (240 * 60 * 60 * 1000)
+             }
+           ],
+           isLoading: true
+         },
+         {
+           heading: "Notification Tab 2",
+           subHeading: "3 New Events",
+           notifications: [
+             {
+               unread: true,
+               message: "A New Event! Huzzah! Bold",
+               status: 'info',
+               actions: menuActions,
+               timeStamp: currentTime - (1 * 60 * 60 * 1000)
+             },
+             {
+               unread: true,
+               message: "Another Event Notification",
+               status: 'error',
+               actions: menuActions,
+               timeStamp: currentTime - (2 * 60 * 60 * 1000)
+             },
+             {
+               unread: false,
+               message: "Another Event Notification",
+               status: 'warning',
+               actions: menuActions,
+               timeStamp: currentTime - (10 * 60 * 60 * 1000)
+             },
+             {
+               unread: false,
+               message: "Another Event Notification",
+               status: 'ok',
+               actions: menuActions,
+               timeStamp: currentTime - (12 * 60 * 60 * 1000)
+             },
+             {
+               unread: true,
+               message: "Another Event Notification",
+               status: 'warning',
+               actions: menuActions,
+               timeStamp: currentTime - (240 * 60 * 60 * 1000)
+             }
+           ]
+         },
+         {
+           heading: "Notification Tab 3",
+           subHeading: "0 New Events",
+           notifications: [],
+           noNotificationsText: "No Tab 3 notifications found."
+         },
+         {
+           heading: "Notification Tab 4",
+           subHeading: "3 New Events",
+           notifications: [
+             {
+               unread: true,
+               message: "A New Event! Huzzah! Bold",
+               status: 'warning',
+               actions: menuActions,
+               timeStamp: currentTime - (1 * 60 * 60 * 1000)
+             },
+             {
+               unread: true,
+               message: "Another Event Notification",
+               status: 'ok',
+               actions: menuActions,
+               timeStamp: currentTime - (2 * 60 * 60 * 1000)
+             },
+             {
+               unread: false,
+               message: "Another Event Notification",
+               status: 'ok',
+               actions: menuActions,
+               timeStamp: currentTime - (10 * 60 * 60 * 1000)
+             },
+             {
+               unread: false,
+               message: "Another Event Notification",
+               status: 'error',
+               actions: menuActions,
+               timeStamp: currentTime - (12 * 60 * 60 * 1000)
+             },
+             {
+               unread: true,
+               message: "Another Event Notification",
+               status: 'info',
+               actions: menuActions,
+               timeStamp: currentTime - (240 * 60 * 60 * 1000)
+             }
+           ]
+         },
+         {
+           heading: "Notification Tab 5",
+           subHeading: "3 New Events",
+           notifications: [
+             {
+               unread: true,
+               message: "A New Event! Huzzah! Bold",
+               status: 'error',
+               actions: menuActions,
+               timeStamp: currentTime - (1 * 60 * 60 * 1000)
+             },
+             {
+               unread: true,
+               message: "Another Event Notification",
+               status: 'error',
+               actions: menuActions,
+               timeStamp: currentTime - (2 * 60 * 60 * 1000)
+             },
+             {
+               unread: false,
+               message: "Another Event Notification",
+               status: 'warning',
+               actions: menuActions,
+               timeStamp: currentTime - (10 * 60 * 60 * 1000)
+             },
+             {
+               unread: false,
+               message: "Another Event Notification",
+               status: 'warning',
+               actions: menuActions,
+               timeStamp: currentTime - (12 * 60 * 60 * 1000)
+             },
+             {
+               unread: true,
+               message: "Another Event Notification",
+               status: 'error',
+               actions: menuActions,
+               timeStamp: currentTime - (240 * 60 * 60 * 1000)
+             }
+           ]
+         },
+         {
+           heading: "Notification Tab 6",
+           subHeading: "0 New Events",
+           notifications: []
+         },
+       ];
+
+       updateUnreadStatus();
+       $scope.actionsText = "";
+
+       $scope.markAllRead = function (group) {
+         $scope.actionsText = "Mark all read: " + group.heading + "\n" + $scope.actionsText;
+         angular.forEach(group.notifications, function(nextNotification) {
+           nextNotification.unread = false;
+         });
+         group.subHeading =  "0 New Events";
+         updateUnreadStatus();
+       };
+
+       $scope.clearAll = function (group) {
+         $scope.actionsText = "Clear all: " + group.heading + "\n" + $scope.actionsText;
+         group.notifications = [];
+         group.subHeading = "0 New Events";
+       };
+
+       //
+       // Define customScope to contain anything that needs to be accessed from the included source
+       // html files (heading, subheading, or notificaton body).
+       //
+
+       $scope.customScope = {};
+       $scope.customScope.getNotficationStatusIconClass = function (notification) {
+         var retClass = '';
+         if (notification && notification.status) {
+           if (notification.status === 'info') {
+             retClass = "pficon pficon-info";
+           } else if (notification.status === 'error') {
+             retClass = "pficon pficon-error-circle-o";
+           } else if (notification.status === 'warning') {
+             retClass = "pficon pficon-warning-triangle-o";
+           } else if (notification.status === 'ok') {
+             retClass = "pficon pficon-ok";
+           }
+         }
+         return retClass;
+       };
+
+       $scope.customScope.handleAction = function (notification, action) {
+         if (action.isDisabled) {
+           return;
+         }
+         var newText = notification.message + " - " + action.name;
+         $scope.actionsText = newText + "\n" + $scope.actionsText;
+       };
+
+       $scope.customScope.markRead = function (notification) {
+         if (notification.unread) {
+           notification.unread = false;
+           $scope.actionsText = "Mark notification read" + "\n" + $scope.actionsText;
+           var notificationGroup = $scope.groups.find(function(group) {
+             return group.notifications.find(function(nextNotification) {
+               return notification === nextNotification;
+             });
+           });
+           var unread = notificationGroup.notifications.filter(function(nextNotification) {
+             return nextNotification.unread;
+           });
+           notificationGroup.subHeading =  unread.length + " New Events";
+           updateUnreadStatus();
+         }
+       };
+
+     }
+   ]);
+ </file>
+</example>
+*/

--- a/src/notification/notification-drawer.component.js
+++ b/src/notification/notification-drawer.component.js
@@ -1,484 +1,15 @@
-/**
- * @ngdoc directive
- * @name patternfly.notification.component:pfNotificationDrawer
- * @restrict E
- *
- * @description
- *   Component for rendering a notification drawer. This provides a common mechanism to handle how the notification
- *   drawer should look and behave without mandating the look of the notification group heading or notification body.
- *   <br><br>
- *   An array of notification groups must be passed to create each group in the drawer. Each notification
- *   group must include an array of notifications to be shown for that group, the array MUST be called 'notifications'.
- *   You must provide the source for the heading, sub-heading, and notification body to show the content you desire for each.
- *   Pass a customScope object containing any scope variables/functions you need to access from the included source, access these
- *   via handlers.<your handler> in your included source.
- *   <br><br>
- *
- * @param {boolean} drawerHidden Flag if the drawer is currently hidden
- * @param {boolean} allowExpand Flag if the drawer can be expanded. Optional, default: false
- * @param {boolean} drawExpanded Flag if the drawer is expanded (only valid if allowExpand is true). Optional, default: false
- * @param {string}  drawerTitle  Title to display for the drawer (leaving this blank will remove the provided expand capability)
- * @param {object} notificationGroups Array of notification groups to add to the drawer
- * @param {string} actionButtonTitle Text for the lower action button of the drawer (optional, if not specified there will be no action button)
- * @param {function} actionButtonCallback function(notificationGroup) Callback method for action button for each group, the notificationGroup is passed (Optional)
- * @param {string} titleInclude Include src for the title area for the notification drawer, use this to customize the drawer title area
- * @param {string} headingInclude Include src for the heading area for each notification group, access the group via notificationGroup
- * @param {string} subheadingInclude Include src for the sub-heading area for each notification group, access the group via notificationGroup
- * @param {string} notificationBodyInclude Include src for the notification body for each notification, access the notification via notification
- * @param {string} notificationFooterInclude Include src for the notification footer for each notification, access the notification via notification
- * @param {object} customScope Object containing any variables/functions used by the included src, access via $ctrl.customScope.<xxx>
- *
- * @example
- <example module="patternfly.notification" deps="patternfly.utils, patternfly.filters, patternfly.sort, patternfly.views">
- <file name="index.html">
-   <div ng-controller="DrawerCtrl" class="row example-container">
-     <div class="col-md-12 pre-demo-text">
-       <label>Click the notifications indicator to show the Notification Drawer: </label>
-     </div>
-     <div class="navbar-pf-vertical">
-       <nav class="collapse navbar-collapse">
-         <ul class="nav navbar-nav navbar-left navbar-iconic">
-           <li class="drawer-pf-trigger dropdown">
-             <a class="nav-item-iconic drawer-pf-trigger-icon" ng-click="toggleShowDrawer()">
-               <span class="fa fa-bell" title="Notifications"></span>
-             </a>
-           </li>
-         </ul>
-       </nav>
-     </div>
-     <div class="layout-pf-fixed">
-       <div class="navbar-pf-vertical">
-         <pf-notification-drawer drawer-hidden="hideDrawer" drawer-title="Notifications Drawer" allow-expand="true"
-              action-button-title="Mark All Read" action-button-callback="actionButtonCB" notification-groups="groups"
-              heading-include="heading.html" subheading-include="subheading.html" notification-body-include="notification-body.html"
-              notification-footer-include="notification-footer.html" custom-scope="customScope">
-         </pf-notification-drawer>
-       </div>
-     </div>
-     <div class="col-md-12">
-       <label class="actions-label">Actions: </label>
-     </div>
-     <div class="col-md-12">
-       <textarea rows="3" class="col-md-12">{{actionsText}}</textarea>
-     </div>
-   </div>
- </file>
- <file name="heading.html">
-   {{notificationGroup.heading}}
- </file>
- <file name="subheading.html">
-   {{notificationGroup.subHeading}}
- </file>
- <file name="notification-footer.html">
-   <a class="btn btn-link btn-block" role="button" ng-click="$ctrl.customScope.clearAll(notificationGroup)">
-     <span class="pficon pficon-close"></span>
-     <span> Clear All</span>
-   </a>
- </file>
- <file name="notification-body.html">
-   <div ng-if="!drawerExpanded">
-     <div uib-dropdown class="dropdown pull-right dropdown-kebab-pf" ng-if="notification.actions && notification.actions.length > 0">
-       <button uib-dropdown-toggle class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-         <span class="fa fa-ellipsis-v"></span>
-       </button>
-       <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight">
-         <li ng-repeat="action in notification.actions"
-             role="{{action.isSeparator === true ? 'separator' : 'menuitem'}}"
-             ng-class="{'divider': action.isSeparator === true, 'disabled': action.isDisabled === true}">
-           <a ng-if="action.isSeparator !== true" class="secondary-action" title="{{action.title}}" ng-click="$ctrl.customScope.handleAction(notification, action)">
-             {{action.name}}
-           </a>
-         </li>
-       </ul>
-     </div>
-     <span ng-if="notification.status" class="{{'pull-left ' + $ctrl.customScope.getNotficationStatusIconClass(notification)}}" ng-click="$ctrl.customScope.markRead(notification)"></span>
-     <span class="drawer-pf-notification-message" ng-click="$ctrl.customScope.markRead(notification)">{{notification.message}}</span>
-     <div class="drawer-pf-notification-info" ng-click="$ctrl.customScope.markRead(notification)">
-       <span class="date">{{notification.timeStamp | date:'MM/dd/yyyy'}}</span>
-       <span class="time">{{notification.timeStamp | date:'h:mm:ss a'}}</span>
-     </div>
-   </div>
-   <div ng-if="drawerExpanded" class="container-fluid">
-     <div class="row">
-       <div class="col-sm-6">
-         <span class="pull-left {{$ctrl.customScope.getNotficationStatusIconClass(notification)}}"></span>
-         <span class="drawer-pf-notification-message notification-message"
-               tooltip-append-to-body="true" tooltip-popup-delay="500" tooltip-placement="bottom" tooltip="{{notification.message}}">
-               {{notification.message}}
-         </span>
-       </div>
-       <div class="col-sm-6">
-         <div class="drawer-pf-notification-info">
-           <span class="date">{{notification.timeStamp | date:'MM/dd/yyyy'}}</span>
-           <span class="time">{{notification.timeStamp | date:'h:mm:ss a'}}</span>
-         </div>
-         <div class="dropdown pull-right dropdown-kebab-pf" ng-if="notification.actions && notification.actions.length > 0">
-           <button class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-             <span class="fa fa-ellipsis-v"></span>
-           </button>
-           <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight">
-             <li ng-repeat="action in notification.actions"
-                 role="{{action.isSeparator === true ? 'separator' : 'menuitem'}}"
-                 ng-class="{'divider': action.isSeparator === true, 'disabled': action.isDisabled === true}">
-               <a ng-if="action.isSeparator !== true" class="secondary-action" title="{{action.title}}" ng-click="$ctrl.customScope.handleAction(notification, action)">
-                 {{action.name}}
-               </a>
-             </li>
-           </ul>
-         </div>
-       </div>
-     </div>
-   </div>
- </file>
- <file name="script.js">
-   angular.module('patternfly.notification').controller('DrawerCtrl', ['$scope',
-     function ($scope) {
-       var currentTime = (new Date()).getTime();
-       $scope.hideDrawer = true;
-       $scope.toggleShowDrawer = function () {
-         $scope.hideDrawer = !$scope.hideDrawer;
-       };
-
-       var menuActions = [
-          {
-            name: 'Action',
-            title: 'Perform an action'
-          },
-          {
-            name: 'Another Action',
-            title: 'Do something else'
-          },
-          {
-            name: 'Disabled Action',
-            title: 'Unavailable action',
-            isDisabled: true
-          },
-          {
-            name: 'Something Else',
-            title: ''
-          },
-          {
-            isSeparator: true
-          },
-          {
-            name: 'Grouped Action 1',
-            title: 'Do something'
-          },
-          {
-            name: 'Grouped Action 2',
-            title: 'Do something similar'
-          }
-        ];
-
-
-       $scope.groups = [
-         {
-           heading: "Notification Tab 1",
-           subHeading: "5 New Events",
-           notifications: [
-             {
-               unread: true,
-               message: "A New Event! Huzzah! Bold",
-               status: 'info',
-               actions: menuActions,
-               timeStamp: currentTime - (1 * 60 * 60 * 1000)
-             },
-             {
-               unread: true,
-               message: "Another Event Notification",
-               status: 'ok',
-               actions: menuActions,
-               timeStamp: currentTime - (2 * 60 * 60 * 1000)
-             },
-             {
-               unread: false,
-               message: "Another Event Notification",
-               status: 'warning',
-               actions: menuActions,
-               timeStamp: currentTime - (10 * 60 * 60 * 1000)
-             },
-             {
-               unread: false,
-               message: "Another Event Notification",
-               status: 'error',
-               actions: menuActions,
-               timeStamp: currentTime - (12 * 60 * 60 * 1000)
-             },
-             {
-               unread: true,
-               message: "A New Event! Huzzah! Bold",
-               status: 'info',
-               actions: menuActions,
-               timeStamp: currentTime - (1 * 60 * 60 * 1000)
-             },
-             {
-               unread: true,
-               message: "Another Event Notification",
-               status: 'error',
-               actions: menuActions,
-               timeStamp: currentTime - (2 * 60 * 60 * 1000)
-             },
-             {
-               unread: false,
-               message: "Another Event Notification",
-               status: 'ok',
-               actions: menuActions,
-               timeStamp: currentTime - (10 * 60 * 60 * 1000)
-             },
-             {
-               unread: false,
-               message: "Another Event Notification",
-               status: 'warning',
-               actions: menuActions,
-               timeStamp: currentTime - (12 * 60 * 60 * 1000)
-             },
-             {
-               unread: true,
-               message: "Another Event Notification",
-               status: 'info',
-               actions: menuActions,
-               timeStamp: currentTime - (240 * 60 * 60 * 1000)
-             }
-           ],
-           isLoading: true
-         },
-         {
-           heading: "Notification Tab 2",
-           subHeading: "3 New Events",
-           notifications: [
-             {
-               unread: true,
-               message: "A New Event! Huzzah! Bold",
-               status: 'info',
-               actions: menuActions,
-               timeStamp: currentTime - (1 * 60 * 60 * 1000)
-             },
-             {
-               unread: true,
-               message: "Another Event Notification",
-               status: 'error',
-               actions: menuActions,
-               timeStamp: currentTime - (2 * 60 * 60 * 1000)
-             },
-             {
-               unread: false,
-               message: "Another Event Notification",
-               status: 'warning',
-               actions: menuActions,
-               timeStamp: currentTime - (10 * 60 * 60 * 1000)
-             },
-             {
-               unread: false,
-               message: "Another Event Notification",
-               status: 'ok',
-               actions: menuActions,
-               timeStamp: currentTime - (12 * 60 * 60 * 1000)
-             },
-             {
-               unread: true,
-               message: "Another Event Notification",
-               status: 'warning',
-               actions: menuActions,
-               timeStamp: currentTime - (240 * 60 * 60 * 1000)
-             }
-           ]
-         },
-         {
-           heading: "Notification Tab 3",
-           subHeading: "3 New Events",
-           notifications: [
-             {
-               unread: true,
-               message: "A New Event! Huzzah! Bold",
-               status: 'ok',
-               actions: menuActions,
-               timeStamp: currentTime - (1 * 60 * 60 * 1000)
-             },
-             {
-               unread: true,
-               message: "Another Event Notification",
-               status: 'warning',
-               actions: menuActions,
-               timeStamp: currentTime - (2 * 60 * 60 * 1000)
-             },
-             {
-               unread: false,
-               message: "Another Event Notification",
-               status: 'info',
-               actions: menuActions,
-               timeStamp: currentTime - (10 * 60 * 60 * 1000)
-             },
-             {
-               unread: false,
-               message: "Another Event Notification",
-               status: 'ok',
-               actions: menuActions,
-               timeStamp: currentTime - (12 * 60 * 60 * 1000)
-             },
-             {
-               unread: true,
-               message: "Another Event Notification",
-               status: 'error',
-               actions: menuActions,
-               timeStamp: currentTime - (240 * 60 * 60 * 1000)
-             }
-           ]
-         },
-         {
-           heading: "Notification Tab 4",
-           subHeading: "3 New Events",
-           notifications: [
-             {
-               unread: true,
-               message: "A New Event! Huzzah! Bold",
-               status: 'warning',
-               actions: menuActions,
-               timeStamp: currentTime - (1 * 60 * 60 * 1000)
-             },
-             {
-               unread: true,
-               message: "Another Event Notification",
-               status: 'ok',
-               actions: menuActions,
-               timeStamp: currentTime - (2 * 60 * 60 * 1000)
-             },
-             {
-               unread: false,
-               message: "Another Event Notification",
-               status: 'ok',
-               actions: menuActions,
-               timeStamp: currentTime - (10 * 60 * 60 * 1000)
-             },
-             {
-               unread: false,
-               message: "Another Event Notification",
-               status: 'error',
-               actions: menuActions,
-               timeStamp: currentTime - (12 * 60 * 60 * 1000)
-             },
-             {
-               unread: true,
-               message: "Another Event Notification",
-               status: 'info',
-               actions: menuActions,
-               timeStamp: currentTime - (240 * 60 * 60 * 1000)
-             }
-           ]
-         },
-         {
-           heading: "Notification Tab 5",
-           subHeading: "3 New Events",
-           notifications: [
-             {
-               unread: true,
-               message: "A New Event! Huzzah! Bold",
-               status: 'error',
-               actions: menuActions,
-               timeStamp: currentTime - (1 * 60 * 60 * 1000)
-             },
-             {
-               unread: true,
-               message: "Another Event Notification",
-               status: 'error',
-               actions: menuActions,
-               timeStamp: currentTime - (2 * 60 * 60 * 1000)
-             },
-             {
-               unread: false,
-               message: "Another Event Notification",
-               status: 'warning',
-               actions: menuActions,
-               timeStamp: currentTime - (10 * 60 * 60 * 1000)
-             },
-             {
-               unread: false,
-               message: "Another Event Notification",
-               status: 'warning',
-               actions: menuActions,
-               timeStamp: currentTime - (12 * 60 * 60 * 1000)
-             },
-             {
-               unread: true,
-               message: "Another Event Notification",
-               status: 'error',
-               actions: menuActions,
-               timeStamp: currentTime - (240 * 60 * 60 * 1000)
-             }
-           ]
-         }
-       ];
-
-       $scope.actionsText = "";
-       $scope.actionButtonCB = function (group) {
-         $scope.actionsText = "Action Button clicked: " + group.heading + "\n" + $scope.actionsText;
-         group.notifications.forEach(function(nextNotification) {
-           nextNotification.unread = false;
-         });
-         group.subHeading =  "0 New Events";
-       };
-
-       //
-       // Define customScope to contain anything that needs to be accessed from the included source
-       // html files (heading, subheading, or notificaton body).
-       //
-
-       $scope.customScope = {};
-       $scope.customScope.getNotficationStatusIconClass = function (notification) {
-         var retClass = '';
-         if (notification && notification.status) {
-           if (notification.status === 'info') {
-             retClass = "pficon pficon-info";
-           } else if (notification.status === 'error') {
-             retClass = "pficon pficon-error-circle-o";
-           } else if (notification.status === 'warning') {
-             retClass = "pficon pficon-warning-triangle-o";
-           } else if (notification.status === 'ok') {
-             retClass = "pficon pficon-ok";
-           }
-         }
-         return retClass;
-       };
-       $scope.customScope.handleAction = function (notification, action) {
-         if (action.isDisabled) {
-           return;
-         }
-         var newText = notification.message + " - " + action.name;
-         $scope.actionsText = newText + "\n" + $scope.actionsText;
-       };
-       $scope.customScope.clearAll = function (group) {
-         var newText = group.heading + " - Clear All";
-         $scope.actionsText = newText + "\n" + $scope.actionsText;
-         group.notifications = [];
-         group.subHeading = "0 New Events";
-       };
-
-       $scope.customScope.markRead = function (notification) {
-         if (notification.unread) {
-           notification.unread = false;
-           $scope.actionsText = "Mark notification read" + "\n" + $scope.actionsText;
-           var notificationGroup = $scope.groups.find(function(group) {
-             return group.notifications.find(function(nextNotification) {
-               return notification == nextNotification;
-             });
-           });
-           var unread = notificationGroup.notifications.filter(function(nextNotification) {
-             return nextNotification.unread;
-           });
-           notificationGroup.subHeading =  unread.length + " New Events";
-         }
-       };
-     }
-   ]);
- </file>
-</example>
-*/
 angular.module('patternfly.notification').component('pfNotificationDrawer', {
   bindings: {
-    drawerHidden: '<?',
+    drawerHidden: '<',
     allowExpand: '=?',
     drawerExpanded: '=?',
     drawerTitle: '@',
     notificationGroups: '<',
+    onClose: '=?',
+    showMarkAllRead: '<?',
+    onMarkAllRead: '=?',
+    showClearAll: '<?',
+    onClearAll: '=?',
     actionButtonTitle: '@',
     actionButtonCallback: '=?',
     titleInclude: '@',
@@ -486,6 +17,7 @@ angular.module('patternfly.notification').component('pfNotificationDrawer', {
     subheadingInclude: '@',
     notificationBodyInclude: '@',
     notificationFooterInclude: '@',
+    noNotificationsText: '@',
     customScope: '=?'
   },
   templateUrl: 'notification/notification-drawer.html',
@@ -493,11 +25,37 @@ angular.module('patternfly.notification').component('pfNotificationDrawer', {
     'use strict';
     var ctrl = this;
 
+    var setupGroups = function () {
+      var openFound = false;
+
+      if (angular.isDefined(_.get(ctrl.notificationGroups, 'notifications'))) {
+        ctrl.notificationGroups = [ctrl.notificationGroups];
+      }
+      ctrl.singleGroup = _.size(ctrl.notificationGroups) < 2;
+
+      angular.forEach(ctrl.notificationGroups, function (group) {
+        group.emptyStateConfig = {
+          icon: 'pficon-info',
+          title: group.noNotificationsText || ctrl.noNotificationsText || "There are no notifications to display."
+        };
+      });
+
+      angular.forEach(ctrl.notificationGroups, function (group) {
+        if (group.open) {
+          if (openFound) {
+            group.open = false;
+          } else {
+            openFound = true;
+          }
+        }
+      });
+    };
+
     ctrl.toggleCollapse = function (selectedGroup) {
       if (selectedGroup.open) {
         selectedGroup.open = false;
       } else {
-        ctrl.notificationGroups.forEach(function (group) {
+        angular.forEach(ctrl.notificationGroups, function (group) {
           group.open = false;
         });
         selectedGroup.open = true;
@@ -512,20 +70,18 @@ angular.module('patternfly.notification').component('pfNotificationDrawer', {
       if (!ctrl.allowExpand || angular.isUndefined(ctrl.drawerExpanded)) {
         ctrl.drawerExpanded = false;
       }
+
+      ctrl.emptyStateConfig = {
+        icon: 'pficon-info',
+        title: ctrl.noNotificationsText || "There are no notifications to display."
+      };
+
+      setupGroups();
     };
 
     ctrl.$onChanges = function (changesObj) {
-      var openFound = false;
       if (changesObj.notificationGroups) {
-        changesObj.notificationGroups.currentValue.forEach(function (group) {
-          if (group.open) {
-            if (openFound) {
-              group.open = false;
-            } else {
-              openFound = true;
-            }
-          }
-        });
+        setupGroups();
       }
 
       if (changesObj.drawerHidden) {
@@ -542,6 +98,14 @@ angular.module('patternfly.notification').component('pfNotificationDrawer', {
       if (ctrl.groupClass) {
         $element.find('.panel-group').addClass(ctrl.groupClass);
       }
+    };
+
+    ctrl.hasNotifications = function (notificationGroup) {
+      return _.size(_.get(notificationGroup, 'notifications')) > 0;
+    };
+
+    ctrl.hasUnread = function (notificationGroup) {
+      return _.size(_.filter(_.get(notificationGroup, 'notifications'), {'unread': true})) > 0;
     };
   }
 });

--- a/src/notification/notification-drawer.html
+++ b/src/notification/notification-drawer.html
@@ -1,29 +1,52 @@
 <div class="drawer-pf" ng-class="{'hide': $ctrl.drawerHidden, 'drawer-pf-expanded': $ctrl.drawerExpanded}">
   <div  ng-if="$ctrl.drawerTitle" class="drawer-pf-title">
-    <a ng-if="$ctrl.allowExpand" class="drawer-pf-toggle-expand" ng-click="$ctrl.toggleExpandDrawer()"></a>
+    <a ng-if="$ctrl.allowExpand" class="drawer-pf-toggle-expand fa fa-angle-double-left" ng-click="$ctrl.toggleExpandDrawer()"></a>
+    <a  ng-if="$ctrl.onClose" class="drawer-pf-close pficon pficon-close" ng-click="$ctrl.onClose()"></a>
     <h3 class="text-center">{{$ctrl.drawerTitle}}</h3>
   </div>
   <div ng-if="$ctrl.titleInclude" class="drawer-pf-title" ng-include src="$ctrl.titleInclude"></div>
-  <div pf-fixed-accordion scroll-selector=".panel-body">
+  <div ng-if="!$ctrl.notificationGroups" class="apf-blank-notification-groups">
+    <pf-empty-state config="$ctrl.emptyStateConfig"></pf-empty-state>
+  </div>
+  <div ng-if="$ctrl.notificationGroups" pf-fixed-accordion scroll-selector=".panel-body">
     <div class="panel-group">
       <div class="panel panel-default" ng-repeat="notificationGroup in $ctrl.notificationGroups track by $index">
         <div class="panel-heading">
           <h4 class="panel-title">
-            <a ng-click="$ctrl.toggleCollapse(notificationGroup)" ng-class="{collapsed: !notificationGroup.open}" ng-include src="$ctrl.headingInclude"></a>
+            <a ng-if="!$ctrl.singleGroup" ng-click="$ctrl.toggleCollapse(notificationGroup)" ng-class="{collapsed: !notificationGroup.open}" ng-include src="$ctrl.headingInclude"></a>
+            <span ng-if="$ctrl.singleGroup" ng-include src="$ctrl.headingInclude"></span>
           </h4>
           <span class="panel-counter" ng-include src="$ctrl.subheadingInclude"></span>
         </div>
-        <div class="panel-collapse collapse" ng-class="{in: notificationGroup.open}">
-          <div class="panel-body">
-            <div class="drawer-pf-notification" ng-class="{unread: notification.unread, 'expanded-notification': $ctrl.drawerExpanded}"
-                 ng-repeat="notification in notificationGroup.notifications" ng-include src="$ctrl.notificationBodyInclude">
+        <div class="panel-collapse collapse" ng-class="{in: notificationGroup.open || $ctrl.notificationGroups.length === 1}">
+          <div ng-if="$ctrl.hasNotifications(notificationGroup)">
+            <div class="panel-body">
+              <div class="drawer-pf-notification" ng-class="{unread: notification.unread, 'expanded-notification': $ctrl.drawerExpanded}"
+                   ng-repeat="notification in notificationGroup.notifications" ng-include src="$ctrl.notificationBodyInclude">
+              </div>
+              <div ng-if="notificationGroup.isLoading" class="drawer-pf-loading text-center">
+                <span class="spinner spinner-xs spinner-inline"></span> Loading More
+              </div>
             </div>
-            <div ng-if="notificationGroup.isLoading" class="drawer-pf-loading text-center">
-              <span class="spinner spinner-xs spinner-inline"></span> Loading More
+            <div class="drawer-pf-action">
+            <span class="drawer-pf-action-link" ng-if="$ctrl.showMarkAllRead && $ctrl.hasUnread(notificationGroup)">
+              <button class="btn btn-link" ng-click="$ctrl.onMarkAllRead(notificationGroup)">Mark All Read</button>
+            </span>
+            <span class="drawer-pf-action-link">
+              <button class="btn btn-link" ng-if="$ctrl.showClearAll" ng-click="$ctrl.onClearAll(notificationGroup)">
+                <span class="pficon pficon-close"></span>
+                Clear All
+              </button>
+            </span>
+            </div>
+            <div class="drawer-pf-action" ng-if="$ctrl.actionButtonTitle">
+              <a class="btn btn-link btn-block" ng-click="$ctrl.actionButtonCallback(notificationGroup)">{{$ctrl.actionButtonTitle}}</a>
             </div>
           </div>
-          <div class="drawer-pf-action" ng-if="$ctrl.actionButtonTitle">
-            <a class="btn btn-link btn-block" ng-click="$ctrl.actionButtonCallback(notificationGroup)">{{$ctrl.actionButtonTitle}}</a>
+          <div ng-if="!$ctrl.hasNotifications(notificationGroup)">
+            <div class="panel-body">
+              <pf-empty-state config="notificationGroup.emptyStateConfig"></pf-empty-state>
+            </div>
           </div>
           <div ng-if="$ctrl.notificationFooterInclude" ng-include src="$ctrl.notificationFooterInclude">
           </div>

--- a/test/notification/notification-footer.html
+++ b/test/notification/notification-footer.html
@@ -1,4 +1,4 @@
-<a class="btn btn-link btn-block footer-class" role="button" ng-click="$ctrl.customScope.handleAction(notificationGroup, 'Clear All')">
+<a class="btn btn-block footer-class" role="button" ng-click="$ctrl.customScope.handleAction(notificationGroup, 'Clear All')">
   <span class="pficon pficon-close"></span>
   <span> Clear All</span>
 </a>


### PR DESCRIPTION
Updates to latest Patternfly design pattern from: https://github.com/patternfly/patternfly-design/pull/297
Bumps https://github.com/patternfly/patternfly version to 3.26.0  

Fixes #414
Fixes #419 
Fixes #420 - Adds documentation on styling for drawer with different navigation layouts
Fixes #421 - Adds a close button to the notification drawer title area
Fixes #430 - Update layout to handle long notification messages
Fixes #429 #432 - Allows a single group to be used thus not using an accordion for groups
Fixes #431 - Displays the pf-empty-state when there are no notifications or none in a particular group. Allows setting the empty message for each.

@benjaminapetersen
