### PR TITLE
Fix transitions in c3-charts and non-threshold donutPctCharts

### DIFF
--- a/src/charts/c3/c3-chart.component.js
+++ b/src/charts/c3/c3-chart.component.js
@@ -97,9 +97,9 @@
           chartData = ctrl.config;
           if (chartData) {
             chartData.bindto = '#' + $attrs.id;
-            // always re-generate donut pct chart because it's colors
-            // change based on data and thresholds
-            if (!chart || $attrs.id.includes('donutPctChart')) {
+            // only re-generate donut pct chart if it has a threshold object
+            // because it's colors will change based on data and thresholds
+            if (!chart || ($attrs.id.includes('donutPctChart') && chartData.thresholds)) {
               chart = c3.generate(chartData);
             } else {
               //if chart is already created, then we only need to re-load data

--- a/src/charts/c3/c3-chart.component.js
+++ b/src/charts/c3/c3-chart.component.js
@@ -99,7 +99,7 @@
             chartData.bindto = '#' + $attrs.id;
             // only re-generate donut pct chart if it has a threshold object
             // because it's colors will change based on data and thresholds
-            if (!chart || ($attrs.id.includes('donutPctChart') && chartData.thresholds)) {
+            if (!chart || ($attrs.id.indexOf('donutPctChart') !== -1 && chartData.thresholds)) {
               chart = c3.generate(chartData);
             } else {
               //if chart is already created, then we only need to re-load data

--- a/src/charts/c3/c3-chart.component.js
+++ b/src/charts/c3/c3-chart.component.js
@@ -99,7 +99,7 @@
             chartData.bindto = '#' + $attrs.id;
             // always re-generate donut pct chart because it's colors
             // change based on data and thresholds
-            if (!chart || $attrs.id.indexOf('donutPctChart')) {
+            if (!chart || $attrs.id.includes('donutPctChart')) {
               chart = c3.generate(chartData);
             } else {
               //if chart is already created, then we only need to re-load data


### PR DESCRIPTION
## Description
This PR addresses issues #541 and #542.

The first short commit corrects #541, where updating charts would cause a re-generation of the chart, and as a result, potentially shift screen orientation. This was caused by 
`if (!chart || $attrs.id.indexOf('donutPctChart')) {`
because indexOf() returns a number, and will not cause the condition to fail if the result is '-1'. As a result, charts that are not donutPctCharts (e.g., line, sparkline, and trends) will pass this condition and re-generate. My proposed solution here is to change indexOf() to includes(), which will return a boolean instead, and ensure intended behaviour.

The second short commit addresses #542, and fixes the 'transition' behaviour in donutPctCharts that do not contain a 'thresholds' attribute. Not all donutPctCharts will use thresholds, and only those that do will need to be re-generated to change colours. The transition attribute gets nullified by the chart being re-generated, because instead of using an animation when updating the chart will just re-draw itself to it's new value. My proposed solution is to add a check to the condition which makes the chart re-generate only if:
1. the chart doesn't exist, OR
2. the chart is a donutPctChart AND contains a threshold object
This doesn't fix transitions in thresholds utilizing donutPctCharts, but will fix the behaviour in charts that don't use thresholds.

Thoughts?

Cheers,
aptmac

## PR Checklist

- [ ] Unit tests are included
- [ ] Screenshots are attached (if there are visual changes in the UI)
- [ ] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [ ] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
