### PR TITLE
fix(pfCanvasEditor): Fix for drag-n-drop items from toolbar

### DIFF
--- a/src/canvas-view/canvas-editor/toolbox-items.html
+++ b/src/canvas-view/canvas-editor/toolbox-items.html
@@ -1,9 +1,9 @@
 <ul class="toolbox-items-list">
   <li class="toolbox-item" ng-repeat="item in $ctrl.items | filter:$ctrl.searchText"
-      data-drag="{{!item.disableInToolbox}}" jqyoui-draggable="{onStart:'$ctrl.startDragCallbackfmDir(item)'}"
+      data-drag="{{!item.disableInToolbox}}" jqyoui-draggable="{onStart:'$ctrl.startItemDrag(item)'}"
       ng-class="{'not-draggable': item.disableInToolbox}"
       data-jqyoui-options="{revert: 'invalid', helper: 'clone'}"
-      ng-click="$ctrl.clickCallbackfmDir(item)"
+      ng-click="$ctrl.itemClicked(item)"
       uib-tooltip="{{(item.disableInToolbox ? 'Items cannot be added to the canvas more than once.' : '')}}">
     <img ng-if="item.image" src="{{item.image}}" alt="{{item.name}}"/>
     <i ng-if="item.icon && !item.image" class="draggable-item-icon {{item.icon}}"></i>


### PR DESCRIPTION
## Description
Fixes #651
Restored the drag-n-drop capabilities when dragging or clicking on an item in the items toolbox.