### PR TITLE
fix(pfNotificationDrawer): Do not add #0 to URL on close or expand

### DIFF
--- a/src/notification/examples/notification-drawer.js
+++ b/src/notification/examples/notification-drawer.js
@@ -64,7 +64,7 @@
            <li class="drawer-pf-trigger dropdown" ng-class="{'open': !hideDrawer}">
              <a class="nav-item-iconic drawer-pf-trigger-icon" ng-click="toggleShowDrawer()">
                <span class="fa fa-bell" title="Notifications"></span>
-               <span ng-if="unreadNotifications" class="badge"> </span>
+               <span ng-if="unreadNotifications" class="badge badge-pf-bordered"> </span>
              </a>
            </li>
          </ul>

--- a/src/notification/notification-drawer.html
+++ b/src/notification/notification-drawer.html
@@ -1,7 +1,7 @@
 <div class="drawer-pf" ng-class="{'hide': $ctrl.drawerHidden, 'drawer-pf-expanded': $ctrl.drawerExpanded}">
   <div ng-if="$ctrl.drawerTitle" class="drawer-pf-title">
-    <a href="#0" ng-if="$ctrl.allowExpand" class="drawer-pf-toggle-expand fa fa-angle-double-left hidden-xs" ng-click="$ctrl.toggleExpandDrawer()"></a>
-    <a href="#0" ng-if="$ctrl.onClose" class="drawer-pf-close pficon pficon-close" ng-click="$ctrl.onClose()"></a>
+    <a href="" ng-if="$ctrl.allowExpand" class="drawer-pf-toggle-expand fa fa-angle-double-left hidden-xs" ng-click="$ctrl.toggleExpandDrawer()"></a>
+    <a href="" ng-if="$ctrl.onClose" class="drawer-pf-close pficon pficon-close" ng-click="$ctrl.onClose()"></a>
     <h3 class="text-center">{{$ctrl.drawerTitle}}</h3>
   </div>
   <div ng-if="$ctrl.titleInclude" class="drawer-pf-title" ng-include src="$ctrl.titleInclude"></div>

--- a/test/notification/notification-drawer.spec.js
+++ b/test/notification/notification-drawer.spec.js
@@ -499,7 +499,7 @@ describe('Component:  pfNotificationDrawer', function () {
     var expandToggle = element.find('.drawer-pf-toggle-expand');
     expect(expandToggle.length).toBe(1);
 
-    eventFire(expandToggle[0], 'click');
+    expandToggle[0].click();
     $scope.$digest();
 
     expandedDrawer = element.find('.drawer-pf.drawer-pf-expanded');
@@ -529,7 +529,7 @@ describe('Component:  pfNotificationDrawer', function () {
 
     expect($scope.closed).toBe(false);
 
-    eventFire(closeButton[0], 'click');
+    closeButton[0].click();
     $scope.$digest();
 
     expect($scope.closed).toBe(true);


### PR DESCRIPTION
## Description
Remove the #0 from the href for the close and expand links in the drawer header. This required commenting out some tests but those are pretty simple and unlikely to break.

Fixes #641 
