### PR TITLE
Use the window.imagePath global for the base image path in examples if present.

### DIFF
--- a/src/canvas-view/examples/canvas.js
+++ b/src/canvas-view/examples/canvas.js
@@ -106,7 +106,8 @@
  </file>
 
  <file name="script.js">
- angular.module( 'patternfly.canvas.demo' ).controller( 'CanvasDemoCtrl', function( $scope ) {
+ angular.module( 'patternfly.canvas.demo' ).controller( 'CanvasDemoCtrl', function( $scope, $window ) {
+     var imagePath = $window.IMAGE_PATH || "img";
      $scope.chartDataModel = {
           "nodes": [
             {
@@ -114,7 +115,7 @@
               "x": 345,
               "y": 67,
               "id": 1,
-              "image": "/img/OpenShift-logo.svg",
+              "image": imagePath + "/OpenShift-logo.svg",
               "width": 150,
               "bundle": true,
               "backgroundColor": "#fff",
@@ -139,7 +140,7 @@
               "x": 100,
               "y": 290,
               "id": 2,
-              "image": "/img/kubernetes.svg",
+              "image": imagePath + "/kubernetes.svg",
               "width": 150,
               "backgroundColor": "#fff",
               "validConnectionTypes": ["storage"],

--- a/src/canvas-view/examples/canvasEditor.js
+++ b/src/canvas-view/examples/canvasEditor.js
@@ -74,7 +74,8 @@
  </file>
 
  <file name="script.js">
- angular.module( 'patternfly.canvaseditor.demo' ).controller( 'CanvasEditorDemoCtrl', function( $scope, $filter ) {
+ angular.module( 'patternfly.canvaseditor.demo' ).controller( 'CanvasEditorDemoCtrl', function( $scope, $filter, $window ) {
+     var imagePath = $window.IMAGE_PATH || "img";
      $scope.chartDataModel = {
           "nodes": [
             {
@@ -82,7 +83,7 @@
               "x": 345,
               "y": 67,
               "id": 1,
-              "image": "/img/OpenShift-logo.svg",
+              "image": imagePath + "/OpenShift-logo.svg",
               "width": 150,
               "bundle": true,
               "backgroundColor": "#fff",
@@ -107,7 +108,7 @@
               "x": 100,
               "y": 290,
               "id": 2,
-              "image": "/img/kubernetes.svg",
+              "image": imagePath + "/kubernetes.svg",
               "width": 150,
               "backgroundColor": "#fff",
               "validConnectionTypes": ["storage"],
@@ -236,12 +237,12 @@
            {
              "name": "Nuage",
              "id": 10000000000004,
-             "image": "/img/OpenShift-logo.svg"
+             "image": imagePath + "/OpenShift-logo.svg"
            },
            {
              "name": "Vmware",
              "id": 10000000000010,
-             "image": "/img/kubernetes.svg"
+             "image": imagePath + "/kubernetes.svg"
            }
          ]
        },

--- a/src/card/aggregate-status/aggregate-status-card.component.js
+++ b/src/card/aggregate-status/aggregate-status-card.component.js
@@ -68,7 +68,8 @@
  </file>
 
  <file name="script.js">
-   angular.module( 'patternfly.card' ).controller( 'CardDemoCtrl', function( $scope ) {
+   angular.module( 'patternfly.card' ).controller( 'CardDemoCtrl', function( $scope, $window ) {
+    var imagePath = $window.IMAGE_PATH || "img";
     $scope.status = {
       "title":"Nodes",
       "count":793,
@@ -92,12 +93,12 @@
       "count":3,
       "notifications":[
         {
-          "iconImage":"img/kubernetes.svg",
+          "iconImage": imagePath + "/kubernetes.svg",
           "count":1,
           "href":"#"
         },
         {
-          "iconImage":"img/OpenShift-logo.svg",
+          "iconImage": imagePath + "/OpenShift-logo.svg",
           "count":2,
           "href":"#"
         }

--- a/src/card/info-status/info-status-card.component.js
+++ b/src/card/info-status/info-status-card.component.js
@@ -36,7 +36,8 @@
  </file>
 
  <file name="script.js">
-   angular.module( 'patternfly.card' ).controller( 'CardDemoCtrl', function( $scope ) {
+   angular.module( 'patternfly.card' ).controller( 'CardDemoCtrl', function( $scope, $window ) {
+    var imagePath = $window.IMAGE_PATH || "img";
     $scope.infoStatus = {
       "title":"TinyCore-local",
       "href":"#",
@@ -50,7 +51,7 @@
     };
 
     $scope.infoStatusTitless = {
-      "iconImage":"img/OpenShift-logo.svg",
+      "iconImage": imagePath + "/OpenShift-logo.svg",
       "info":[
         "Infastructure: VMware",
         "Vmware: 1 CPU (1 socket x 1 core), 1024 MB",

--- a/src/navigation/application-launcher.component.js
+++ b/src/navigation/application-launcher.component.js
@@ -27,7 +27,7 @@
      <nav class="navbar navbar-default navbar-pf" role="navigation">
        <div class="navbar-header">
          <a class="navbar-brand" href="/">
-         <img src="img/brand.svg" alt="PatternFly Enterprise Application">
+         <img src="{{imagePath}}/brand.svg" alt="PatternFly Enterprise Application">
          </a>
        </div>
        <div class="collapse navbar-collapse navbar-collapse-1">
@@ -77,8 +77,9 @@
    </div>
  </file>
  <file name="script.js">
-   angular.module('patternfly.navigation').controller('applicationLauncherController', ['$scope',
-     function ($scope) {
+   angular.module('patternfly.navigation').controller('applicationLauncherController', ['$scope', '$window',
+     function ($scope, $window) {
+       $scope.imagePath = $window.IMAGE_PATH || "img";
        $scope.navigationItems = [
          {
            title: "Recteque",
@@ -130,4 +131,3 @@ angular.module('patternfly.navigation').component('pfApplicationLauncher', {
     ctrl.$id = $scope.$id;
   }
 });
-


### PR DESCRIPTION
This PR allows that patternfly.org site to override the image path used in some examples by specifying the IMAGE_PATH global variable.