### PR TITLE
Include lodash for datatables

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Note:
     
     <!-- Angular-PatternFly  -->
     <script src="node_modules/angular-patternfly/dist/angular-patternfly.min.js"></script>
+
+    <!-- Lodash -->
+    <script src="node_modules/angular-patternfly/node_modules/lodash/lodash.min.js"></script>
     ```
 
 5. (optional) The 'patternfly.charts' module is not a dependency in the default angular 'patternfly' module.


### PR DESCRIPTION
## Description
lodash dependency was not included for `patternfly.table`.

## PR Checklist

(none needed, documentation fix)
