### PR TITLE
fix(pfFilter): Added alias support to select/complex-select

### DIFF
--- a/src/filters/examples/filter.js
+++ b/src/filters/examples/filter.js
@@ -81,26 +81,26 @@
             name: "John Smith",
             address: "415 East Main Street, Norfolk, Virginia",
             birthMonth: 'October',
-            car: 'Subaru-Outback'
+            car: 'subie-out'
 
           },
           {
             name: "Frank Livingston",
             address: "234 Elm Street, Pittsburgh, Pennsylvania",
             birthMonth: 'March',
-            car: 'Toyota-Prius'
+            car: 'Toyota-pri'
           },
           {
             name: "Judy Green",
             address: "2 Apple Boulevard, Cincinatti, Ohio",
             birthMonth: 'December',
-            car: 'Subaru-Impreza'
+            car: 'subie-Impreza'
           },
           {
             name: "Pat Thomas",
             address: "50 Second Street, New York, New York",
-            birthMonth: 'February',
-            car: 'Subaru-Outback'
+            birthMonth: 'jan',
+            car: 'subie-Crosstrek'
           }
         ];
         $scope.items = $scope.allItems;
@@ -174,24 +174,24 @@
               title:  'Birth Month',
               placeholder: 'Filter by Birth Month',
               filterType: 'select',
-              filterValues: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+              filterValues: [{title:'January', id:'jan'}, {title:'Feb', id:'February'}, 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
             },
            {
               id: 'car',
               title:  'Car',
               placeholder: 'Filter by Car Make',
               filterType: 'complex-select',
-              filterValues: ['Subaru', 'Toyota'],
+              filterValues: [{title:'Subaru', id:'subie'}, 'Toyota'],
               filterDelimiter: '-',
               filterCategoriesPlaceholder: 'Filter by Car Model',
-              filterCategories: {subaru: {
-                id: 'subaru',
+              filterCategories: {subie: {
+                id: 'subie',
                 title:  'Subaru',
-                filterValues: ['Outback', 'Crosstrek', 'Impreza']},
+                filterValues: [{title:'Outback', id:'out'}, 'Crosstrek', 'Impreza']},
                 toyota: {
                 id: 'toyota',
                 title:  'Toyota',
-                filterValues: ['Prius', 'Corolla', 'Echo']}
+                filterValues: [{title:'Prius', id:'pri'}, 'Corolla', 'Echo']}
                 }
             }
           ],

--- a/src/filters/simple-filter/filter-fields-component.js
+++ b/src/filters/simple-filter/filter-fields-component.js
@@ -79,7 +79,7 @@ angular.module('patternfly.filters').component('pfFilterFields', {
           }
         } else {
           ctrl.addFilterFn(ctrl.currentField, filterValue);
-          ctrl.currentValue = null;
+          ctrl.currentValue = filterValue;
         }
       }
     }

--- a/src/filters/simple-filter/filter-fields.html
+++ b/src/filters/simple-filter/filter-fields.html
@@ -31,9 +31,10 @@
               {{$ctrl.currentField.placeholder}}
             </a>
           </li>
-          <li ng-repeat="filterValue in $ctrl.currentField.filterValues" ng-class="{'selected': filterValue === $ctrl.currentValue}">
-            <a role="menuitem" tabindex="-1" ng-click="$ctrl.selectValue(filterValue)">
-              {{filterValue}}
+          <li ng-repeat="filterValue in $ctrl.currentField.filterValues"
+              ng-class="{'selected': (filterValue === $ctrl.currentValue || filterValue.id === $ctrl.currentValue)}">
+            <a role="menuitem" tabindex="-1" ng-click="$ctrl.selectValue(filterValue.id || filterValue)">
+              {{filterValue.title || filterValue}}
             </a>
           </li>
         </ul>
@@ -52,9 +53,10 @@
               {{$ctrl.currentField.placeholder}}
             </a>
           </li>
