### PR TITLE
Issue Standalone Angular PatternFly

### DIFF
--- a/eslint.yaml
+++ b/eslint.yaml
@@ -35,7 +35,7 @@ rules:
   vars-on-top: 2
   no-debugger: 2
   no-cond-assign: 2
-  no-console: 2
+  no-console: 1
   no-extra-semi: 2
   no-irregular-whitespace: 2
   dot-notation:

--- a/src/charts/c3/c3-chart-defaults.js
+++ b/src/charts/c3/c3-chart-defaults.js
@@ -1,7 +1,17 @@
-(function () {
+(function (window, patternfly) {
   'use strict';
 
-  var patternflyDefaults = patternfly.c3ChartDefaults();
+  var patternflyDefaults;
+
+  var fallbackC3ChartDefaults = function () {
+    console.error('patternfly.c3ChartDefaults unavailable.\nhttps://github.com/patternfly/angular-patternfly');
+    return {};
+  };
+
+  window.patternfly = patternfly || {};
+  window.patternfly.c3ChartDefaults = patternfly.c3ChartDefaults || fallbackC3ChartDefaults;
+
+  patternflyDefaults = patternfly.c3ChartDefaults();
 
   angular.module('patternfly.charts').constant('c3ChartDefaults', {
     getDefaultColors: patternflyDefaults.getDefaultColors,
@@ -20,4 +30,6 @@
     getDefaultSparklineConfig: patternflyDefaults.getDefaultSparklineConfig,
     getDefaultLineConfig: patternflyDefaults.getDefaultLineConfig
   });
-})();
+
+})(window, patternfly);
+

--- a/test/charts/c3/c3.spec.js
+++ b/test/charts/c3/c3.spec.js
@@ -1,4 +1,4 @@
-describe('Directive: pfC3Chart', function() {
+describe('Component: pfC3Chart', function() {
   var $scope, $compile, element;
 
   beforeEach(module(
@@ -16,6 +16,11 @@ describe('Directive: pfC3Chart', function() {
     element = '<pf-c3-chart id="myChart" config="chartConfig"></pf-c3-chart>';
     element = $compile(element)($scope);
     $scope.$digest();
+  });
+
+  it("should have access to a global PatternFly object & method", function() {
+    expect(window.patternfly).toBeDefined();
+    expect(window.patternfly.c3ChartDefaults()).toBeDefined();
   });
 
   it("chart should find empty template", function() {

--- a/test/charts/donut/donut-pct.spec.js
+++ b/test/charts/donut/donut-pct.spec.js
@@ -1,4 +1,4 @@
-describe('Directive: pfDonutPctChart', function() {
+describe('Component: pfDonutPctChart', function() {
   var $scope, ctrl, $compile, $timeout, element;
 
   beforeEach(module(
@@ -40,6 +40,11 @@ describe('Directive: pfDonutPctChart', function() {
   var compileDonutCenterLabel = function () {
     element = compileDonut('<pf-donut-pct-chart config="config" data="data" center-label="cntrLabel"></pf-donut-pct-chart>');
   };
+
+  it("should have access to a global PatternFly object & method", function() {
+    expect(window.patternfly).toBeDefined();
+    expect(window.patternfly.c3ChartDefaults()).toBeDefined();
+  });
 
   it("should trigger error threshold", function() {
     compileSimpleDonut();

--- a/test/charts/heatmap/heatmap-legend.spec.js
+++ b/test/charts/heatmap/heatmap-legend.spec.js
@@ -1,4 +1,4 @@
-describe('Directive: pfHeatmapLegend', function() {
+describe('Component: pfHeatmapLegend', function() {
   var $scope, $compile, element, legendItem, legendText;
 
   beforeEach(module(

--- a/test/charts/heatmap/heatmap.spec.js
+++ b/test/charts/heatmap/heatmap.spec.js
@@ -32,6 +32,9 @@ describe('Component: pfHeatmap', function() {
       {'id': 21, 'value': 0.81, 'tooltip': 'Node 21 : My OpenShift Provider<br>81% : 81 Used of 100 Total<br>19 Available'}];
   });
 
+  it("should have access to a global d3 object", function() {
+    expect(window.d3).toBeDefined();
+  });
 
   it("should set the heatmap title", function() {
     element = compileChart('<pf-heatmap chart-title="title" data="data"></pf-heatmap>',$scope);

--- a/test/charts/sparkline/sparkline-chart.spec.js
+++ b/test/charts/sparkline/sparkline-chart.spec.js
@@ -40,6 +40,11 @@ describe('Component: pfSparklineChart', function() {
     return element;
   };
 
+  it("should have access to a global PatternFly object & method", function() {
+    expect(window.patternfly).toBeDefined();
+    expect(window.patternfly.c3ChartDefaults()).toBeDefined();
+  });
+
   it("should not show axis by default", function() {
     element = compileChart('<pf-sparkline-chart config="config" chart-data="data"></pf-sparkline-chart>',$scope);
 

--- a/test/charts/topology/topology.spec.js
+++ b/test/charts/topology/topology.spec.js
@@ -205,6 +205,10 @@ describe('Component: pfTopology', function() {
     d3.selectAll('pf-topology').remove();
   });
 
+  it("should have access to a global d3 object", function() {
+    expect(window.d3).toBeDefined();
+  });
+
   it("should create an svg internally", function() {
     var element = compileTopology('<div><pf-topology items="data.items" relations="data.relations" kinds="kinds" icons="data.icons" nodes="nodes" item-selected="itemSelected(item)" search-text="searchText" show-labels="showLabels" tooltip-function="tooltip(node)"></pf-topology></div>', $scope);
     expect(element.find('svg')).not.toBe(undefined);

--- a/test/charts/trends/trends-chart.spec.js
+++ b/test/charts/trends/trends-chart.spec.js
@@ -1,4 +1,4 @@
-describe('Directive: pfTrendsChart', function() {
+describe('Component: pfTrendsChart', function() {
   var $scope, $compile, element, isolateScope, trendCard;
 
   beforeEach(module(

--- a/test/charts/utilization-bar/utilization-bar.spec.js
+++ b/test/charts/utilization-bar/utilization-bar.spec.js
@@ -1,4 +1,4 @@
-describe('Directive: pfUtilizationBarChart', function() {
+describe('Component: pfUtilizationBarChart', function() {
   var $scope, $compile, $sanitize, element, utilizationBar, title, subTitle;
 
   beforeEach(module(


### PR DESCRIPTION
## Description
Allows Angular Patternfly JS  to run as a standalone script reference without including core Patternfly JS. Unit test updates related to globals "d3" and "c3ChartDefaults"
- Closes #534 

#### Side-Note
  Had to relax the linter around "console statements", converted to warnings. If there's another way to handle it more than willing to convert it

## PR Checklist

- [x] Unit tests are included
- [n/a ] Screenshots are attached (if there are visual changes in the UI)
- [n/a] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [n/a] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
