### PR TITLE
feat(pfInfoStatusCard): Adds Info Status Card and tests

### DIFF
--- a/src/card/card.less
+++ b/src/card/card.less
@@ -28,10 +28,12 @@
     }
   }
 }
+
 .card-pf-heading-no-bottom {
   margin: 0 -20px 0px;
   padding: 0 20px 0;
 }
+
 .card-pf-icon-image {
   height: 18px;
   margin: 0 5px 5px;
@@ -54,6 +56,7 @@
     font-weight: 400;
   }
 }
+
 .trend-card-small-pf {
   .trend-header-pf {
     display: block;
@@ -69,5 +72,22 @@
   .trend-title-small-pf {
     font-size: 10px;
     font-weight: 400;
+  }
+}
+
+.card-pf-info-status {
+  display: flex;
+  .info-image-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction:column;
+    margin-right: 10px;
+    .info-icon {
+      font-size: 50px;
+    }
+    .info-img {
+      max-height: 50px;
+    }
   }
 }

--- a/src/card/info-status/info-status-card.component.js
+++ b/src/card/info-status/info-status-card.component.js
@@ -1,0 +1,95 @@
+/**
+ * @ngdoc directive
+ * @name patternfly.card.component:pfInfoStatusCard
+ * @restrict E
+ *
+ * @param {object} status Status configuration information<br/>
+ * <ul style='list-style-type: none'>
+ * <li>.title         - the main title of the info status card
+ * <li>.href          - the href to navigate to if one clicks on the title or count
+ * <li>.iconClass     - an icon to display to the left of the count
+ * <li>.iconImage     - an image to display to the left of Infrastructure
+ * <li>.info          - an array of strings to display, each element in the array is on a new line, accepts HTML content
+ * </ul>
+ * @param {boolean=} show-top-border Show/hide the top border, true shows top border, false (default) hides top border
+ * @param {boolean} htmlContent Flag to allow HTML content within the info options
+ *
+ * @description
+ * Component for easily displaying textual information
+ *
+ * @example
+ <example module="patternfly.card">
+
+ <file name="index.html">
+   <div ng-controller="CardDemoCtrl" style="display:inline-block;">
+     <div class="col-md-10">
+       <label>With Top Border, Icon Class, Href</label>
+       <pf-info-status-card status="infoStatus" show-top-border="true"></pf-info-status-card>
+       <br/>
+       <label>No Top Border, Icon Image, No Title</label>
+       <pf-info-status-card status="infoStatusTitless"></pf-info-status-card>
+       <br/>
+       <label>With HTML</label>
+       <pf-info-status-card status="infoStatusAlt" html-content="true"></pf-info-status-card>
+     </div>
+   </div>
+ </file>
+
+ <file name="script.js">
+   angular.module( 'patternfly.card' ).controller( 'CardDemoCtrl', function( $scope ) {
+    $scope.infoStatus = {
+      "title":"TinyCore-local",
+      "href":"#",
+      "iconClass": "fa fa-shield",
+      "info":[
+        "VM Name: aapdemo002",
+        "Host Name: localhost.localdomian",
+        "IP Address: 10.9.62.100",
+        "Power status: on"
+      ]
+    };
+
+    $scope.infoStatusTitless = {
+      "iconImage":"img/OpenShift-logo.svg",
+      "info":[
+        "Infastructure: VMware",
+        "Vmware: 1 CPU (1 socket x 1 core), 1024 MB",
+        "12 Snapshots",
+        "Drift History: 1"
+        ]
+    };
+
+    $scope.infoStatusAlt = {
+      "title":"Favorite Things",
+      "iconClass":"fa fa-heart",
+      "info":[
+        "<i class='fa fa-coffee'>",
+        "<i class='fa fa-motorcycle'>",
+        "<b>Tacos</b>"
+      ]
+    };
+   });
+ </file>
+
+ </example>
+ */
+
+angular.module( 'patternfly.card' ).component('pfInfoStatusCard', {
+  bindings: {
+    status: '=',
+    showTopBorder: '@?',
+    htmlContent: '@?'
+  },
+  templateUrl: 'card/info-status/info-status-card.html',
+  controller: function ($sce) {
+    'use strict';
+    var ctrl = this;
+    ctrl.$onInit = function () {
+      ctrl.shouldShowTopBorder = (ctrl.showTopBorder === 'true');
+      ctrl.shouldShowHtmlContent = (ctrl.htmlContent === 'true');
+      ctrl.trustAsHtml = function (html) {
+        return $sce.trustAsHtml(html);
+      };
+    };
+  }
+});

--- a/src/card/info-status/info-status-card.html
+++ b/src/card/info-status/info-status-card.html
@@ -1,0 +1,22 @@
+<div class="card-pf card-pf-info-status"
+     ng-class="{'card-pf-accented': $ctrl.shouldShowTopBorder}">
+  <div class="info-image-container">
+    <img ng-if="$ctrl.status.iconImage" ng-src="{{$ctrl.status.iconImage}}" alt=""
+         class="info-img"/>
+    <span class="info-icon {{$ctrl.status.iconClass}}"></span>
+  </div>
+  <div>
+    <h2 class="card-pf-title" ng-if="$ctrl.status.title">
+      <a href="{{$ctrl.status.href}}" ng-if="$ctrl.status.href">
+        <span class="">{{$ctrl.status.title}}</span>
+      </a>
+      <span ng-if="!$ctrl.status.href">
+            <span class="">{{$ctrl.status.title}}</span>
+          </span>
+    </h2>
+    <p ng-if="$ctrl.shouldShowHtmlContent" ng-bind-html="$ctrl.trustAsHtml(item)"
+       ng-repeat="item in $ctrl.status.info track by $index"></p>
+    <p ng-if="!$ctrl.shouldShowHtmlContent" ng-bind="item"
+       ng-repeat="item in $ctrl.status.info track by $index"></p>
+  </div>
+</div>

