### PR TITLE
chore(pfToolbar): fix typo in directive name and link from 'componenet' to 'component'

### DIFF
--- a/src/table/tableview/examples/table-view-basic.js
+++ b/src/table/tableview/examples/table-view-basic.js
@@ -5,7 +5,7 @@
   * @description
   * Component for rendering a simple table view.<br><br>
   * See {@link patternfly.table.component:pfTableView%20-%20with%20Toolbar pfTableView - with Toolbar} for use with a Toolbar<br>
-  * See {@link patternfly.toolbars.componenet:pfToolbar pfToolbar} for use in Toolbar View Switcher
+  * See {@link patternfly.toolbars.component:pfToolbar pfToolbar} for use in Toolbar View Switcher
   *
   * @param {object} config Optional configuration object
   * <ul style='list-style-type: none'>

--- a/src/table/tableview/examples/table-view-with-toolbar.js
+++ b/src/table/tableview/examples/table-view-with-toolbar.js
@@ -4,7 +4,7 @@
  *
  * @description
  * Example configuring a table view with a toolbar.<br><br>
- * Please see {@link patternfly.toolbars.componenet:pfToolbar pfToolbar} for use in Toolbar View Switcher
+ * Please see {@link patternfly.toolbars.component:pfToolbar pfToolbar} for use in Toolbar View Switcher
  *
  * @param {object} config Optional configuration object
  * <ul style='list-style-type: none'>

--- a/src/toolbars/examples/toolbar.js
+++ b/src/toolbars/examples/toolbar.js
@@ -1,6 +1,6 @@
 /**
  * @ngdoc directive
- * @name patternfly.toolbars.componenet:pfToolbar
+ * @name patternfly.toolbars.component:pfToolbar
  * @restrict E
  *
  * @description


### PR DESCRIPTION
## Description
Hi,

While browsing the PatternFly API, I noticed a typo in the URL [0] of the pfToolbar ('componenet' is used instead of 'component').

This short patch changes the name and links to 'component', so it's URL is more consistent with other component URLs. 

Thoughts?

Cheers,
aptmac

[0] https://www.patternfly.org/angular-patternfly/#/api/patternfly.toolbars.componenet:pfToolbar

## PR Checklist

- [ ] Unit tests are included
- [ ] Screenshots are attached (if there are visual changes in the UI)
- [ ] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [ ] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
