### PR TITLE
fix(pfToastNotificationList): HTML Content for Toast Notifications

### DIFF
--- a/src/notification/toast-notification-list.component.js
+++ b/src/notification/toast-notification-list.component.js
@@ -7,8 +7,8 @@
  * @param {Array} notifications The list of current notifications to display. Each notification should have the following (see pfToastNotification):
  *           <ul style='list-style-type: none'>
  *             <li>.type - (String) The type of the notification message. Allowed value is one of these: 'success','info','danger', 'warning'
- *             <li>.header - (String) The header to display for the notification (optional)
- *             <li>.message - (String) The main text message of the notification.
+ *             <li>.header - (String) The header to display for the notification, accepts HTML content. (optional)
+ *             <li>.message - (String) The main text message of the notification. Accepts HTML content.
  *             <li>.actionTitle Text to show for the primary action, optional.
  *             <li>.actionCallback (function(this notification)) Function to invoke when primary action is selected, optional
  *             <li>.menuActions  Optional list of actions to place in the kebab menu:<br/>
@@ -118,7 +118,7 @@
 
        $scope.type = $scope.types[0];
        $scope.header = 'Default header.';
-       $scope.message = 'Default notification message.';
+       $scope.message = 'Default <strong>notification</strong> message.';
        $scope.showClose = false;
        $scope.persistent = false;
 
@@ -193,7 +193,7 @@
            $scope.handleAction,
            ($scope.showMenu ? $scope.menuActions : undefined)
          );
-       }
+       };
 
        $scope.notifications = Notifications.data;
      });
@@ -225,3 +225,4 @@ angular.module('patternfly.notification').component('pfToastNotificationList', {
     };
   }
 });
+

--- a/src/notification/toast-notification-list.component.js
+++ b/src/notification/toast-notification-list.component.js
@@ -7,8 +7,8 @@
  * @param {Array} notifications The list of current notifications to display. Each notification should have the following (see pfToastNotification):
  *           <ul style='list-style-type: none'>
  *             <li>.type - (String) The type of the notification message. Allowed value is one of these: 'success','info','danger', 'warning'
- *             <li>.header - (String) The header to display for the notification, accepts HTML content. (optional)
- *             <li>.message - (String) The main text message of the notification. Accepts HTML content.
+ *             <li>.header - (String) The header to display for the notification, accepts HTML content when allowed. (optional)
+ *             <li>.message - (String) The main text message of the notification. Accepts HTML content when allowed.
  *             <li>.actionTitle Text to show for the primary action, optional.
  *             <li>.actionCallback (function(this notification)) Function to invoke when primary action is selected, optional
  *             <li>.menuActions  Optional list of actions to place in the kebab menu:<br/>
@@ -21,6 +21,7 @@
  *             <li>.isPersistent Flag to show close button for the notification even if showClose is false.
  *           </ul>
  * @param {Boolean} showClose Flag to show the close button on all notifications (not shown if the notification has menu actions)
+ * @param {Boolean} htmlContent Flag to allow HTML content within the header and message options.
  * @param {function} closeCallback (function(data)) Function to invoke when closes a toast notification
  * @param {function} updateViewing (function(boolean, data)) Function to invoke when user is viewing/not-viewing (hovering on) a toast notification
  *
@@ -32,7 +33,7 @@
 
    <file name="index.html">
      <div ng-controller="ToastNotificationListDemoCtrl" >
-       <pf-toast-notification-list notifications="notifications" show-close="showClose" close-callback="handleClose" update-viewing="updateViewing"></pf-toast-notification-list>
+       <pf-toast-notification-list notifications="notifications" show-close="showClose" html-content="htmlContent" close-callback="handleClose" update-viewing="updateViewing"></pf-toast-notification-list>
        <div class="row example-container">
          <div class="col-md-12">
            <form class="form-horizontal">
@@ -84,8 +85,12 @@
                  <input type="checkbox" ng-model="persistent"/>
                </div>
                <label class="col-sm-2 control-label" for="type">Show Menu:</label>
