### PR TITLE
Semantic release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: node_js
 node_js:
   - '4'
 
+cache:
+  directories:
+    - node_modules
+
+notifications:
+  email: false
+
 env:
   global:
     - ENCRYPTION_LABEL: "aa286ccd339e"
@@ -11,14 +18,21 @@ env:
 
 before_install:
   - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
-  - if [[ -n ${NPM_TOKEN} ]]; then echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc; fi
   - npm install -g bower grunt-cli
-  - npm install git+https://github.com/patternfly/patternfly-eng-release.git
+  - npm install patternfly-eng-release
+  - npm install semantic-release
 
 install: true
 
 script:
+  - if [[ -n "$NPM_TOKEN" && -n "$GH_TOKEN" ]]; then npm run semantic-release-pre; fi
   - sh -x ./node_modules/patternfly-eng-release/scripts/_build.sh -a
 
 after_success:
+  - npm prune
+  - npm run semantic-release
   - ./scripts/publish-ghpages.sh -t docs
+
+branches:
+  except:
+    - /^v\d+\.\d+\.\d+$/

--- a/README.md
+++ b/README.md
@@ -208,33 +208,38 @@ After executing this tasks you'll be able to access the documentation at [http:/
 $ npm run ngdocs:view -- --port=8002
 ```
 
-## Releasing
+## Git Commit Guidelines
 
-Angular PatternFly is released through Bower and npm. To release a new version version of Angular PatternFly, edit `bower.json` and `package.json` accordingly.
+PatternFly uses a semantic release process to automate npm and bower package publishing, based on the following commit message format.
 
-Update the version listed in `bower.json` by editing the file and changing the line:
-```
-"version": "<new_version>"
-```
+Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
+format that includes a **type**, a **scope** and a **subject** ([full explanation](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md)):
 
-Update the patternfly reference version listed in `bower.json` by editing the file and changing the line below. Angular patternfly has a dependency on the patternfly reference implementation so the major and minor version numbers of the two project should be the same:
 ```
-"patternfly": "<new_version>"
-```
-
-
-Update the version listed in `package.json` by editing the file and changing the line:
-```
-"version": "<new_version>"
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
 ```
 
-Commit the version bump:
-```shell
-$ git commit -m "Version bump to <new_version>"
+##### Patch Release
+
+```
+fix(pencil): stop graphite breaking when too much pressure applied
 ```
 
-Publish a new set of release notes with ```new version``` as the tag version:
-https://github.com/patternfly/angular-patternfly/releases/new
+##### Feature Release
+
+```
+feat(pencil): add 'graphiteWidth' option
+```
+
+##### Breaking Release
+
+```
+perf(pencil): remove graphiteWidth option
+```
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "matchdep": "0.3.0",
     "nsp": "^2.6.1",
-    "patternfly-eng-release": "3.26.6"
+    "patternfly-eng-release": "^3.26.9",
+    "semantic-release": "^6.3.6"
   },
   "optionalDependencies": {
     "angularjs-datatables": "^0.5.7",
@@ -67,10 +68,17 @@
     "jquery": "~3.2.1",
     "moment": "~2.14.1"
   },
+  "release": {
+    "branch": "master-dist",
+    "debug": false,
+    "verifyConditions": {
+      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
+    }
+  },
   "scripts": {
-    "clean":"grunt clean",
+    "clean": "grunt clean",
     "build": "grunt build",
-    "watch":"grunt watch",
+    "watch": "grunt watch",
     "ngdocs": "grunt ngdocs",
     "ngdocs:view": "grunt ngdocs:view",
     "ngdocs:publish": "grunt ngdocs:publish",
@@ -79,7 +87,9 @@
     "check": "grunt check",
     "help": "grunt help",
     "serve": "grunt serve",
-    "start": "grunt serve"
+    "start": "grunt serve",
+    "semantic-release": "npm publish && semantic-release post",
+    "semantic-release-pre": "semantic-release pre"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added semantic release to create a new package versions from master-dist.

Note that the patternfly-eng-release scripts will continue to run npm install, bower install, grunt build, grunt ngdocs:publish, npm test, nsp shrinkwrap audit, and will verify npm/bower installs. An npm shrinkwrap file will also be created and committed to master-dist along with other generated files. The scripts will continue to ensure master-dist is not published during pull requests and tagged builds -- it must be a merge to master and not a fork.