### PR TITLE
Added pagination controls to List and Card views.

### DIFF
--- a/src/filters/simple-filter/filter-fields-component.js
+++ b/src/filters/simple-filter/filter-fields-component.js
@@ -88,6 +88,8 @@ angular.module('patternfly.filters').component('pfFilterFields', {
       if (keyEvent.which === 13) {
         ctrl.addFilterFn(ctrl.currentField, ctrl.currentValue);
         ctrl.currentValue = undefined;
+        keyEvent.stopPropagation();
+        keyEvent.preventDefault();
       }
     }
 

--- a/src/table/tableview/table-view.component.js
+++ b/src/table/tableview/table-view.component.js
@@ -14,7 +14,7 @@ angular.module('patternfly.table').component('pfTableView', {
   templateUrl: 'table/tableview/table-view.html',
   controller: function (DTOptionsBuilder, DTColumnDefBuilder, $element, pfUtils, $log, $filter, $timeout) {
     'use strict';
-    var ctrl = this, prevDtOptions, prevItems;
+    var ctrl = this, prevDtOptions, prevItems, prevPageConfig;
 
     // Once datatables is out of active development I'll remove log statements
     ctrl.debug = false;
@@ -40,16 +40,7 @@ angular.module('patternfly.table').component('pfTableView', {
       showCheckboxes: true
     };
 
-    ctrl.$onInit = function () {
-
-      if (ctrl.debug) {
-        $log.debug("$onInit");
-      }
-
-      if (angular.isDefined(ctrl.colummns) && angular.isUndefined(ctrl.columns)) {
-        ctrl.columns = ctrl.colummns;
-      }
-
+    function setPagination () {
       if (angular.isUndefined(ctrl.dtOptions)) {
         ctrl.dtOptions = {};
       } else {
@@ -59,16 +50,16 @@ angular.module('patternfly.table').component('pfTableView', {
           if (angular.isUndefined(ctrl.pageConfig)) {
             ctrl.pageConfig = {};
           }
-          if (angular.isUndefined(ctrl.pageConfig.pageNumber)) {
+          if (!angular.isNumber(ctrl.pageConfig.pageNumber)) {
             ctrl.pageConfig.pageNumber = 1;
           }
         }
-        if (angular.isDefined(ctrl.dtOptions.displayLength)) {
+        if (angular.isNumber(ctrl.dtOptions.displayLength)) {
           ctrl.dtOptions.paging = true;
           if (angular.isUndefined(ctrl.pageConfig)) {
             ctrl.pageConfig = {};
           }
-          if (angular.isUndefined(ctrl.pageConfig.pageSize)) {
+          if (!angular.isNumber(ctrl.pageConfig.pageSize)) {
             ctrl.pageConfig.pageSize = ctrl.dtOptions.displayLength;
           }
         }
@@ -92,6 +83,17 @@ angular.module('patternfly.table').component('pfTableView', {
           ctrl.pageConfig.pageNumber = 1;
         }
       }
+    }
+
+    ctrl.$onInit = function () {
+
+      if (ctrl.debug) {
+        $log.debug("$onInit");
+      }
+
+      if (angular.isDefined(ctrl.colummns) && angular.isUndefined(ctrl.columns)) {
+        ctrl.columns = ctrl.colummns;
+      }
 
       if (angular.isUndefined(ctrl.config)) {
         ctrl.config = {};
@@ -103,11 +105,13 @@ angular.module('patternfly.table').component('pfTableView', {
     };
 
     ctrl.updateConfigOptions = function () {
-      var col, props = "";
+      var props = "";
 
       if (ctrl.debug) {
         $log.debug("  updateConfigOptions");
       }
+
+      setPagination();
 
       if (angular.isDefined(ctrl.dtOptions) && angular.isDefined(ctrl.dtOptions.displayLength)) {
         ctrl.dtOptions.displayLength = Number(ctrl.dtOptions.displayLength);
@@ -116,6 +120,7 @@ angular.module('patternfly.table').component('pfTableView', {
       // Need to deep watch changes in dtOptions and items
       prevDtOptions = angular.copy(ctrl.dtOptions);
       prevItems = angular.copy(ctrl.items);
+      prevPageConfig = angular.copy(ctrl.pageConfig);
 
       // Setting bound variables to new variables loses it's one way binding
       //   ctrl.dtOptions = pfUtils.merge(ctrl.defaultDtOptions, ctrl.dtOptions);
@@ -143,7 +148,6 @@ angular.module('patternfly.table').component('pfTableView', {
     };
 
     ctrl.dtInstanceCallback = function (_dtInstance) {
-      var oTable, rows;
       if (ctrl.debug) {
         $log.debug("--> dtInstanceCallback");
       }
@@ -188,7 +192,8 @@ angular.module('patternfly.table').component('pfTableView', {
         $log.debug("$doCheck");
       }
       // do a deep compare on dtOptions and items
-      if (!angular.equals(ctrl.dtOptions, prevDtOptions)) {
+      if (!angular.equals(ctrl.dtOptions, prevDtOptions) ||
+          !angular.equals(ctrl.pageConfig, prevPageConfig)) {
         if (ctrl.debug) {
           $log.debug("  dtOptions !== prevDtOptions");
         }
@@ -223,7 +228,7 @@ angular.module('patternfly.table').component('pfTableView', {
 
     function setColumnDefs () {
       var i = 0, actnBtns = 1;
-      var item, prop, offset;
+      var offset;
       ctrl.dtColumnDefs = [];
 
       // add checkbox col, not sortable
@@ -368,7 +373,6 @@ angular.module('patternfly.table').component('pfTableView', {
       //     returns ['Mary Jane', 'Fred Flinstone', 'Frank Livingston']
       //
       var i, rowData, visibleRows = new Array();
-      var oTable = ctrl.dtInstance.dataTable;
 
       var anNodes = document.querySelectorAll("#" + ctrl.tableId + "  tbody tr");
 
@@ -470,7 +474,8 @@ angular.module('patternfly.table').component('pfTableView', {
       });
     };
 
-    ctrl.checkDisabled = function (item) {
+    ctrl.checkDisabled = function () {
+      //TODO: implement checkDisabled
       return false;
     };
 

--- a/src/toolbars/examples/toolbar.js
+++ b/src/toolbars/examples/toolbar.js
@@ -80,8 +80,9 @@
          </actions>
         </pf-toolbar>
       </div>
-      <div class="col-md-12" ng-if="viewType == 'listView'">
+      <div class="col-md-12" ng-if="viewType == 'listView' && showComponent">
         <pf-list-view config="listConfig"
+                      page-config="pageConfig"
                       items="items"
                       empty-state-config="emptyStateConfig">
           <div class="list-view-pf-description">
@@ -102,8 +103,9 @@
           </div>
         </pf-list-view>
       </div>
-      <div class="col-md-12" ng-if="viewType == 'cardView'">
+      <div class="col-md-12" ng-if="viewType == 'cardView' && showComponent">
         <pf-card-view config="listConfig"
+                      page-config="pageConfig"
                       items="items"
                       empty-state-config="emptyStateConfig">
           <div class="col-md-12">
@@ -117,8 +119,9 @@
           </div>
         </pf-card-view>
       </div>
-      <div class="col-md-12" ng-if="viewType == 'tableView'">
+      <div class="col-md-12" ng-if="viewType == 'tableView' && showComponent">
         <pf-table-view config="tableConfig"
+                       page-config="pageConfig"
                        columns="columns"
                        items="items"
                        empty-state-config="emptyStateConfig">
@@ -129,6 +132,9 @@
         <div class="form-group">
           <label class="checkbox-inline">
             <input type="checkbox" ng-model="listConfig.itemsAvailable" ng-change="updateItemsAvailable()">Items Available</input>
+          </label>
+          <label class="checkbox-inline">
+            <input type="checkbox" ng-model="showPagination" ng-change="togglePagination()">Show Pagination</input>
           </label>
         </div>
       </div>
@@ -152,9 +158,10 @@
   </file>
 
   <file name="script.js">
-  angular.module('patternfly.toolbars.demo').controller('ViewCtrl', ['$scope', 'pfViewUtils', '$filter',
-    function ($scope, pfViewUtils, $filter) {
+  angular.module('patternfly.toolbars.demo').controller('ViewCtrl', ['$scope', '$timeout', 'pfViewUtils', '$filter',
+    function ($scope, $timeout, pfViewUtils, $filter) {
       $scope.filtersText = '';
+      $scope.showPagination = false;
 
       $scope.columns = [
         { header: "Name", itemField: "name" },
@@ -162,23 +169,6 @@
         { header: "Address", itemField: "address" },
         { header: "BirthMonth", itemField: "birthMonth"}
       ];
-
-      // attempt to dyamically turn on/off pagination controls
-      // See: issues turning on/off pagination. see: https://datatables.net/manual/tech-notes/3
-
-      $scope.usePagination = true;
-      $scope.togglePagination = function () {
-        $scope.usePagination = !$scope.usePagination;
-        console.log("---> togglePagination: " + $scope.usePagination);
-        if($scope.usePagination) {
-          $scope.dtOptions.displayLength = 3;
-          $scope.dtOptions.dom = "tp";
-          console.log("---> use pagination: " + $scope.dtOptions.displayLength + ":" + $scope.dtOptions.dom);
-        } else {
-          $scope.dtOptions.displayLength = undefined;
-          $scope.dtOptions.dom = "t";
-        }
-      };
 
       $scope.allItems = [
         {
@@ -228,6 +218,30 @@
           age: 34,
           address: "21 Jump Street, Hollywood, California",
           birthMonth: 'March'
+        },
+        {
+          name: "Chris Thomas",
+          age: 21,
+          address: "50 Second Street, New York, New York",
+          birthMonth: 'April'
+        },
+        {
+          name: "Jeff McGovern",
+          age: 30,
+          address: "22 Oak Stree, Denver, Colorado",
+          birthMonth: 'November'
+        },
+        {
+          name: "Jessica Brown",
+          age: 50,
+          address: "72 Bourbon Way. Nashville. Tennessee",
+          birthMonth: 'January'
+        },
+        {
+          name: "Dave Nichols",
+          age: 32,
+          address: "21 Jump Street, Hollywood, California",
+          birthMonth: 'June'
         }
       ];
       $scope.items = $scope.allItems;
@@ -507,6 +521,24 @@
           $scope.toolbarConfig.filterConfig.selectedCount = selectedItems.length;
         }
       }
+
+      $scope.togglePagination = function () {
+        if ($scope.showPagination) {
+          $scope.pageConfig = {
+             pageSize: 5
+          }
+        } else {
+          delete $scope.pageConfig;
+        }
+        $scope.addNewComponentToDOM();
+      };
+
+      $scope.showComponent = true;
+
+      $scope.addNewComponentToDOM = function () {
+        $scope.showComponent = false;
+        $timeout(() => $scope.showComponent = true);
+      };
     }
   ]);
   </file>

--- a/src/views/cardview/card-view.html
+++ b/src/views/cardview/card-view.html
@@ -1,6 +1,6 @@
 <span>
   <div ng-if="$ctrl.config.itemsAvailable !== false" class="card-view-pf" >
-    <div class="card" ng-repeat="item in $ctrl.items"
+    <div class="card" ng-repeat="item in $ctrl.items | startFrom:($ctrl.pageConfig.pageNumber - 1)*$ctrl.pageConfig.pageSize | limitTo:$ctrl.pageConfig.pageSize"
          ng-class="{'pf-selectable': $ctrl.selectItems, 'active': $ctrl.isSelected(item), 'disabled': $ctrl.checkDisabled(item)}">
       <div class="card-content"
            ng-click="$ctrl.itemClick($event, item)"
@@ -12,5 +12,11 @@
       </div>
     </div>
   </div>
+  <pf-pagination ng-if="$ctrl.pageConfig.showPaginationControls && $ctrl.config.itemsAvailable === true"
+                 page-size="$ctrl.pageConfig.pageSize"
+                 page-size-increments="$ctrl.pageConfig.pageSizeIncrements"
+                 page-number="$ctrl.pageConfig.pageNumber"
+                 num-total-items="$ctrl.pageConfig.numTotalItems">
+  </pf-pagination>
   <pf-empty-state ng-if="$ctrl.config.itemsAvailable === false" config="$ctrl.emptyStateConfig" action-buttons="$ctrl.emptyStateActionButtons"></pf-empty-state>
 </span>

--- a/src/views/listview/examples/list-view.js
+++ b/src/views/listview/examples/list-view.js
@@ -34,6 +34,13 @@
  * <li>.onClick                - ( function(item, event) ) Called to notify when an item is clicked, default is none. Note: row expansion is the default behavior after onClick performed, but user can stop such default behavior by adding the sentence "return false;" to the end of onClick function body
  * <li>.onDblClick             - ( function(item, event) ) Called to notify when an item is double clicked, default is none
  * </ul>
+ * @param {object} pageConfig Optional pagination configuration object.  Since all properties are optional it is ok to specify: 'pageConfig = {}' to indicate that you want to
+ * use pagination with the default parameters.
+ * <ul style='list-style-type: none'>
+ *   <li>.pageNumber  - (number) Optional Initial page number to display. Default is page 1.
+ *   <li>.pageSize    - (number) Optional Initial page size/display length to use. Ie. Number of "Items per Page".  Default is 10 items per page
+ *   <li>.pageSizeIncrements - (Array[Number]) Optional Page size increments for the 'per page' dropdown.  If not specified, the default values are: [5, 10, 20, 40, 80, 100]
+ * </ul>
  * @param {array} actionButtons List of action buttons in each row
  *   <ul style='list-style-type: none'>
  *     <li>.name - (String) The name of the action, displayed on the button
@@ -66,9 +73,11 @@
        <ul class="nav nav-tabs">
          <li ng-class="{'active': viewType === 'basic'}"><a href="#" ng-click="setView('basic')">Basic (w/ Options)</a></li>
          <li ng-class="{'active': viewType === 'compound'}"><a href="#" ng-click="setView('compound')">Compound Expansion</a></li>
+         <li ng-class="{'active': viewType === 'pagination'}"><a href="#" ng-click="setView('pagination')">Pagination</a></li>
        </ul>
        <div ng-if="viewType === 'basic'" ng-include="'basic.html'"></div>
        <div ng-if="viewType === 'compound'" ng-include="'compound.html'"></div>
+       <div ng-if="viewType === 'pagination'" ng-include="'pagination.html'"></div>
      </div>
   </file>
   <file name="view.js">
@@ -281,7 +290,7 @@
             $scope.config.selectItems = true;
             $scope.config.showSelectBox = false;
           } else {
-            $scope.config.selectItems = false
+            $scope.config.selectItems = false;
             $scope.config.showSelectBox = false;
           }
         };
@@ -397,7 +406,7 @@
             address: "50 Second Street",
             city: "New York",
             state: "New York"
-          },
+          }
         ];
 
         $scope.getMenuClass = function (item) {
@@ -661,7 +670,7 @@
             clusterCount: 6,
             nodeCount: 10,
             imageCount: 8
-          },
+          }
         ];
 
         $scope.getMenuClass = function (item) {
@@ -740,7 +749,7 @@
   <file name="itemExpansion.js">
     angular.module('patternfly.views').component('itemExpansion', {
       bindings: {
-        item: '<',
+        item: '<'
       },
       templateUrl: 'itemExpansion.html',
       controller: function () {
@@ -754,6 +763,215 @@
    <div ng-if="$ctrl.item.expandField === 'clusters'" ng-include="'views/listview/examples/clusters-content.html'"></div>
    <div ng-if="$ctrl.item.expandField === 'nodes'" ng-include="'views/listview/examples/nodes-content.html'"></div>
    <div ng-if="$ctrl.item.expandField === 'images'" ng-include="'views/listview/examples/images-content.html'"></div>
+ </file>
+
+ <file name="pagination.html">
+   <div ng-controller="PaginationCtrl" class="row example-container">
+     <div class="col-md-12 list-view-container example-list-view">
+       <pf-list-view id="paginationListView"
+         items="items"
+         page-config="pageConfig"
+         action-buttons="actionButtons"
+         menu-actions="menuActions">
+         <div class="list-view-pf-description">
+           <div class="list-group-item-heading">
+             {{item.name}}
+           </div>
+           <div class="list-group-item-text">
+             {{item.address}}
+           </div>
+         </div>
+         <div class="list-view-pf-additional-info">
+           <div class="list-view-pf-additional-info-item">
+             {{item.city}}
+           </div>
+           <div class="list-view-pf-additional-info-item">
+             {{item.state}}
+           </div>
+         </div>
+       </pf-list-view>
+     </div>
+   </div>
+ </file>
+
+ <file name="pagination.js">
+   angular.module('patternfly.views').controller('PaginationCtrl', ['$scope', '$templateCache',
+     function ($scope, $templateCache) {
+
+        $scope.pageConfig = {
+          pageSize: 5
+        };
+
+        var startServer = function (action, item) {
+          console.log(item.name + " : " + action.name);
+        };
+
+        var performAction = function (action, item) {
+          console.log(item.name + " : " + action.name);
+        };
+
+        $scope.items = [
+          {
+            name: "Fred Flintstone",
+            address: "20 Dinosaur Way",
+            city: "Bedrock",
+            state: "Washingstone"
+          },
+          {
+            name: "John Smith",
+            address: "415 East Main Street",
+            city: "Norfolk",
+            state: "Virginia"
+          },
+          {
+            name: "Frank Livingston",
+            address: "234 Elm Street",
+            city: "Pittsburgh",
+            state: "Pennsylvania"
+          },
+          {
+            name: "Linda McGovern",
+            address: "22 Oak Street",
+            city: "Denver",
+            state: "Colorado"
+          },
+          {
+            name: "Jim Brown",
+            address: "72 Bourbon Way",
+            city: "Nashville",
+            state: "Tennessee"
+          },
+          {
+            name: "Holly Nichols",
+            address: "21 Jump Street",
+            city: "Hollywood",
+            state: "California"
+          },
+          {
+            name: "Marie Edwards",
+            address: "17 Cross Street",
+            city: "Boston",
+            state: "Massachusetts"
+          },
+          {
+            name: "Pat Thomas",
+            address: "50 Second Street",
+            city: "New York",
+            state: "New York"
+          },
+          {
+            name: "Betty Rubble",
+            address: "30 Dinosaur Way",
+            city: "Bedrock",
+            state: "Washingstone"
+          },
+          {
+            name: "Martha Smith",
+            address: "415 East Main Street",
+            city: "Norfolk",
+            state: "Virginia",
+          },
+          {
+            name: "Liz Livingston",
+            address: "234 Elm Street",
+            city: "Pittsburgh",
+            state: "Pennsylvania"
+          },
+          {
+            name: "Howard McGovern",
+            address: "22 Oak Street",
+            city: "Denver",
+            state: "Colorado"
+          },
+          {
+            name: "Joyce Brown",
+            address: "72 Bourbon Way",
+            city: "Nashville",
+            state: "Tennessee"
+          },
+          {
+            name: "Mike Nichols",
+            address: "21 Jump Street",
+            city: "Hollywood",
+            state: "California"
+          },
+          {
+            name: "Mark Edwards",
+            address: "17 Cross Street",
+            city: "Boston",
+            state: "Massachusetts"
+          },
+          {
+            name: "Chris Thomas",
+            address: "50 Second Street",
+            city: "New York",
+            state: "New York"
+          }
+        ];
+
+        $scope.actionButtons = [
+          {
+            name: 'Start',
+            class: 'btn-primary',
+            include: 'start-button-template',
+            title: 'Start the server',
+            actionFn: startServer
+          },
+          {
+            name: 'Action 1',
+            title: 'Perform an action',
+            actionFn: performAction
+          },
+          {
+            name: 'Action 2',
+            title: 'Do something else',
+            actionFn: performAction
+          },
+          {
+            name: 'Action 3',
+            include: 'my-button-template',
+            title: 'Do something special',
+            actionFn: performAction
+          }
+        ];
+        $scope.menuActions = [
+          {
+            name: 'Action',
+            title: 'Perform an action',
+            actionFn: performAction
+          },
+          {
+            name: 'Another Action',
+            title: 'Do something else',
+            actionFn: performAction
+          },
+          {
+            name: 'Disabled Action',
+            title: 'Unavailable action',
+            actionFn: performAction,
+            isDisabled: true
+          },
+          {
+            name: 'Something Else',
+            title: '',
+            actionFn: performAction
+          },
+          {
+            isSeparator: true
+          },
+          {
+            name: 'Grouped Action 1',
+            title: 'Do something',
+            actionFn: performAction
+          },
+          {
+            name: 'Grouped Action 2',
+            title: 'Do something similar',
+            actionFn: performAction
+          }
+        ];
+      }
+   ]);
  </file>
  </example>
  */

--- a/src/views/listview/list-view.html
+++ b/src/views/listview/list-view.html
@@ -5,7 +5,7 @@
        ng-if="$ctrl.config.itemsAvailable !== false">
     <div class='dndPlaceholder'></div>
     <div class="list-group-item {{item.rowClass}}"
-         ng-repeat="item in $ctrl.items track by $index"
+         ng-repeat="item in $ctrl.items | startFrom:($ctrl.pageConfig.pageNumber - 1)*$ctrl.pageConfig.pageSize | limitTo:$ctrl.pageConfig.pageSize track by $index"
          dnd-draggable="item"
          dnd-effect-allowed="move"
          dnd-disable-if="$ctrl.config.dragEnabled !== true"
@@ -65,6 +65,12 @@
         <div class="list-group-item-container container-fluid" ng-transclude="expandedContent" ng-if="$ctrl.config.useExpandingRows && item.isExpanded"></div>
       </div>
     </div>
+    <pf-pagination ng-if="$ctrl.pageConfig.showPaginationControls && $ctrl.config.itemsAvailable === true"
+      page-size="$ctrl.pageConfig.pageSize"
+      page-size-increments="$ctrl.pageConfig.pageSizeIncrements"
+      page-number="$ctrl.pageConfig.pageNumber"
+      num-total-items="$ctrl.pageConfig.numTotalItems">
+    </pf-pagination>
   </div>
   <pf-empty-state ng-if="$ctrl.config.itemsAvailable === false" config="$ctrl.emptyStateConfig" action-buttons="$ctrl.emptyStateActionButtons"></pf-empty-state>
 </span>

--- a/src/views/views.module.js
+++ b/src/views/views.module.js
@@ -5,4 +5,5 @@
  *   Views module for patternfly.
  *
  */
-angular.module('patternfly.views', ['patternfly.utils', 'patternfly.filters', 'patternfly.sort', 'patternfly.charts', 'dndLists']);
+angular.module('patternfly.views', ['patternfly.utils', 'patternfly.filters', 'patternfly.sort', 'patternfly.charts',
+  'dndLists', 'patternfly.pagination']);

--- a/test/table/tableview/table-view.spec.js
+++ b/test/table/tableview/table-view.spec.js
@@ -180,20 +180,34 @@ describe('Component: pfTableView', function () {
   });
 
   it('should change the page size when selected from dropdown', function() {
+    paginationSetup();
+
     var ctrl = element.isolateScope().$ctrl;
     spyOn(ctrl, 'updatePageSize');
+
+    // initially on page 2, showing 2 rows 3 and 4
+    expect(angular.element(element.find('.pagination-pf-items-current')).text().trim()).toBe('3-4');
 
     //Get pageSizeDropdown
     var pageSizeDropdown = element.find('div[uib-dropdown]');
     expect(pageSizeDropdown.length).toBe(1);
+
+    var selectedPageSize = pageSizeDropdown.find('.display-length-increment.selected');
+    expect(selectedPageSize.length).toBe(1);
+    expect(angular.element(selectedPageSize).text().trim()).toBe('2', 'selected pageSize should be 2');
 
     //Change pageSizeDropdown to 10
     pageSizeDropdown.find('button').click();
     var pageSizeLinks = pageSizeDropdown.find('a');
     expect(pageSizeLinks.length).toBe(3);
     pageSizeLinks[1].click();  // switch to 10 items per page
-    $scope.$digest();
+    element.isolateScope().$digest();
 
     expect(ctrl.updatePageSize).toHaveBeenCalled();
+
+    selectedPageSize = pageSizeDropdown.find('.display-length-increment.selected');
+    expect(selectedPageSize.length).toBe(1);
+    expect(angular.element(selectedPageSize).text().trim()).toBe('10', 'selected pageSize should be 10');
+    expect(angular.element(element.find('.pagination-pf-items-current')).text().trim()).toBe('1-7');
   });
 });

--- a/test/views/cardview/card-view.spec.js
+++ b/test/views/cardview/card-view.spec.js
@@ -5,7 +5,7 @@ describe('Component:  pfCardView', function () {
 
   // load the controller's module
   beforeEach(function () {
-    module('patternfly.views', 'patternfly.utils', 'views/cardview/card-view.html', 'views/empty-state.html');
+    module('patternfly.views', 'patternfly.utils', 'views/cardview/card-view.html', 'views/empty-state.html', 'pagination/pagination.html');
   });
 
   beforeEach(inject(function (_$compile_, _$rootScope_) {
@@ -20,7 +20,7 @@ describe('Component:  pfCardView', function () {
     scope.$digest();
   };
 
-  beforeEach(function () {
+  function basicSetup() {
     $scope.systemModel = [
       {uuid: '1', name: 'One', size: 291445030, capacity: 8200000000},
       {uuid: '2', name: 'Two', size: 1986231544, capacity: 8700000000},
@@ -40,9 +40,41 @@ describe('Component:  pfCardView', function () {
       '</pf-card-view>';
 
     compileHTML(htmlTmp, $scope);
-  });
+  }
+
+  function paginationSetup() {
+    $scope.systemModel = [
+      {uuid: '1', name: 'One', size: 291445030, capacity: 8200000000},
+      {uuid: '2', name: 'Two', size: 1986231544, capacity: 8700000000},
+      {uuid: '3', name: 'Three', size: 7864632, capacity: 7800000000},
+      {uuid: '4', name: 'Four', size: 8162410, capacity: 3200000000},
+      {uuid: '5', name: 'Five', size: 6781425410, capacity: 7600000000},
+      {uuid: '6', name: 'Six', size: 6781425410, capacity: 7600000000},
+      {uuid: '7', name: 'Seven', size: 6781425410, capacity: 7600000000}
+    ];
+
+    $scope.cardConfig = {
+      selectedItems: [],
+      showSelectBox: true
+    };
+
+    $scope.pageConfig = {
+      pageNumber: 2,
+      pageSize: 2,
+      pageSizeIncrements: [2, 10, 15]
+    };
+
+    var htmlTmp = '<pf-card-view items="systemModel" config="cardConfig" page-config="pageConfig">' +
+      '<div class="nameLabel1">{{item.name}}</div>' +
+      '<div class="nameLabel1">{{item.size}}</div>' +
+      '<div class="nameLabel1">{{item.capacity}}</div>' +
+      '</pf-card-view>';
+
+    compileHTML(htmlTmp, $scope);
+  }
 
   it('should have correct number cards', function () {
+    basicSetup();
     var rows = element.find('.card-content');
     expect(rows.length).toBe(5);
 
@@ -51,6 +83,8 @@ describe('Component:  pfCardView', function () {
   it('should show the select checkbox by default', function () {
     var items;
     var checkItems;
+
+    basicSetup();
 
     items = element.find('.card-content');
     checkItems = element.find('.card-check-box');
@@ -67,6 +101,8 @@ describe('Component:  pfCardView', function () {
   it('should not show the select checkboxes when showSelectBox is false', function () {
     var checkItems;
 
+    basicSetup();
+
     checkItems = element.find('.card-check-box');
     expect(checkItems.length).toBe(5);
 
@@ -81,6 +117,8 @@ describe('Component:  pfCardView', function () {
   it('should not allow selection when selectItems is false', function () {
     var items;
     var selectedItems;
+
+    basicSetup();
 
     items = element.find('.card-content');
     selectedItems = element.find('.active');
@@ -98,6 +136,8 @@ describe('Component:  pfCardView', function () {
     var items;
     var selectedItems;
 
+    basicSetup();
+
     items = element.find('.card-content');
     selectedItems = element.find('.active');
     expect(selectedItems.length).toBe(0);
@@ -114,6 +154,8 @@ describe('Component:  pfCardView', function () {
   it('should manage selected array', function () {
     var items;
     var selectedItems;
+
+    basicSetup();
 
     items = element.find('.card-content');
     expect($scope.cardConfig.selectedItems.length).toBe(0);
@@ -136,6 +178,8 @@ describe('Component:  pfCardView', function () {
       doubleClickWorking = true;
     };
 
+    basicSetup();
+
     $scope.cardConfig.onDblClick = onDoubleClick;
 
     items = element.find('.card-content');
@@ -149,6 +193,8 @@ describe('Component:  pfCardView', function () {
   it('should respect the multiSelect setting', function () {
     var items;
     var selectedItems;
+
+    basicSetup();
 
     items = element.find('.card-content');
     selectedItems = element.find('.active');
@@ -182,6 +228,8 @@ describe('Component:  pfCardView', function () {
       return item.uuid === '2';
     };
 
+    basicSetup();
+
     // allow item selection
     $scope.cardConfig.selectItems = true;
     $scope.cardConfig.showSelectBox = false;
@@ -201,6 +249,8 @@ describe('Component:  pfCardView', function () {
 
   it('should not allow both row and checkbox selection', function () {
     var exceptionRaised = false;
+
+    basicSetup();
 
     $scope.badConfig = {
       selectItems: true,
@@ -222,8 +272,70 @@ describe('Component:  pfCardView', function () {
   });
 
   it('should show the empty state when specified', function () {
+    basicSetup();
     $scope.cardConfig.itemsAvailable = false;
     $scope.$digest();
     expect(element.find('#title').text()).toContain('No Items Available');
   });
-})
+
+  it('should not show pagination controls by default', function () {
+    basicSetup();
+    expect(element.find('pf-pagination').length).toBe(0);
+  });
+
+  it('should show pagination controls when configured', function () {
+    paginationSetup();
+
+    expect(element.find('pf-pagination').length).toBe(1);
+
+    expect(angular.element(element.find('.pagination-pf-items-current')).text().trim()).toBe('3-4');  // page # 2
+    expect(angular.element(element.find('.pagination-pf-items-total')).text().trim()).toBe('7');
+    expect(angular.element(element.find('.pagination-pf-page')).val().trim()).toBe('2');
+    expect(angular.element(element.find('.pagination-pf-pages')).text().trim()).toBe('4');
+
+    // two items shown in the list
+    expect(element.find('.card-content').length).toBe(2);
+  });
+
+  it('should goto a specific page when inputted', function () {
+    paginationSetup();
+
+    angular.element(element.find('.pagination-pf-page ')).val('3').trigger('input').blur();
+    $scope.$digest();
+
+    expect(angular.element(element.find('.pagination-pf-items-current')).text().trim()).toBe('5-6');
+    expect(angular.element(element.find('.pagination-pf-items-total')).text().trim()).toBe('7');
+    expect(angular.element(element.find('.pagination-pf-page')).val().trim()).toBe('3');
+    expect(angular.element(element.find('.pagination-pf-pages')).text().trim()).toBe('4');
+
+    // two items shown in the list
+    expect(element.find('.card-content').length).toBe(2);
+  });
+
+  it('should change the page size when selected from dropdown', function() {
+    paginationSetup();
+
+    //Get pageSizeDropdown
+    var pageSizeDropdown = element.find('div[uib-dropdown]');
+    expect(pageSizeDropdown.length).toBe(1);
+
+    // two items shown in the list
+    expect(element.find('.card-content').length).toBe(2);
+
+    var selectedPageSize = pageSizeDropdown.find('.display-length-increment.selected');
+    expect(selectedPageSize.length).toBe(1);
+    expect(angular.element(selectedPageSize).text().trim()).toBe('2', 'selected pageSize should be 2');
+
+    //Change pageSizeDropdown to 10
+    var pageSizeLinks = pageSizeDropdown.find('a');
+    expect(pageSizeLinks.length).toBe(3);
+    pageSizeLinks[1].click();  // switch to 10 items per page
+    element.isolateScope().$digest();
+
+    selectedPageSize = pageSizeDropdown.find('.display-length-increment.selected');
+    expect(selectedPageSize.length).toBe(1);
+    expect(angular.element(selectedPageSize).text().trim()).toBe('10', 'selected pageSize should be 10');
+
+    expect(element.find('.card-content').length).toBe(7, 'should be 7 items shown in list');
+  });
+});

--- a/test/views/listview/list-view.spec.js
+++ b/test/views/listview/list-view.spec.js
@@ -1,4 +1,4 @@
-describe('Component:  pfDataList', function () {
+describe('Component:  pfListView', function () {
   var $scope;
   var $compile;
   var element;
@@ -7,7 +7,7 @@ describe('Component:  pfDataList', function () {
 
   // load the controller's module
   beforeEach(function () {
-    module('patternfly.views', 'patternfly.utils', 'views/listview/list-view.html', 'views/empty-state.html');
+    module('patternfly.views', 'patternfly.utils', 'views/listview/list-view.html', 'views/empty-state.html', 'pagination/pagination.html');
   });
 
   beforeEach(inject(function (_$compile_, _$rootScope_, _$timeout_) {
@@ -23,7 +23,7 @@ describe('Component:  pfDataList', function () {
     scope.$digest();
   };
 
-  beforeEach(function () {
+  function basicSetup() {
     $scope.systemModel = [
       {uuid: '1', name: 'One', size: 291445030, capacity: 8200000000},
       {uuid: '2', name: 'Two', size: 1986231544, capacity: 8700000000},
@@ -31,6 +31,7 @@ describe('Component:  pfDataList', function () {
       {uuid: '4', name: 'Four', size: 8162410, capacity: 3200000000},
       {uuid: '5', name: 'Five', size: 6781425410, capacity: 7600000000}
     ];
+
     $scope.listConfig = {
       selectedItems: []
     };
@@ -132,9 +133,34 @@ describe('Component:  pfDataList', function () {
       '</pf-list-view>';
 
     compileHTML(htmlTmp, $scope);
-  });
+  };
+
+  function paginationSetup() {
+    $scope.systemModel = [
+      {uuid: '1', name: 'One', size: 291445030, capacity: 8200000000},
+      {uuid: '2', name: 'Two', size: 1986231544, capacity: 8700000000},
+      {uuid: '3', name: 'Three', size: 7864632, capacity: 7800000000},
+      {uuid: '4', name: 'Four', size: 8162410, capacity: 3200000000},
+      {uuid: '5', name: 'Five', size: 6781425410, capacity: 7600000000},
+      {uuid: '6', name: 'Six', size: 6781425410, capacity: 7600000000},
+      {uuid: '7', name: 'Seven', size: 6781425410, capacity: 7600000000}
+    ];
+
+    $scope.pageConfig = {
+      pageNumber: 2,
+      pageSize: 2,
+      pageSizeIncrements: [2, 10, 15]
+    };
+
+    var htmlTmp = '<pf-list-view items="systemModel" page-config="pageConfig">' +
+      '<div class="nameLabel1">{{item.name}}</div>' +
+      '</pf-list-view>';
+
+    compileHTML(htmlTmp, $scope);
+  }
 
   it('should have correct number list items', function () {
+    basicSetup();
     var rows = element.find('.list-group-item');
     expect(rows.length).toBe(5);
 
@@ -143,6 +169,8 @@ describe('Component:  pfDataList', function () {
   it('should show the select checkbox by default', function () {
     var items;
     var checkItems;
+
+    basicSetup();
 
     items = element.find('.list-group-item');
     checkItems = element.find('.list-view-pf-checkbox');
@@ -159,6 +187,8 @@ describe('Component:  pfDataList', function () {
   it('should not show the select checkboxes when showSelectBox is false', function () {
     var checkItems;
 
+    basicSetup();
+
     checkItems = element.find('.list-view-pf-checkbox');
     expect(checkItems.length).toBe(5);
 
@@ -173,6 +203,8 @@ describe('Component:  pfDataList', function () {
   it('should not allow selection when selectItems is false', function () {
     var items;
     var selectedItems;
+
+    basicSetup();
 
     items = element.find('.list-group-item');
     selectedItems = element.find('.active');
@@ -190,6 +222,8 @@ describe('Component:  pfDataList', function () {
     var items;
     var selectedItems;
 
+    basicSetup();
+
     items = element.find('.list-view-pf-main-info');
     selectedItems = element.find('.active');
     expect(selectedItems.length).toBe(0);
@@ -206,6 +240,8 @@ describe('Component:  pfDataList', function () {
   it('should manage selected array', function () {
     var items;
     var selectedItems;
+
+    basicSetup();
 
     items = element.find('.list-view-pf-main-info');
     expect($scope.listConfig.selectedItems.length).toBe(0);
@@ -228,6 +264,8 @@ describe('Component:  pfDataList', function () {
       doubleClickWorking = true;
     };
 
+    basicSetup();
+
     $scope.listConfig.onDblClick = onDoubleClick;
 
     items = element.find('.list-view-pf-main-info');
@@ -241,6 +279,8 @@ describe('Component:  pfDataList', function () {
   it('should respect the multiSelect setting', function () {
     var items;
     var selectedItems;
+
+    basicSetup();
 
     items = element.find('.list-view-pf-main-info');
     selectedItems = element.find('.active');
@@ -274,6 +314,8 @@ describe('Component:  pfDataList', function () {
       return item.uuid === '2';
     };
 
+    basicSetup();
+
     // allow item selection
     $scope.listConfig.selectItems = true;
     $scope.listConfig.showSelectBox = false;
@@ -293,6 +335,8 @@ describe('Component:  pfDataList', function () {
 
   it('should not allow both row and checkbox selection', function () {
     var exceptionRaised = false;
+
+    basicSetup();
 
     $scope.badConfig = {
       selectItems: true,
@@ -314,6 +358,8 @@ describe('Component:  pfDataList', function () {
   });
 
   it('should show the action buttons for each row', function () {
+    basicSetup();
+
     var items = element.find('.list-group-item');
     var buttons = element.find('.list-view-pf-actions .btn-default');
     expect(items.length).toBe(5);
@@ -321,6 +367,8 @@ describe('Component:  pfDataList', function () {
   });
 
   it('should have the proper button class applied', function() {
+    basicSetup();
+
     var items = element.find('.list-group-item');
     var buttons = element.find('.list-view-pf-actions .btn-danger');
     expect(items.length).toBe(5);
@@ -330,6 +378,8 @@ describe('Component:  pfDataList', function () {
   });
 
   it('should disable action buttons appropriately', function () {
+    basicSetup();
+
     var items = element.find('.list-group-item');
     var buttons = element.find('.list-view-pf-actions .btn-default');
     var disabledButtons = element.find('.list-view-pf-actions .btn-default.disabled');
@@ -339,6 +389,9 @@ describe('Component:  pfDataList', function () {
   });
 
   it('should call the action function with the appropriate action when an action button is clicked', function () {
+
+    basicSetup();
+
     var items = element.find('.list-group-item');
     var actionButtons = element.find('.list-view-pf-actions .btn-default');
     var dangerButton = element.find('.list-view-pf-actions .btn-danger');
@@ -363,6 +416,8 @@ describe('Component:  pfDataList', function () {
   });
 
   it('should not call the action function when a disabled action button is clicked', function () {
+    basicSetup();
+
     var items = element.find('.list-group-item');
     var actionButtons = element.find('.list-view-pf-actions .btn-default');
     expect(items.length).toBe(5);
@@ -383,11 +438,14 @@ describe('Component:  pfDataList', function () {
   });
 
   it('should show the actions menu button for each row', function () {
+    basicSetup();
     var menuButtons = element.find('.dropdown-kebab-pf .dropdown-toggle');
     expect(menuButtons.length).toBe(5);
   });
 
   it('should show the actions menu with the correct items', function () {
+    basicSetup();
+
     var menuButtons = element.find('.dropdown-kebab-pf .dropdown-toggle');
     var menuItems = element.find('[role=menuitem]');
     var separators = element.find('[role=separator]');
@@ -398,6 +456,8 @@ describe('Component:  pfDataList', function () {
   });
 
   it('should correctly disable menu actions', function () {
+    basicSetup();
+
     var menuButtons = element.find('.dropdown-kebab-pf .dropdown-toggle');
     var disabled = element.find('li .disabled');
 
@@ -413,6 +473,8 @@ describe('Component:  pfDataList', function () {
   });
 
   it('should call the action function with the appropriate action when a menu action is clicked', function () {
+    basicSetup();
+
     var menuButtons = element.find('.dropdown-kebab-pf .dropdown-toggle');
     var menus = element.find('.dropdown-kebab-pf .dropdown-menu');
     var separators = element.find('[role=separator]');
@@ -438,6 +500,8 @@ describe('Component:  pfDataList', function () {
   });
 
   it('should not call the action function when a disabled menu action is clicked', function () {
+    basicSetup();
+
     var menuButtons = element.find('.dropdown-kebab-pf .dropdown-toggle');
     var menus = element.find('.dropdown-kebab-pf .dropdown-menu');
     var separators = element.find('[role=separator]');
@@ -458,6 +522,8 @@ describe('Component:  pfDataList', function () {
   });
 
   it ('should not show action components when actions are not supplied', function () {
+    basicSetup();
+
     var menuButtons = element.find('.dropdown-kebab-pf .dropdown-toggle');
 
     expect(menuButtons.length).toBe(5);
@@ -474,6 +540,8 @@ describe('Component:  pfDataList', function () {
   });
 
   it ('should only show the actions component when either button or menu actions are supplied', function () {
+    basicSetup();
+
     var actionArea = element.find('.list-view-pf-actions');
 
     expect(actionArea.length).toBe(5);
@@ -520,6 +588,8 @@ describe('Component:  pfDataList', function () {
   });
 
   it ('should hide kebab menu when specified', function () {
+    basicSetup();
+
     var kebabs  = element.find('.dropdown-kebab-pf');
     expect(kebabs.length).toBe(5);
 
@@ -528,6 +598,8 @@ describe('Component:  pfDataList', function () {
   });
 
   it ('should add a class to the kebab menu when specified', function () {
+    basicSetup();
+
     var kebabs  = element.find('.dropdown-kebab-pf');
     expect(kebabs.length).toBe(5);
 
@@ -537,6 +609,9 @@ describe('Component:  pfDataList', function () {
 
   it('should allow expanding rows by clicking the caret icon', function () {
     var items;
+
+    basicSetup();
+
     $scope.listConfig.useExpandingRows = true;
     $scope.$digest();
 
@@ -551,6 +626,9 @@ describe('Component:  pfDataList', function () {
 
   it('should allow expanding rows by clicking the main-info section', function () {
     var items;
+
+    basicSetup();
+
     $scope.listConfig.useExpandingRows = true;
 
     $scope.$digest();
@@ -563,6 +641,8 @@ describe('Component:  pfDataList', function () {
   });
 
   it('should allow expanding rows to disable individual expansion', function () {
+    basicSetup();
+
     $scope.systemModel[0].disableRowExpansion = true;
     $scope.listConfig.useExpandingRows = true;
     var htmlTmp = '<pf-list-view items="systemModel" ' +
@@ -578,6 +658,9 @@ describe('Component:  pfDataList', function () {
 
   it('should not show the expansion icon when using compound expansion', function () {
     var items;
+
+    basicSetup();
+
     $scope.listConfig.useExpandingRows = true;
     $scope.listConfig.compoundExpansionOnly = true;
     $scope.$digest();
@@ -588,6 +671,9 @@ describe('Component:  pfDataList', function () {
 
   it('should not expand rows by clicking the main-info section when using compound expansion', function () {
     var items;
+
+    basicSetup();
+
     $scope.listConfig.useExpandingRows = true;
     $scope.listConfig.compoundExpansionOnly = true;
 
@@ -601,8 +687,70 @@ describe('Component:  pfDataList', function () {
   });
 
   it('should show the empty state when specified', function () {
+    basicSetup();
+
     $scope.listConfig.itemsAvailable = false;
     $scope.$digest();
     expect(element.find('#title').text()).toContain('No Items Available');
+  });
+
+  it('should not show pagination controls by default', function () {
+    basicSetup();
+    expect(element.find('pf-pagination').length).toBe(0);
+  });
+
+  it('should show pagination controls when configured', function () {
+    paginationSetup();
+    expect(element.find('pf-pagination').length).toBe(1);
+
+    expect(angular.element(element.find('.pagination-pf-items-current')).text().trim()).toBe('3-4');  // page # 2
+    expect(angular.element(element.find('.pagination-pf-items-total')).text().trim()).toBe('7');
+    expect(angular.element(element.find('.pagination-pf-page')).val().trim()).toBe('2');
+    expect(angular.element(element.find('.pagination-pf-pages')).text().trim()).toBe('4');
+
+    // two items shown in the list
+    expect(element.find('.list-group-item').length).toBe(2);
+  });
+
+  it('should goto a specific page when inputted', function () {
+    paginationSetup();
+
+    angular.element(element.find('.pagination-pf-page ')).val('3').trigger('input').blur();
+    $scope.$digest();
+
+    expect(angular.element(element.find('.pagination-pf-items-current')).text().trim()).toBe('5-6');
+    expect(angular.element(element.find('.pagination-pf-items-total')).text().trim()).toBe('7');
+    expect(angular.element(element.find('.pagination-pf-page')).val().trim()).toBe('3');
+    expect(angular.element(element.find('.pagination-pf-pages')).text().trim()).toBe('4');
+
+    // two items shown in the list
+    expect(element.find('.list-group-item').length).toBe(2);
+  });
+
+  it('should change the page size when selected from dropdown', function() {
+    paginationSetup();
+
+    //Get pageSizeDropdown
+    var pageSizeDropdown = element.find('div[uib-dropdown]');
+    expect(pageSizeDropdown.length).toBe(1);
+
+    // two items shown in the list
+    expect(element.find('.list-group-item').length).toBe(2);
+
+    var selectedPageSize = pageSizeDropdown.find('.display-length-increment.selected');
+    expect(selectedPageSize.length).toBe(1);
+    expect(angular.element(selectedPageSize).text().trim()).toBe('2', 'selected pageSize should be 2');
+
+    //Change pageSizeDropdown to 10
+    var pageSizeLinks = pageSizeDropdown.find('a');
+    expect(pageSizeLinks.length).toBe(3);
+    pageSizeLinks[1].click();  // switch to 10 items per page
+    element.isolateScope().$digest();
+
+    selectedPageSize = pageSizeDropdown.find('.display-length-increment.selected');
+    expect(selectedPageSize.length).toBe(1);
+    expect(angular.element(selectedPageSize).text().trim()).toBe('10', 'selected pageSize should be 10');
+
+    expect(element.find('.list-group-item').length).toBe(7, 'should be 7 items shown in list');
   });
 });


### PR DESCRIPTION
## Description
Added pagination controls to List and Card Views.  Updated List, Card, and Toolbar ngDoc examples to show pagination controls.

- Updated ngDoc for List View,  added Pagination Tab, added @param for ```pageConfig```
- Updated ngDoc for Card View, added '[ ] Show Pagination' checkbox, added @param for ```pageConfig```
- Updated ngDoc for Toolbar
    - added '[ ] Show Pagination' checkbox.  
    - Pagination controls 'sticky' across switching between List, Card, and Table views
    - Tested pagination controls across views: setting/clearing filters, selecting items, sorting, changing pageSize, inputing page number, toggling emptystate on/off

Here is the [ngDoc](https://rawgit.com/dtaylor113/angular-patternfly/list-card-view-pagination-ngdocs/docs/index.html#/api/patternfly.views.component:pfListView) examples.

**List View ngDoc example:**
![image](https://user-images.githubusercontent.com/12733153/29372026-ff2fe59e-8277-11e7-9977-bd56429a969b.png)

**Card View ngDoc example:**
![image](https://user-images.githubusercontent.com/12733153/29372179-63a008ba-8278-11e7-8b6d-ee945112005d.png)

**Toolbar ngDoc example:**
![image](https://user-images.githubusercontent.com/12733153/29372257-9961b9d0-8278-11e7-889e-1e7b4dc3a706.png)

https://patternfly.atlassian.net/browse/OSUX-118
https://patternfly.atlassian.net/browse/OSUX-119

## PR Checklist

- [X] Unit tests are included
- [X] Screenshots are attached (if there are visual changes in the UI)
- [X] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [X] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
