### PR TITLE
New (old) pf-bootstrap-select directive

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -168,6 +168,8 @@ module.exports = function (grunt) {
           image: 'misc/logo-alt.svg',
           scripts: [
             'node_modules/jquery/dist/jquery.js',
+            'node_modules/bootstrap/dist/js/bootstrap.min.js',
+            'node_modules/bootstrap-select/js/bootstrap-select.js',
             'node_modules/components-jqueryui/jquery-ui.min.js',
             'node_modules/datatables.net/js/jquery.dataTables.js',
             'node_modules/datatables.net-select/js/dataTables.select.js',

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Note:
     <!-- Angular -->
     <script src="node_modules/angular-patternfly/node_modules/angular/angular.min.js"></script>
 
+    <!-- Bootstrap-Select (Optional): The following lines are only required if you use the pfBootstrapSelect directive -->
+    <script src="node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
+    <script src="node_modules/bootstrap-select/js/bootstrap-select.js"></script>
+
     <!-- Angular-Bootstrap -->
     <script src="node_modules/angular-patternfly/node_modules/angular-ui-bootstrap/dist/ui-bootstrap.js"></script>
     <script src="node_modules/angular-patternfly/node_modules/angular-ui-bootstrap/dist/ui-bootstrap-tpls.js"></script>

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
   "optionalDependencies": {
     "angularjs-datatables": "^0.5.9",
     "angular-drag-and-drop-lists": "2.0.0",
-    "bootstrap-select": "~1.10.0",
+    "bootstrap": "~3.3.7",
+    "bootstrap-select": "~1.12.4",
     "c3": "~0.4.11",
     "components-jqueryui": "components/jqueryui#1.12.1",
     "d3": "~3.5.17",

--- a/src/select/bootstrap-select.directive.js
+++ b/src/select/bootstrap-select.directive.js
@@ -1,0 +1,47 @@
+angular.module('patternfly.select').directive('pfBootstrapSelect', function () {
+  'use strict';
+
+  return {
+    restrict: 'A',
+    require: '?ngModel',
+    scope: {
+      selectPickerOptions: '=pfBootstrapSelect'
+    },
+    link: function (scope, element, attrs, ngModel) {
+      var optionCollectionList, optionCollectionExpr, optionCollection, $render = ngModel.$render;
+
+      var selectpickerRefresh = function (argument) {
+        scope.$applyAsync(function () {
+          element.selectpicker('refresh');
+        });
+      };
+
+      var selectpickerDestroy = function () {
+        element.selectpicker('destroy');
+      };
+
+      element.selectpicker(scope.selectPickerOptions);
+
+      ngModel.$render = function () {
+        $render.apply(this, arguments);
+        selectpickerRefresh();
+      };
+
+      if (attrs.ngOptions) {
+        optionCollectionList = attrs.ngOptions.split('in ');
+        optionCollectionExpr = optionCollectionList[optionCollectionList.length - 1].split(/track by|\|/);
+        optionCollection = optionCollectionExpr[0];
+
+        scope.$parent.$watchCollection(optionCollection, selectpickerRefresh);
+      }
+
+      if (attrs.ngModel) {
+        scope.$parent.$watch(attrs.ngModel, selectpickerRefresh);
+      }
+
+      attrs.$observe('disabled', selectpickerRefresh);
+
+      scope.$on('$destroy', selectpickerDestroy);
+    }
+  };
+});

--- a/src/select/examples/bootstrap.select.js
+++ b/src/select/examples/bootstrap.select.js
@@ -1,0 +1,67 @@
+/**
+ * @ngdoc directive
+ * @name patternfly.select.directive:pfBootstrapSelect
+ * @element select
+ *
+ * @param {string} ngModel Model binding using the {@link https://docs.angularjs.org/api/ng/type/ngModel.NgModelController/ NgModelController} is mandatory.
+ * @param {string=} ngOptions The `{@link https://docs.angularjs.org/api/ng/directive/select/ ngOptions}` attribute can be used to dynamically generate a list of `<option>`
+ * elements for the `<select>` element.
+ *
+ * @description
+ * An AngularJS wrapper for the {@link http://silviomoreto.github.io/bootstrap-select/ Bootstrap-select} jQuery plugin which is used
+ * as a default select decorator in {@link https://www.patternfly.org/widgets/#bootstrap-select Patternfly}.
+ *
+ * @example
+ <example module="patternfly.select">
+
+   <file name="index.html">
+     <div ng-controller="SelectDemoCtrl">
+
+     <form class="form-horizontal">
+       <div class="form-group">
+         <label class="col-sm-2 control-label" for="pet">Preferred pet:</label>
+         <div class="col-sm-10">
+          <select pf-bootstrap-select ng-model="pet" id="pet" ng-options="o as o for o in pets"></select>
+         </div>
+       </div>
+
+       <div class="form-group">
+         <label class="col-sm-2 control-label" for="fruit">Preferred fruit:</label>
+         <div class="col-sm-10">
+           <select pf-bootstrap-select ng-model="fruit" id="fruit">
+             <option value="orange">Orange</option>
+             <option value="apple" ng-selected="true" selected>Apple</option>
+             <option value="banana">Banana</option>
+           </select>
+         </div>
+       </div>
+
+       <div class="form-group">
+         <label class="col-sm-2 control-label" for="drink">Preferred drink:</label>
+         <div class="col-sm-10">
+           <select pf-bootstrap-select="{ noneSelectedText: 'None' }" ng-model="drink" id="drink" ng-options="o as o for o in drinks">
+             <option value="">No drink selected</option>
+           </select>
+         </div>
+       </div>
+
+     </form>
+
+     <p>Your preferred pet is {{pet}}.</p>
+     <p>Your preferred fruit is {{fruit}}.</p>
+     <p>Your preferred drink is {{drink || 'No drink selected'}}.</p>
+
+     </div>
+   </file>
+
+   <file name="script.js">
+     angular.module( 'patternfly.select' ).controller( 'SelectDemoCtrl', function( $scope ) {
+       $scope.drinks = ['tea', 'coffee', 'water'];
+       $scope.pets = ['Dog', 'Cat', 'Chicken'];
+       $scope.pet = $scope.pets[0];
+       $scope.fruit = 'orange';
+     });
+   </file>
+
+ </example>
+ */

--- a/src/select/examples/select.js
+++ b/src/select/examples/select.js
@@ -10,7 +10,7 @@
  * @param {function(item)} onSelect Function to call upon user selection of an item.
  *
  * @description
- * The pfSelect component provides a wrapper for the angular ui bootstrap dropdown container allowing for use of ng-model and ng-options
+ * The pfSelect component provides a wrapper for the angular ui bootstrap dropdown.
  *
  * @example
  <example module="patternfly.select">
@@ -37,7 +37,7 @@
        </div>
      </form>
      <p>Your preferred pet is {{pet || noPet}}.</p>
-     <p>Your preferred drink is {{fruit.name}}.</p>
+     <p>Your preferred fruit is {{fruit.name}}.</p>
      <p>Your preferred drink is {{drink ? drink.name : noDrink}}.</p>
    </div>
    </file>

--- a/test/select/bootstrap-select.spec.js
+++ b/test/select/bootstrap-select.spec.js
@@ -1,0 +1,117 @@
+describe('pf-bootstrap-select', function () {
+
+  var $scope, $compile;
+
+  beforeEach(module('patternfly.select'));
+
+  beforeEach(inject(function (_$rootScope_, _$compile_) {
+    $scope = _$rootScope_;
+    $compile = _$compile_;
+  }));
+
+  describe('Page with pf-select directive', function () {
+
+    var compileSelect = function (markup, scope) {
+      var el = $compile(markup)(scope);
+      scope.$digest();
+      return el;
+    };
+
+    it('should generate correct options from ng-options', function () {
+
+      $scope.options = ['a','b','c'];
+      $scope.modelValue = $scope.options[1];
+
+      var select = compileSelect('<select pf-bootstrap-select ng-model="modelValue" ng-options="o as o for o in options"></select>', $scope);
+
+      $scope.$digest();
+
+      expect(select.text()).toBe('abc');
+      expect(select).toEqualSelect(['a', ['b'], 'c']);
+
+      var bsSelect = angular.element(select).siblings('.dropdown-menu');
+      var bsSelItems = bsSelect.find('li');
+      expect(bsSelItems.length).toBe($scope.options.length);
+      expect(bsSelItems.text()).toBe('abc');
+
+      var bsSelected = bsSelect.find('li.selected');
+      expect(bsSelected.length).toBe(1);
+      expect(bsSelected.text()).toBe('b');
+    });
+
+    it('should respond to changes in ng-options', function () {
+
+      $scope.options = ['a','b','c'];
+      $scope.modelValue = $scope.options[0];
+      var select = compileSelect('<select pf-bootstrap-select ng-model="modelValue" ng-options="o as o for o in options"></select>', $scope);
+
+      expect(select.text()).toBe('abc');
+      expect(select).toEqualSelect([['a'], 'b', 'c']);
+
+      var bsSelect = angular.element(select).siblings('.dropdown-menu');
+      var bsSelItems = bsSelect.find('li');
+      expect(bsSelItems.length).toBe($scope.options.length);
+      expect(bsSelItems.text()).toBe('abc');
+
+      $scope.$apply(function() {
+        $scope.options.push('d');
+      });
+
+      $scope.$digest();
+
+      expect(select.text()).toBe('abcd');
+      expect(select).toEqualSelect([['a'], 'b', 'c', 'd']);
+
+      bsSelect = angular.element(select).siblings('.dropdown-menu');
+      bsSelItems = bsSelect.find('li');
+      expect(bsSelItems.length).toBe($scope.options.length);
+      expect(bsSelItems.text()).toBe('abcd');
+    });
+
+    it('should respond to ng-model changes', function () {
+
+      $scope.options = ['a','b','c'];
+      $scope.modelValue = $scope.options[0];
+      var select = compileSelect('<select pf-bootstrap-select ng-model="modelValue" ng-options="o as o for o in options"></select>', $scope);
+
+      expect(select.text()).toBe('abc');
+      expect(select).toEqualSelect([['a'], 'b', 'c']);
+
+      var bsSelect = angular.element(select).siblings('.dropdown-menu');
+      var bsSelItems = bsSelect.find('li');
+      expect(bsSelItems.length).toBe($scope.options.length);
+      expect(bsSelItems.text()).toBe('abc');
+
+      var bsSelected = bsSelect.find('li.selected');
+      expect(bsSelected.length).toBe(1);
+      expect(bsSelected.text()).toBe('a');
+
+      $scope.$apply(function() {
+        $scope.modelValue = $scope.options[1];
+      });
+
+      $scope.$digest();
+
+      expect(select.text()).toBe('abc');
+      expect(select).toEqualSelect(['a', ['b'], 'c']);
+
+      bsSelected = bsSelect.find('li.selected');
+      expect(bsSelected.length).toBe(1);
+      expect(bsSelected.text()).toBe('b');
+
+      $scope.$apply(function() {
+        $scope.modelValue = $scope.options[2];
+      });
+
+      $scope.$digest();
+
+      expect(select.text()).toBe('abc');
+      expect(select).toEqualSelect(['a', 'b', ['c']]);
+
+      bsSelected = bsSelect.find('li.selected');
+      expect(bsSelected.length).toBe(1);
+      expect(bsSelected.text()).toBe('c');
+    });
+
+  });
+});


### PR DESCRIPTION
## Description
This restores the a-pf v3.x `pf-select` directive -now renamed to `pf-bootstrap-select`.   The current `pf-select` uses angular-ui-bootstrap's dropdown attributes which do not support ngModel or ngOptions; and is also a component, which doesn't support being used as an attribute in HTML.
The new (old) `pf-bootstrap-select` directive uses the `bootstrap-select` plug-in which does support ngModel and ngOptions; and can be used as an attribute in the `<select> `element.  

This was asked for by MiQ which requires the use of ngModel, ngOptions, and pf(Bootstrap)Select attributes for their `<select>` elements.

NgDoc is located [here](https://rawgit.com/dtaylor113/angular-patternfly/pf-bootstrap-select-docs/docs/index.html#/api/patternfly.select.directive:pfBootstrapSelect)

Fixes #408 

![image](https://user-images.githubusercontent.com/12733153/30555694-3fb081d8-9c76-11e7-961f-8ef6d8fa522c.png)

## PR Checklist

- [x] Unit tests are included
- [x] Screenshots are attached (if there are visual changes in the UI)
- [ ] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [ ] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
