### PR TITLE
Update readme to reflect changes to dependency paths in node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,21 +67,21 @@ Note:
 
     ```html
     <!-- Angular -->
-    <script src="node_modules/angular-patternfly/node_modules/angular/angular.min.js"></script>
+    <script src="node_modules/angular/angular.min.js"></script>
     
     <!-- Angular-Bootstrap -->
-    <script src="node_modules/angular-patternfly/node_modules/angular-ui-bootstrap/dist/ui-bootstrap.js"></script>
-    <script src="node_modules/angular-patternfly/node_modules/angular-ui-bootstrap/dist/ui-bootstrap-tpls.js"></script>
+    <script src="node_modules/angular-ui-bootstrap/dist/ui-bootstrap.js"></script>
+    <script src="node_modules/angular-ui-bootstrap/dist/ui-bootstrap-tpls.js"></script>
     
     <!-- Angular-Sanitize -->
-    <script src="node_modules/angular-patternfly/node_modules/angular-sanitize/angular-sanitize.min.js"></script>
+    <script src="node_modules/angular-sanitize/angular-sanitize.min.js"></script>
     
     <!-- Angular-PatternFly  -->
     <script src="node_modules/angular-patternfly/dist/angular-patternfly.min.js"></script>
     
     <!-- C3, D3 - Charting Libraries. Only required if you are using the 'patternfly.charts' module-->
-    <script src="node_modules/angular-patternfly/node_modules/patternfly/node_modules/c3/c3.min.js"></script>
-    <script src="node_modules/angular-patternfly/node_modules/patternfly/node_modules/d3/d3.min.js"></script>
+    <script src="node_modules/patternfly/node_modules/c3/c3.min.js"></script>
+    <script src="node_modules/patternfly/node_modules/d3/d3.min.js"></script>
     ```
 
 5. (optional) The 'patternfly.charts' module is not a dependency in the default angular 'patternfly' module.
@@ -171,7 +171,7 @@ In order to let Webpack find the correct jQuery module when assembling all the d
 ...
 resolve: {
   alias: {
-    "jquery": "angular-patternfly/node_modules/patternfly/node_modules/jquery"
+    "jquery": "patternfly/node_modules/jquery"
   }
 }
 ...


### PR DESCRIPTION
## Description

Following a discussion in issue https://github.com/patternfly/angular-patternfly/issues/516, the README needs to be updated to reflect the recent changes to how angular-pf's dependencies are located within node_modules. This short patch fixes the instances in the README where packages that were formerly located in 

`node_modules/angular-patternfly/node_modules` 

are now located in 

`node_modules/`

## PR Checklist

- [ ] Unit tests are included
- [ ] Screenshots are attached (if there are visual changes in the UI)
- [ ] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [ ] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