--- a/test/card/info-status/info-status-card.component.spec.js
+++ b/test/card/info-status/info-status-card.component.spec.js
@@ -1,0 +1,119 @@
+describe('Component: pfInfoStatusCard', function () {
+  var $scope, $compile, element, cardClass
+
+  beforeEach(module('patternfly.card', 'card/info-status/info-status-card.html'))
+
+  beforeEach(inject(function (_$compile_, _$rootScope_) {
+    $compile = _$compile_
+    $scope = _$rootScope_
+  }))
+
+  describe('Page with pf-info-status-card component', function () {
+
+    var compileCard = function (markup, scope) {
+      var el = $compile(markup)(scope)
+      scope.$digest()
+      return el
+    }
+
+    it('should set the title link, and icons class', function () {
+
+      $scope.status = {
+        'title': 'TinyCore-local',
+        'href': '#',
+        'iconClass': 'fa fa-shield',
+        'info': [
+          'VM Name: aapdemo002'
+        ]
+      }
+
+      element = compileCard('<pf-info-status-card status="status"></pf-info-status-card>', $scope)
+
+      //Make sure a link renders in the title
+      expect(angular.element(element).find('.card-pf-title').find('a').length).toBe(1)
+
+      //Make sure the class is getting set for the title icon
+      expect(angular.element(element).find('.fa').hasClass('fa-shield')).toBeTruthy()
+
+      // By default, showTopBorder if not defined, should be false, resulting in hiding the top
+      // border, ie. having a .card-pf class
+      cardClass = angular.element(element).find('.card-pf').hasClass('card-pf-accented')
+      expect(cardClass).toBeFalsy()
+    })
+
+    it('No link should be present in the title', function () {
+
+      $scope.status = {
+        'title': 'TinyCore-local',
+        'iconClass': 'fa fa-shield',
+        'info': [
+          'VM Name: aapdemo002'
+        ]
+      }
+
+      element = compileCard('<pf-info-status-card status="status"></pf-info-status-card>', $scope)
+
+      //Make sure a link renders in the title
+      expect(angular.element(element).find('.card-pf-title').find('a').length).toBe(0)
+    })
+
+    it('should set the info', function () {
+
+      $scope.status = {
+        'title': 'TinyCore-local',
+        'href': '#',
+        'iconClass': 'fa fa-shield',
+        'info': [
+          'VM Name: aapdemo002',
+          'Host Name: localhost.localdomian',
+          'IP Address: 10.9.62.100',
+          'Power status: on'
+        ]
+      }
+
+      element = compileCard('<pf-info-status-card status="status"></pf-info-status-card>', $scope)
+
+      info = angular.element(element).find('p')
+
+      //Make sure four info blocks render
+      expect(info.length).toBe(4)
+    })
+
+    it('should show the top border', function () {
+      element = compileCard('<pf-info-status-card show-top-border="true"></pf-info-status-card>', $scope)
+
+      // showTopBorder set to true, results in having the .card-pf-accented class
+      cardClass = angular.element(element).find('.card-pf').hasClass('card-pf-accented')
+      expect(cardClass).toBeTruthy()
+
+    })
+
+    it('should hide the top border', function () {
+      element = compileCard('<pf-info-status-card show-top-border="false"></pf-info-status-card>', $scope)
+
+      // showTopBorder set to false, results in not having the .card-pf-accented class
+      cardClass = angular.element(element).find('.card-pf').hasClass('card-pf-accented')
+      expect(cardClass).toBeFalsy()
+    })
+
+    it('should set of the iconImage value', function () {
+
+      $scope.status = {
+        'iconImage': 'img/OpenShift-logo.svg',
+        'info': [
+          'Infastructure: VMware',
+          'Vmware: 1 CPU (1 socket x 1 core), 1024 MB',
+          '12 Snapshots',
+          'Drift History: 1'
+        ]
+      }
+
+      element = compileCard('<pf-info-status-card status="status"></pf-info-status-card>', $scope)
+
+      // should have the images
+      imageElements = angular.element(element).find('.info-img')
+      expect(imageElements.length).toBe(1)
+      expect(angular.element(imageElements[0]).attr('src')).toBe('img/OpenShift-logo.svg')
+    })
+  })
+})


### PR DESCRIPTION
## Description
As per the issue, creates the requested component as to the spec.

### Whatz it look like? 
<img width="825" alt="screen shot 2017-09-20 at 4 02 40 pm" src="https://user-images.githubusercontent.com/6640236/30664886-337e9744-9e1d-11e7-9060-aabcb6a2984b.png">

## PR Checklist

- [x] Unit tests are included
- [x] Screenshots are attached (if there are visual changes in the UI)
- [x] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [x] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)

closes #629 

@cdcabrera @jeff-phillips-18 @dtaylor113  I can't add any labels to this, hoping ya can help out (enhancement, tagging those who need to review)

cc @serenamarie125 @chriskacerguis 