### PR TITLE
fix(pfTrendsChart): In compact layout, tightened up space

### DIFF
--- a/src/charts/charts.less
+++ b/src/charts/charts.less
@@ -63,6 +63,15 @@ pf-c3-chart {
   }
 }
 
+.trend-card-compact-pf {
+  .col-sm-2 {
+    padding-right: 0;
+  }
+  .col-sm-10 {
+    padding-left: 0;
+  }
+}
+
 .trend-flat-details {
   display: table;
   margin-top: 5px;

--- a/src/charts/trends/trends-chart.html
+++ b/src/charts/trends/trends-chart.html
@@ -19,7 +19,7 @@
   </div>
   <div ng-switch-when="compact" class="trend-card-compact-pf">
     <div class="row trend-row">
-      <div class="col-sm-4 col-md-4">
+      <div class="col-sm-2">
         <div class="trend-compact-details">
           <span ng-if="$ctrl.showActualValue">
             <span class="trend-title-compact-big-pf">{{$ctrl.getLatestValue()}}</span>
@@ -32,7 +32,7 @@
           <span class="trend-header-compact-pf" ng-if="$ctrl.config.title">{{$ctrl.config.title}}</span>
         </div>
       </div>
-      <div class="col-sm-8 col-md-8">
+      <div class="col-sm-10">
         <pf-sparkline-chart ng-if="$ctrl.chartData.dataAvailable !== false" config="$ctrl.config" chart-data="$ctrl.chartData" chart-height="$ctrl.getChartHeight()"
              show-x-axis="$ctrl.showXAxis" show-y-axis="$ctrl.showYAxis"></pf-sparkline-chart>
         <pf-empty-chart ng-if="$ctrl.chartData.dataAvailable === false" chart-height="$ctrl.getChartHeight()"></pf-empty-chart>
@@ -41,12 +41,12 @@
   </div>
   <div ng-switch-when="inline" class="trend-card-inline-pf">
     <div class="row trend-row">
-      <div class="col-sm-8 col-md-8 trend-flat-col">
+      <div class="col-sm-8 trend-flat-col">
         <pf-sparkline-chart ng-if="$ctrl.chartData.dataAvailable !== false" config="$ctrl.config" chart-data="$ctrl.chartData" chart-height="$ctrl.getChartHeight()"
              show-x-axis="$ctrl.showXAxis" show-y-axis="$ctrl.showYAxis"></pf-sparkline-chart>
         <pf-empty-chart ng-if="$ctrl.chartData.dataAvailable === false" chart-height="$ctrl.getChartHeight()"></pf-empty-chart>
       </div>
-      <div class="col-sm-4 col-md-4 trend-flat-col">
+      <div class="col-sm-4 trend-flat-col">
         <div class="trend-flat-details">
           <div class="trend-flat-details-cell">
             <span class="trend-title-flat-big-pf">{{$ctrl.getPercentageValue() + '%'}}</span>


### PR DESCRIPTION
## Description
In compact layout, tightened space up between labels and chart:
## PR Checklist

- [ ] Unit tests are included
- [X] Screenshots are attached (if there are visual changes in the UI)
- [X] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [X] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)

**Previous:**
![screen shot 2017-08-17 at 4 27 49 pm](https://user-images.githubusercontent.com/12504403/29432510-f9da065e-8369-11e7-8b18-41119eff925f.png)

**Now:**
![image](https://user-images.githubusercontent.com/12733153/29627796-4a48940c-8801-11e7-82fb-4ddee31fb107.png)

Fixes #579 

@serenamarie125