### PR TITLE
Semantic release: bump patternfly-eng-release to skip npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "matchdep": "0.3.0",
     "nsp": "^2.6.1",
-    "patternfly-eng-release": "^3.26.28",
+    "patternfly-eng-release": "^3.26.29",
     "semantic-release": "^6.3.6"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Modified patternfly-eng-release to add an indicator when bower.json is bumped. This ensures Travis skips 'npm publish' and runs that only during the next master-dist build.