### PR TITLE
chore(pfNotificationDrawer): Document how to embedd HTML content in messages

### DIFF
--- a/src/notification/examples/notification-drawer.js
+++ b/src/notification/examples/notification-drawer.js
@@ -115,7 +115,7 @@
    <span ng-if="notification.status" class="{{'pull-left ' + $ctrl.customScope.getNotficationStatusIconClass(notification)}}" ng-click="$ctrl.customScope.markRead(notification)"></span>
    <div class="drawer-pf-notification-content" ng-click="$ctrl.customScope.markRead(notification)">
      <span class="drawer-pf-notification-message" tooltip-append-to-body="true" tooltip-popup-delay="500" tooltip-placement="bottom" tooltip="{{notification.message}}">
-      {{notification.message}}
+       <span ng-bind-html="notification.message"></span>
      </span>
      <div class="drawer-pf-notification-info" ng-click="$ctrl.customScope.markRead(notification)">
        <span class="date">{{notification.timeStamp | date:'MM/dd/yyyy'}}</span>
@@ -187,7 +187,7 @@
              {
                uid: 1,
                unread: true,
-               message: "A New Event! Huzzah! Bold.",
+               message: "A New Event! Huzzah! Bold. <a href='http://www.google.com'>Goto Google!</a>",
                status: 'info',
                actions: menuActions,
                timeStamp: currentTime - (1 * 60 * 60 * 1000)

--- a/test/notification/notification-body.html
+++ b/test/notification/notification-body.html
@@ -13,7 +13,9 @@
   </ul>
 </div>
 <span ng-if="notification.status" class="{{'pull-left ' + $ctrl.customScope.getNotficationStatusIconClass(notification)}}"></span>
-<span class="drawer-pf-notification-message">{{notification.message}}</span>
+<span class="drawer-pf-notification-message" tooltip-append-to-body="true" tooltip-popup-delay="500" tooltip-placement="bottom" tooltip="{{notification.message}}">
+   <span ng-bind-html="notification.message"></span>
+</span>
 <div class="drawer-pf-notification-info">
   <span class="date">{{notification.timeStamp | date:'MM/dd/yyyy'}}</span>
   <span class="time">{{notification.timeStamp | date:'h:mm:ss a'}}</span>

--- a/test/notification/notification-drawer.spec.js
+++ b/test/notification/notification-drawer.spec.js
@@ -43,7 +43,6 @@ describe('Component:  pfNotificationDrawer', function () {
       }
     ];
 
-
     $scope.groups = [
       {
         heading: "Group 1",
@@ -51,7 +50,7 @@ describe('Component:  pfNotificationDrawer', function () {
         notifications: [
           {
             unread: true,
-            message: "A New Event! Huzzah! Bold",
+            message: "A New Event! Huzzah! Bold <a href='http://www.google.com'>Goto Google!</a>",
             status: 'info',
             actions: menuActions,
             timeStamp: currentTime - (1 * 60 * 60 * 1000)
@@ -622,5 +621,10 @@ describe('Component:  pfNotificationDrawer', function () {
 
     title = angular.element(emptyStates[1]).find('.blank-state-pf-title').html();
     expect(_.trim(title)).toBe('Nothing');
+  });
+
+  it ('should render HTML in message', function() {
+    var messages = element.find('.drawer-pf-notification-message a');
+    expect(messages.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Description
Very similar to #612 but this allows HTML content into notification draw messages.

![image](https://user-images.githubusercontent.com/12733153/30347700-eec60972-97da-11e7-92a6-a0b37a849299.png)

## PR Checklist

- [x] Unit tests are included
- [x] Screenshots are attached (if there are visual changes in the UI)
- [ ] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [ ] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