-               <div class="col-sm-2">
+               <div class="col-sm-1">
                  <input type="checkbox" ng-model="showMenu"/>
+               </div>
+               <label class="col-sm-2 control-label" for="type">Allow HTML:</label>
+               <div class="col-sm-1">
+               <input type="checkbox" ng-model="htmlContent"/>
                </div>
              </div>
              <div class="form-group">
@@ -120,6 +125,7 @@
        $scope.header = 'Default header.';
        $scope.message = 'Default <strong>notification</strong> message.';
        $scope.showClose = false;
+       $scope.htmlContent = false;
        $scope.persistent = false;
 
        $scope.primaryAction = '';
@@ -205,6 +211,7 @@ angular.module('patternfly.notification').component('pfToastNotificationList', {
   bindings: {
     notifications: '=',
     showClose: '=?',
+    htmlContent: '<?',
     closeCallback: '=?',
     updateViewing: '=?'
   },

--- a/src/notification/toast-notification-list.html
+++ b/src/notification/toast-notification-list.html
@@ -4,6 +4,7 @@
          header="{{notification.header}}"
          message="{{notification.message}}"
          show-close="{{($ctrl.showClose || notification.isPersistent === true) && !(notification.menuActions && notification.menuActions.length > 0)}}"
+         html-content="$ctrl.htmlContent"
          close-callback="$ctrl.handleClose"
          action-title="{{notification.actionTitle}}"
          action-callback="notification.actionCallback"

--- a/src/notification/toast-notification.component.js
+++ b/src/notification/toast-notification.component.js
@@ -5,9 +5,10 @@
  * @scope
  *
  * @param {string} notificationType The type of the notification message. Allowed value is one of these: 'success','info','danger', 'warning'
- * @param {string} header The header text of the notification. Accepts HTML content.
- * @param {string} message The main text message of the notification. Accepts HTML content.
+ * @param {string} header The header text of the notification. Accepts HTML content when allowed.
+ * @param {string} message The main text message of the notification. Accepts HTML content when allowed.
  * @param {boolean} showClose Flag to show the close button, default: true
+ * @param {boolean} htmlContent Flag to allow HTML content within the header and message options.
  * @param {function} closeCallback (function(data)) Function to invoke when close action is selected, optional
  * @param {string} actionTitle Text to show for the primary action, optional.
  * @param {function} actionCallback (function(data)) Function to invoke when primary action is selected, optional
@@ -37,9 +38,9 @@
      <div ng-controller="ToastNotificationDemoCtrl" class="row example-container">
        <div class="col-md-12">
          <pf-toast-notification notification-type="{{type}}" header="{{header}}" message="{{message}}"
-              show-close="{{showClose}}" close-callback="closeCallback"
-              action-title="{{primaryAction}}" action-callback="handleAction"
-              menu-actions="menuActions">
+              show-close="{{showClose}}"  html-content="htmlContent"
+              close-callback="closeCallback" action-title="{{primaryAction}}"
+              action-callback="handleAction" menu-actions="menuActions">
          </pf-toast-notification>
 
          <form class="form-horizontal">
@@ -81,12 +82,16 @@
            </div>
            <div class="form-group">
              <label class="col-sm-2 control-label" for="type">Show Close:</label>
-             <div class="col-sm-3">
+             <div class="col-sm-1">
              <input type="checkbox" ng-model="showClose"/>
              </div>
              <label class="col-sm-2 control-label" for="type">Show Menu:</label>
-             <div class="col-sm-3">
+             <div class="col-sm-1">
               <input type="checkbox" ng-model="showMenu"/>
+             </div>
+             <label class="col-sm-2 control-label" for="type">Allow HTML:</label>
+                <div class="col-sm-1">
+                <input type="checkbox" ng-model="htmlContent"/>
              </div>
            </div>
          </form>
@@ -105,6 +110,7 @@
        $scope.types = ['success','info','danger', 'warning'];
        $scope.type = $scope.types[0];
        $scope.showClose = false;
+       $scope.htmlContent = false;
 
        $scope.header = 'Default Header.';
        $scope.message = 'Default <strong>notification</strong> message.';
@@ -182,6 +188,7 @@ angular.module( 'patternfly.notification' ).component('pfToastNotification', {
     'message': '@',
     'header': '@',
     'showClose': '@',
+    'htmlContent': '<?',
     'closeCallback': '=?',
     'actionTitle': '@',
     'actionCallback': '=?',

--- a/src/notification/toast-notification.component.js
+++ b/src/notification/toast-notification.component.js
@@ -5,8 +5,8 @@
  * @scope
  *
  * @param {string} notificationType The type of the notification message. Allowed value is one of these: 'success','info','danger', 'warning'
- * @param {string} header The header text of the notification.
- * @param {string} message The main text message of the notification.
+ * @param {string} header The header text of the notification. Accepts HTML content.
+ * @param {string} message The main text message of the notification. Accepts HTML content.
  * @param {boolean} showClose Flag to show the close button, default: true
  * @param {function} closeCallback (function(data)) Function to invoke when close action is selected, optional
  * @param {string} actionTitle Text to show for the primary action, optional.
@@ -107,7 +107,7 @@
        $scope.showClose = false;
 
        $scope.header = 'Default Header.';
-       $scope.message = 'Default Message.';
+       $scope.message = 'Default <strong>notification</strong> message.';
        $scope.primaryAction = '';
 
        $scope.updateType = function(item) {
@@ -190,7 +190,7 @@ angular.module( 'patternfly.notification' ).component('pfToastNotification', {
     'data': '=?'
   },
   templateUrl: 'notification/toast-notification.html',
-  controller: function () {
+  controller: function ($sce) {
     'use strict';
     var ctrl = this,
       _showClose;
@@ -249,5 +249,10 @@ angular.module( 'patternfly.notification' ).component('pfToastNotification', {
         ctrl.updateShowClose();
       }
     };
+
+    ctrl.trustAsHtml = function (html) {
+      return $sce.trustAsHtml(html);
+    };
   }
 });
+

--- a/src/notification/toast-notification.html
+++ b/src/notification/toast-notification.html
@@ -27,7 +27,11 @@
   <span class="pficon pficon-info" ng-if="$ctrl.notificationType === 'info'"></span>
   <span class="pficon pficon-error-circle-o" ng-if="$ctrl.notificationType === 'danger'"></span>
   <span class="pficon pficon-warning-triangle-o" ng-if="$ctrl.notificationType === 'warning'"></span>
-  <span>
+  <span ng-if="!$ctrl.htmlContent">
+    <strong ng-if="$ctrl.header" ng-bind="$ctrl.header"></strong>
+    <span ng-bind="$ctrl.message"></span>
+  </span>
+  <span ng-if="$ctrl.htmlContent">
     <strong ng-if="$ctrl.header" ng-bind-html="$ctrl.trustAsHtml($ctrl.header)"></strong>
     <span ng-bind-html="$ctrl.trustAsHtml($ctrl.message)"></span>
   </span>

--- a/src/notification/toast-notification.html
+++ b/src/notification/toast-notification.html
@@ -27,10 +27,9 @@
   <span class="pficon pficon-info" ng-if="$ctrl.notificationType === 'info'"></span>
   <span class="pficon pficon-error-circle-o" ng-if="$ctrl.notificationType === 'danger'"></span>
   <span class="pficon pficon-warning-triangle-o" ng-if="$ctrl.notificationType === 'warning'"></span>
-  <span ng-if="$ctrl.header">
-    <strong>{{$ctrl.header}}</strong> {{$ctrl.message}}
-  </span>
-  <span ng-if="!$ctrl.header">
-    {{$ctrl.message}}
+  <span>
+    <strong ng-if="$ctrl.header" ng-bind-html="$ctrl.trustAsHtml($ctrl.header)"></strong>
+    <span ng-bind-html="$ctrl.trustAsHtml($ctrl.message)"></span>
   </span>
 </div>
+

--- a/test/notification/toast-notification-list.spec.js
+++ b/test/notification/toast-notification-list.spec.js
@@ -157,12 +157,13 @@ describe('Component: pfToastNotificationList', function () {
     // No Menu Actions
     $scope.notifications.forEach(function(nextItem) {
       nextItem.menuActions = undefined;
-    })
+    });
+
     var htmlTmp = '<pf-toast-notification-list notifications="notifications" show-close="false" close-callback="handleClose"></pf-toast-notification-list>';
 
     compileHTML(htmlTmp, $scope);
 
-    var closeButton = element.find('.toast-notifications-list-pf .toast-pf button.close');
+    closeButton = element.find('.toast-notifications-list-pf .toast-pf button.close');
     expect(closeButton.length).toBe(3);
 
     expect($scope.closeData).toBeUndefined();
@@ -208,3 +209,4 @@ describe('Component: pfToastNotificationList', function () {
     expect($scope.menuData.header).toBe("Header 1");
   });
 });
+

--- a/test/notification/toast-notification.spec.js
+++ b/test/notification/toast-notification.spec.js
@@ -21,13 +21,13 @@ describe('Component: pfToastNotification', function () {
     scope.$digest();
   };
 
-  var setupHTML = function (notificationType, header, showClose, primaryAction, showMenu, data) {
+  var setupHTML = function (notificationType, header, message, showClose, primaryAction, showMenu, data) {
     $scope.type = notificationType;
     $scope.header = header;
-    $scope.message = "Test Toast Notification Message";
+    $scope.message = message || "Test Toast Notification Message";
     $scope.showClose = showClose;
     $scope.primaryAction = primaryAction;
-    $scope.data = data
+    $scope.data = data;
 
     $scope.closeData = undefined;
     $scope.closeCallback = function (data) {
@@ -100,26 +100,38 @@ describe('Component: pfToastNotification', function () {
   };
 
   it('should have the correct header and message', function () {
-    setupHTML ("info", "Test Header", false, '', false);
+    setupHTML ("info", "Test Header", null, false, '', false);
     header = element.find('.toast-pf span strong');
     expect(header.length).toBe(1);
     expect(header.text()).toBe("Test Header");
-    message = element.find('.toast-pf span');
+    message = element.find('.toast-pf > span');
     expect(message.length).toBe(2);
     expect(angular.element(message[1]).text()).toContain("Test Toast Notification Message");
   });
 
   it('should have the correct message when no header is given', function () {
-    setupHTML ("info", "", false, '', false);
+    setupHTML ("info", "", null, false, '', false);
     var header = element.find('.toast-pf span strong');
     expect(header.length).toBe(0);
-    var message = element.find('.toast-pf span');
+    var message = element.find('.toast-pf > span');
     expect(message.length).toBe(2);
     expect(angular.element(message[1]).text()).toContain("Test Toast Notification Message");
   });
 
+  it('should allow HTML content within the header and message', function () {
+    setupHTML ("info", "<em>Test Header</em>", null, false, '', false);
+    var header = element.find('.toast-pf span strong em');
+    expect(header.length).toBe(1);
+    expect(header.text()).toContain("Test Header");
+
+    setupHTML ("info", "", "<em>Test Notification Message</em>", false, '', false);
+    var message = element.find('.toast-pf > span em');
+    expect(message.length).toBe(1);
+    expect(message.text()).toContain("Test Notification Message");
+  });
+
   it('should have the correct status icon', function () {
-    setupHTML ("success", "Test Header", false, '', false);
+    setupHTML ("success", "Test Header", null, false, '', false);
     var okIcon = element.find('.pficon.pficon-ok');
     var infoIcon = element.find('.pficon.pficon-info');
     var errorIcon = element.find('.pficon.pficon-error-circle-o');
@@ -129,7 +141,7 @@ describe('Component: pfToastNotification', function () {
     expect(errorIcon.length).toBe(0);
     expect(warnIcon.length).toBe(0);
 
-    setupHTML ("info", "Test Header", false, '', false);
+    setupHTML ("info", "Test Header", null, false, '', false);
     okIcon = element.find('.pficon.pficon-ok');
     infoIcon = element.find('.pficon.pficon-info');
     errorIcon = element.find('.pficon.pficon-error-circle-o');
@@ -139,7 +151,7 @@ describe('Component: pfToastNotification', function () {
     expect(errorIcon.length).toBe(0);
     expect(warnIcon.length).toBe(0);
 
-    setupHTML ("danger", "Test Header", false, '', false);
+    setupHTML ("danger", "Test Header", null, false, '', false);
     okIcon = element.find('.pficon.pficon-ok');
     infoIcon = element.find('.pficon.pficon-info');
     errorIcon = element.find('.pficon.pficon-error-circle-o');
@@ -149,7 +161,7 @@ describe('Component: pfToastNotification', function () {
     expect(errorIcon.length).toBe(1);
     expect(warnIcon.length).toBe(0);
 
-    setupHTML ("warning", "Test Header", false, '', false);
+    setupHTML ("warning", "Test Header", null, false, '', false);
     okIcon = element.find('.pficon.pficon-ok');
     infoIcon = element.find('.pficon.pficon-info');
     errorIcon = element.find('.pficon.pficon-error-circle-o');
@@ -162,11 +174,11 @@ describe('Component: pfToastNotification', function () {
   });
 
   it('should have the close button when specified', function () {
-    setupHTML ("success", "Test Header", false, 'Test Action', true);
+    setupHTML ("success", "Test Header", null, false, 'Test Action', true);
     var closeButton = element.find('button.close');
     expect(closeButton.length).toBe(0);
 
-    setupHTML ("success", "Test Header", true, 'Test Action', false);
+    setupHTML ("success", "Test Header", null, true, 'Test Action', false);
     closeButton = element.find('button.close');
     expect(closeButton.length).toBe(1);
 
@@ -179,13 +191,13 @@ describe('Component: pfToastNotification', function () {
     expect($scope.closeData.title).toBe("Test Notification");
 
     // No close button even if specified when menu actions exist
-    setupHTML ("success", "Test Header", true, 'Test Action', true);
+    setupHTML ("success", "Test Header", null, true, 'Test Action', true);
     closeButton = element.find('button.close');
     expect(closeButton.length).toBe(0);
   });
 
   it('should have the correct primary action and call the correct callback when clicked', function () {
-    setupHTML ("success", "Test Header", false, 'Test Action', false);
+    setupHTML ("success", "Test Header", null, false, 'Test Action', false);
     var actionButton = element.find('.toast-pf-action > a');
     expect(actionButton.length).toBe(1);
     expect($scope.actionData).toBeUndefined();
@@ -198,7 +210,7 @@ describe('Component: pfToastNotification', function () {
   });
 
   it('should have the correct kebab menu and call the correct callback when items are clicked', function () {
-    setupHTML ("success", "Test Header", false, 'Test Action', true);
+    setupHTML ("success", "Test Header", null, false, 'Test Action', true);
     var menuIndicator = element.find('.dropdown-kebab-pf');
     expect(menuIndicator.length).toBe(1);
     var menuItems = element.find('.dropdown-kebab-pf .dropdown-menu li');
@@ -219,13 +231,13 @@ describe('Component: pfToastNotification', function () {
   });
 
   it('should have correct number of separators', function () {
-    setupHTML ("success", "Test Header", false, 'Test Action', true);
+    setupHTML ("success", "Test Header", null, false, 'Test Action', true);
     var fields = element.find('.dropdown-kebab-pf .dropdown-menu .divider');
     expect(fields.length).toBe(1);
   });
 
   it('should correctly disable actions and not call the callback if clicked', function () {
-    setupHTML ("success", "Test Header", false, 'Test Action', true);
+    setupHTML ("success", "Test Header", null, false, 'Test Action', true);
     var fields = element.find('.dropdown-kebab-pf .dropdown-menu .disabled > a');
     expect(fields.length).toBe(1);
 
@@ -239,3 +251,4 @@ describe('Component: pfToastNotification', function () {
     expect($scope.menuData).toBeUndefined();
   });
 });
+

--- a/test/notification/toast-notification.spec.js
+++ b/test/notification/toast-notification.spec.js
@@ -21,13 +21,14 @@ describe('Component: pfToastNotification', function () {
     scope.$digest();
   };
 
-  var setupHTML = function (notificationType, header, message, showClose, primaryAction, showMenu, data) {
+  var setupHTML = function (notificationType, header, message, showClose, primaryAction, showMenu, data, htmlContent) {
     $scope.type = notificationType;
     $scope.header = header;
     $scope.message = message || "Test Toast Notification Message";
     $scope.showClose = showClose;
     $scope.primaryAction = primaryAction;
     $scope.data = data;
+    $scope.htmlContent = htmlContent;
 
     $scope.closeData = undefined;
     $scope.closeCallback = function (data) {
@@ -91,9 +92,9 @@ describe('Component: pfToastNotification', function () {
       title: "Test Notification"
     };
     var htmlTmp = '<pf-toast-notification notification-type="{{type}}" header="{{header}}" message="{{message}}"' +
-                  '    show-close="{{showClose}}" close-callback="closeCallback"' +
-                  '    action-title="{{primaryAction}}" action-callback="handleAction"' +
-                  '    menu-actions="menuActions" data="data">' +
+                  '    show-close="{{showClose}}" html-content="htmlContent" ' +
+                  '    close-callback="closeCallback" action-title="{{primaryAction}}"' +
+                  '    action-callback="handleAction" menu-actions="menuActions" data="data">' +
                   '    </pf-toast-notification>';
 
     compileHTML(htmlTmp, $scope);
@@ -119,12 +120,12 @@ describe('Component: pfToastNotification', function () {
   });
 
   it('should allow HTML content within the header and message', function () {
-    setupHTML ("info", "<em>Test Header</em>", null, false, '', false);
+    setupHTML ("info", "<em>Test Header</em>", null, false, '', false, null, true);
     var header = element.find('.toast-pf span strong em');
     expect(header.length).toBe(1);
     expect(header.text()).toContain("Test Header");
 
-    setupHTML ("info", "", "<em>Test Notification Message</em>", false, '', false);
+    setupHTML ("info", "", "<em>Test Notification Message</em>", false, '', false, null, true);
     var message = element.find('.toast-pf > span em');
     expect(message.length).toBe(1);
     expect(message.text()).toContain("Test Notification Message");


### PR DESCRIPTION
## Description
Minor adjustment to allow HTML content for Toast Notifications. Minor clean up around spec/tests and example.

***Side notes:*** 
- ~~left the ```@``` bindings as is for ```header``` and ```message``` instead of converting them to one-way-binds. Intended backwards compatibility, but can adjust accordingly~~
- ~~nested a ```span``` underneath the original display ```message``` span, there are no intended visual changes~~

***What remains the same:***
- Existing implementations of this component that make use of Angular syntax/markup related to ```strings```, ```one-way binding```, and ```two-way binding``` should remain untouched, meaning your consumer app shouldn't break functionally (i.e Angular & ECMA/JS errors, etc)

***What could cause an issue***
- Nested a ```span``` underneath the original display ```message``` span, there are no intended visual changes. Custom styling on a consumers part could cause alterations
- Activating the **opt-in** ```html-content``` Boolean could have unintended consequences if your toast notifications contain any form of XML/HTML markup/syntax.

## PR Checklist

- [x] Unit tests are included
- [ ] ~~Screenshots are attached (if there are visual changes in the UI)~~
- [ ] ~~A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)~~
- [ ] ~~A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)~~
