### PR TITLE
Fixes issue 575: change h1 to h4 styled as h1

### DIFF
--- a/src/views/empty-state.html
+++ b/src/views/empty-state.html
@@ -2,13 +2,13 @@
   <div ng-if="$ctrl.config.icon" class="blank-slate-pf-icon">
     <span class="{{$ctrl.config.icon}}"></span>
   </div>
-  <h1 id="title">
+  <h4 id="blank-state-pf-title-{{$id}}" class="h1 blank-state-pf-title">
     {{$ctrl.config.title}}
-  </h1>
-  <p id="info" ng-if="$ctrl.config.info">
+  </h4>
+  <p id="blank-state-pf-info-{{$id}}" class="blank-state-pf-info" ng-if="$ctrl.config.info">
     {{$ctrl.config.info}}
   </p>
-  <p id="helpLink" ng-if="$ctrl.config.helpLink">
+  <p id="blank-state-pf-helpLink-{{$id}}" class="blank-state-pf-helpLink" ng-if="$ctrl.config.helpLink">
     {{$ctrl.config.helpLink.label}} <a href="{{$ctrl.config.helpLink.url}}">{{$ctrl.config.helpLink.urlLabel}}</a>.
   </p>
   <div ng-if="$ctrl.hasMainActions()" class="blank-slate-pf-main-action">

--- a/test/notification/notification-drawer.spec.js
+++ b/test/notification/notification-drawer.spec.js
@@ -593,7 +593,7 @@ describe('Component:  pfNotificationDrawer', function () {
     var emptyStates = element.find('.blank-slate-pf');
     expect(emptyStates.length).toBe(1);
 
-    var title = angular.element(emptyStates[0]).find('#title').html();
+    var title = angular.element(emptyStates[0]).find('.blank-state-pf-title').html();
     expect(_.trim(title)).toBe('There are no notifications to display.');
   });
 
@@ -609,7 +609,7 @@ describe('Component:  pfNotificationDrawer', function () {
     var emptyStates = element.find('.blank-slate-pf');
     expect(emptyStates.length).toBe(1);
 
-    var title = angular.element(emptyStates[0]).find('#title').html();
+    var title = angular.element(emptyStates[0]).find('.blank-state-pf-title').html();
     expect(_.trim(title)).toBe('Nothing');
   });
 
@@ -617,10 +617,10 @@ describe('Component:  pfNotificationDrawer', function () {
     var emptyStates = element.find('.blank-slate-pf');
     expect(emptyStates.length).toBe(2);
 
-    var title = angular.element(emptyStates[0]).find('#title').html();
+    var title = angular.element(emptyStates[0]).find('.blank-state-pf-title').html();
     expect(_.trim(title)).toBe('There are no notifications to display.');
 
-    title = angular.element(emptyStates[1]).find('#title').html();
+    title = angular.element(emptyStates[1]).find('.blank-state-pf-title').html();
     expect(_.trim(title)).toBe('Nothing');
   });
 });

--- a/test/table/tableview/table-view.spec.js
+++ b/test/table/tableview/table-view.spec.js
@@ -85,21 +85,21 @@ describe('Component: pfTableView', function () {
     basicSetup();
     $scope.items = null;
     $scope.$digest();
-    expect(element.find('#title').text()).toContain('');
+    expect(element.find('.blank-state-pf-title').text()).toContain('');
   });
 
   it('should show the empty state when items is empty', function () {
     basicSetup();
     $scope.items = [];
     $scope.$digest();
-    expect(element.find('#title').text()).toContain('No Items Available');
+    expect(element.find('.blank-state-pf-title').text()).toContain('No Items Available');
   });
 
   it('should show the empty state when the config property is specified', function () {
     basicSetup();
     $scope.config.itemsAvailable = false;
     $scope.$digest();
-    expect(element.find('#title').text()).toContain('No Items Available');
+    expect(element.find('.blank-state-pf-title').text()).toContain('No Items Available');
   });
 
   it('should show the correct number of items', function () {

--- a/test/views/cardview/card-view.spec.js
+++ b/test/views/cardview/card-view.spec.js
@@ -224,6 +224,6 @@ describe('Component:  pfCardView', function () {
   it('should show the empty state when specified', function () {
     $scope.cardConfig.itemsAvailable = false;
     $scope.$digest();
-    expect(element.find('#title').text()).toContain('No Items Available');
+    expect(element.find('.blank-state-pf-title').text()).toContain('No Items Available');
   });
 })

--- a/test/views/empty-state.spec.js
+++ b/test/views/empty-state.spec.js
@@ -1,4 +1,4 @@
-describe('Component:  pfEnptyState', function () {
+describe('Component:  pfEmptyState', function () {
   var $scope;
   var $compile;
   var element;
@@ -68,9 +68,9 @@ describe('Component:  pfEnptyState', function () {
     compileHTML('<pf-empty-state config="config" action-buttons="actionButtons"></pf-empty-state>', $scope);
 
     expect(element.find('.pficon-add-circle-o').length).toBe(1);
-    expect(element.find('#title').text()).toContain('Empty State Title');
-    expect(element.find('#info').text()).toContain('This is the Empty State component');
-    expect(element.find('#helpLink').text()).toContain('For more information please see');
+    expect(element.find('.blank-state-pf-title').text()).toContain('Empty State Title');
+    expect(element.find('.blank-state-pf-info').text()).toContain('This is the Empty State component');
+    expect(element.find('.blank-state-pf-helpLink').text()).toContain('For more information please see');
     expect(element.find('a').text()).toContain('pfExample');
     expect(element.find('a').prop('href')).toContain('#/api/patternfly.views.component:pfEmptyState');
 
@@ -89,11 +89,11 @@ describe('Component:  pfEnptyState', function () {
   it('should only display main default title when no config and actionButtons defined', function () {
     compileHTML('<pf-empty-state></pf-empty-state>', $scope);
 
-    expect(element.find('#title').text()).toContain('No Items Available');
+    expect(element.find('.blank-state-pf-title').text()).toContain('No Items Available');
 
     expect(element.find('.blank-slate-pf-icon').length).toBe(0);
-    expect(element.find('#info').length).toBe(0);
-    expect(element.find('#helpLink').length).toBe(0);
+    expect(element.find('.info').length).toBe(0);
+    expect(element.find('.helpLink').length).toBe(0);
     expect(element.find('button').length).toBe(0);
   });
 });

--- a/test/views/listview/list-view.spec.js
+++ b/test/views/listview/list-view.spec.js
@@ -603,6 +603,6 @@ describe('Component:  pfDataList', function () {
   it('should show the empty state when specified', function () {
     $scope.listConfig.itemsAvailable = false;
     $scope.$digest();
-    expect(element.find('#title').text()).toContain('No Items Available');
+    expect(element.find('.blank-state-pf-title').text()).toContain('No Items Available');
   });
 });


### PR DESCRIPTION
- Update `h1` to `h4.h1`
- Update id's to be unique via `id="empty-state-title-{{$id}}"`
- Update tests
- Fix typos

@jeff-phillips-18 for review, might be some conventions I should conform to.
@spadgett 

Re: update needed for [origin-web-console PR 1326](https://github.com/openshift/origin-web-console/pull/1326) via [this comment](https://github.com/openshift/origin-web-console/pull/1326#issuecomment-323076310).