### PR TITLE
Small fix to pfFilterPanelResults when clearing a filter

### DIFF
--- a/src/filters/filter-panel/filter-panel-results-component.js
+++ b/src/filters/filter-panel/filter-panel-results-component.js
@@ -60,14 +60,14 @@ angular.module('patternfly.filters').component('pfFilterPanelResults', {
     function clearFilter (filter, value) {
       var changedFilterId = filter.id;
 
-      var changedFilterValue = _.pull(filter.values, value)[0];
+      _.pull(filter.values, value);
 
       if (filter.values.length === 0) {
         _.pull(ctrl.config.appliedFilters, filter);
       }
 
       if (ctrl.config.onFilterChange) {
-        ctrl.config.onFilterChange(ctrl.config.appliedFilters, changedFilterId, changedFilterValue);
+        ctrl.config.onFilterChange(ctrl.config.appliedFilters, changedFilterId, value);
       }
     }
 


### PR DESCRIPTION
## Description
In response to a review issue, I switched to a lodash function which didn't return what previous one did.  
Small fix.