-          <li ng-repeat="filterCategory in $ctrl.currentField.filterValues" ng-class="{'selected': filterCategory === $ctrl.filterCategory}">
-            <a role="menuitem" tabindex="-1" ng-click="$ctrl.selectValue(filterCategory, 'filter-category')">
-              {{filterCategory}}
+          <li ng-repeat="filterCategory in $ctrl.currentField.filterValues"
+              ng-class="{'selected': (filterCategory === $ctrl.filterCategory || filterCategory.id === $ctrl.filterCategory)}">
+            <a role="menuitem" tabindex="-1" ng-click="$ctrl.selectValue(filterCategory.id ||filterCategory, 'filter-category')">
+              {{filterCategory.title ||filterCategory}}
             </a>
           </li>
         </ul>
@@ -71,9 +73,10 @@
               {{$ctrl.currentField.filterCategoriesPlaceholder}}
             </a>
           </li>
-          <li ng-repeat="filterValue in $ctrl.currentField.filterCategories[$ctrl.filterCategory.toLowerCase()].filterValues" ng-class="{'selected': filterValue === $ctrl.filterValue}">
-            <a role="menuitem" tabindex="-1" ng-click="$ctrl.selectValue(filterValue, 'filter-value')">
-              {{filterValue}}
+          <li ng-repeat="filterValue in $ctrl.currentField.filterCategories[$ctrl.filterCategory.toLowerCase()].filterValues"
+              ng-class="{'selected': (filterValue === $ctrl.filterValue || filterValue.id === $ctrl.filterValue)}">
+            <a role="menuitem" tabindex="-1" ng-click="$ctrl.selectValue(filterValue.id || filterValue, 'filter-value')">
+              {{filterValue.title || filterValue}}
             </a>
           </li>
         </ul>

--- a/test/filters/filter.spec.js
+++ b/test/filters/filter.spec.js
@@ -40,24 +40,24 @@ describe('Directive:  pfFilter', function () {
           title:  'Birth Month',
           placeholder: 'Filter by Birth Month',
           filterType: 'select',
-          filterValues: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+          filterValues: [{title:'January', id:'jan'}, {title:'Feb', id:'February'}, 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
         },
         {
           id: 'car',
           title:  'Car',
           placeholder: 'Filter by Car Make',
           filterType: 'complex-select',
-          filterValues: ['Subaru', 'Toyota'],
+          filterValues: [{title:'Subaru', id:'subie'}, 'Toyota'],
           filterDelimiter: '-',
           filterCategoriesPlaceholder: 'Filter by Car Model',
-          filterCategories: {subaru: {
-            id: 'subaru',
+          filterCategories: {subie: {
+            id: 'subie',
             title:  'Subaru',
-            filterValues: ['Outback', 'Crosstrek', 'Impreza']},
+            filterValues: [{title:'Outback', id:'out'}, 'Crosstrek', 'Impreza']},
             toyota: {
               id: 'toyota',
               title:  'Toyota',
-              filterValues: ['Prius', 'Corolla', 'Echo']}
+              filterValues: [{title:'Prius', id:'pri'}, 'Corolla', 'Echo']}
           }
         }
       ],


### PR DESCRIPTION
## Description
closes #583

In pfFilter component `select` and `complex-select`, adds support for a value and catetegory/value alias.  Aliased values are able to exist alongside without issue, example has been updated to reflect added funtionality. 

Moved kinda slow in gif, hoping to make it easy to notice the dropdown descriptions vs the results listing. 

![filter-alias](https://user-images.githubusercontent.com/6640236/29539732-35cd9ae0-8699-11e7-8904-a13f47f8159c.gif)

This might not be a feature, rather something more minor? I defer to reviewers.  ALSO if ya want me to do something differently, 👍 🌭 

## PR Checklist

- [x] Unit tests are included
- [x] Screenshots are attached (if there are visual changes in the UI)
- [ ] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [ ] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
