### PR TITLE
bumped patternfly-eng-release to allow bower.json push

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "matchdep": "0.3.0",
     "nsp": "^2.6.1",
-    "patternfly-eng-release": "^3.26.27",
+    "patternfly-eng-release": "^3.26.28",
     "semantic-release": "^6.3.6"
   },
   "optionalDependencies": {


### PR DESCRIPTION
bumped patternfly-eng-release. 

A small change was necessary to allow patternfly-eng-release scripts to push bower.json to master-dist.