### PR TITLE
Bump patternfly-eng-release version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,6 @@ before_install:
 
 install: true
 
-
-before_script:
- # If this command fails and you can't fix it, file an issue and add an exception to .nsprc
- - npm run nsp-check
-
 script:
   - sh -x ./node_modules/patternfly-eng-release/scripts/_build.sh -a
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "matchdep": "0.3.0",
     "nsp": "^2.6.1",
-    "patternfly-eng-release": "^3.26.29",
+    "patternfly-eng-release": "^3.26.35",
     "semantic-release": "^6.3.6"
   },
   "optionalDependencies": {
@@ -83,7 +83,6 @@
     "ngdocs": "grunt ngdocs",
     "ngdocs:view": "grunt ngdocs:view",
     "ngdocs:publish": "grunt ngdocs:publish",
-    "nsp-check": "nsp check",
     "lint": "grunt lint",
     "test": "grunt test",
     "check": "grunt check",


### PR DESCRIPTION
Backed out the recently added nsp check, which requires an npm install. Instead, the nsp check has been added back to the build scripts, which already handle the npm install.
