### PR TITLE
Semantic release: Move ‘pre’ command before build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,17 @@ before_install:
 install: true
 
 script:
+  - 'if [[ -n "$NPM_TOKEN" && -n "$GH_TOKEN" && "$TRAVIS_BRANCH" = "master-dist" ]]; then
+       npm run semantic-release-pre;
+     fi'
   - sh -x ./node_modules/patternfly-eng-release/scripts/_build.sh -a
 
 after_success:
-  - npm prune
-  - npm run semantic-release
+  - 'if [[ -n "$NPM_TOKEN" && -n "$GH_TOKEN" && "$TRAVIS_BRANCH" = "master-dist" ]]; then
+       npm prune;
+       npm run semantic-release-publish;
+       npm run semantic-release-post;
+     fi'
   - sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_publish-webjar.sh -a
   - ./scripts/publish-ghpages.sh -t docs
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "matchdep": "0.3.0",
     "nsp": "^2.6.1",
-    "patternfly-eng-release": "^3.26.12",
+    "patternfly-eng-release": "^3.26.15",
     "semantic-release": "^6.3.6"
   },
   "optionalDependencies": {
@@ -88,7 +88,10 @@
     "help": "grunt help",
     "serve": "grunt serve",
     "start": "grunt serve",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "semantic-release-post": "semantic-release post",
+    "semantic-release-pre": "semantic-release pre",
+    "semantic-release-publish": "npm publish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Moved the ‘semantic-release pre’ command before the build.

The ‘semantic pre’ command should add a version number to package.json before the build runs. If all goes well, patternfly-eng-release scripts will pull the package.json version number add add it to bower.json. After updated files are committed to master-dist, the npm publish and ‘semantic-release post’ commands are run. 
