### PR TITLE
fix pfTableView: border style not in line with PatternFly

### DIFF
--- a/src/pagination/pagination.html
+++ b/src/pagination/pagination.html
@@ -1,4 +1,4 @@
-<form class="content-view-pf-pagination list-view-pf-pagination clearfix" id="form1">
+<form class="content-view-pf-pagination table-view-pf-pagination list-view-pf-pagination clearfix" id="form1">
   <div class="form-group">
     <div uib-dropdown class="btn-group">
       <button uib-dropdown-toggle type="button" class="btn btn-default">

--- a/src/table/table.less
+++ b/src/table/table.less
@@ -15,6 +15,7 @@ table.dataTable.no-footer {
 }
 table.dataTable {
   margin: 0;
+  border-collapse: collapse;
   thead {
     .sorting_asc {
       background-image: none !important;


### PR DESCRIPTION
fix #663 

Make the pfTableView borders thinner according to PatternFly's [Table View](http://www.patternfly.org/pattern-library/content-views/table-view/).

![image](https://user-images.githubusercontent.com/1910095/32122081-e49ecdf4-bb3d-11e7-9524-c98e8881582c.png)

@cshinn 
