### PR TITLE
Semantic release: refactored patternfly-eng-release to update bower.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,18 +24,17 @@ before_install:
 install: true
 
 script:
-  - 'if [[ -n "$NPM_TOKEN" && -n "$GH_TOKEN" && "$TRAVIS_BRANCH" = "master-dist" ]]; then
-       npm run semantic-release-pre;
-     fi'
   - sh -x ./node_modules/patternfly-eng-release/scripts/_build.sh -a
 
 after_success:
-  - 'if [[ -n "$NPM_TOKEN" && -n "$GH_TOKEN" && "$TRAVIS_BRANCH" = "master-dist" ]]; then
+  - 'if [[ "$TRAVIS_SECURE_ENV_VARS" = "true" && "$TRAVIS_BRANCH" = "master-dist" ]]; then
        npm prune;
+       npm run semantic-release-pre;
+       sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_bump.sh -a || travis_terminate 0;
        npm run semantic-release-publish;
        npm run semantic-release-post;
+       - sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_publish-webjar.sh -a;
      fi'
-  - sh -x ./node_modules/patternfly-eng-release/scripts/semantic-release/_publish-webjar.sh -a
   - ./scripts/publish-ghpages.sh -t docs
 
 branches:

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "matchdep": "0.3.0",
     "nsp": "^2.6.1",
-    "patternfly-eng-release": "^3.26.15",
+    "patternfly-eng-release": "^3.26.25",
     "semantic-release": "^6.3.6"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Refactored the patternfly-eng-release scripts to update bower.json after ‘semantic-release pre’ is run.

The idea is for Patternfly and Angular Patterfnly to run the 'semantic-release pre' step to generate a version number based on the commits in master-dist. If that version is different than what's in bower.json, we update and push bower.json to master-dist -- instead of running npm publish. That commit will kick off another master-dist build that will ultimately publish npm, tag Github, etc.
