### PR TITLE
chore(pfTrendsChart): Updated class selector in unit test to string reference

### DIFF
--- a/test/charts/trends/trends-chart.spec.js
+++ b/test/charts/trends/trends-chart.spec.js
@@ -68,19 +68,19 @@ describe('Directive: pfTrendsChart', function() {
     trendCard = element.find('.trend-card-large-pf');
     expect(trendCard.length).toBe(1);
     // check small card isn't being shown by default
-    expect(trendCard.hasClass('.trend-card-small-pf')).toBeFalsy();
+    expect(trendCard.hasClass('trend-card-small-pf')).toBe(false);
 
     $scope.config.layout = 'small';
     $scope.$digest();
     trendCard = element.find('.trend-card-small-pf');
     expect(trendCard.length).toBe(1);
-    expect(trendCard.hasClass('.trend-card-large-pf')).toBeFalsy();
+    expect(trendCard.hasClass('trend-card-large-pf')).toBe(false);
 
     $scope.config.layout = 'large';
     $scope.$digest();
     trendCard = element.find('.trend-card-large-pf');
     expect(trendCard.length).toBe(1);
-    expect(trendCard.hasClass('.trend-card-small-pf')).toBeFalsy();
+    expect(trendCard.hasClass('trend-card-small-pf')).toBe(false);
   });
 
   it("should show compact card layout", function() {


### PR DESCRIPTION
## Description
This update fixes the ```trends-chart.spec.js``` unit test to use string references for ```hasClass()``` instead of the CSS selectors. This would close #598 

## PR Checklist

- [X] Unit tests are included
- [ ] Screenshots are attached (if there are visual changes in the UI)
- [ ] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [ ] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
