### PR TITLE
Remove early ‘semantic release pre’ step from Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_install:
 install: true
 
 script:
-  - if [[ -n "$NPM_TOKEN" && -n "$GH_TOKEN" ]]; then npm run semantic-release-pre; fi
   - sh -x ./node_modules/patternfly-eng-release/scripts/_build.sh -a
 
 after_success:

--- a/package.json
+++ b/package.json
@@ -88,8 +88,7 @@
     "help": "grunt help",
     "serve": "grunt serve",
     "start": "grunt serve",
-    "semantic-release": "npm publish && semantic-release post",
-    "semantic-release-pre": "semantic-release pre"
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This step was in place so that we could add the generated version number from package.json to bower.json. We just need to get the semantic release going for now, then revisit bower.json if necessary.
