### PR TITLE
fix(pfFilter): do not allow empty filters

### DIFF
--- a/src/filters/simple-filter/filter-fields-component.js
+++ b/src/filters/simple-filter/filter-fields-component.js
@@ -89,7 +89,7 @@ angular.module('patternfly.filters').component('pfFilterFields', {
     }
 
     function onValueKeyPress (keyEvent) {
-      if (keyEvent.which === 13) {
+      if (keyEvent.which === 13 && ctrl.currentValue && ctrl.currentValue.length > 0) {
         ctrl.addFilterFn(ctrl.currentField, ctrl.currentValue);
         ctrl.currentValue = undefined;
         keyEvent.stopPropagation();


### PR DESCRIPTION
## Description
Updated so that hitting [Enter] on an empty input filter field doesn't create an empty filter.

Fixes #509