### PR TITLE
Info card styling alignment

### DIFF
--- a/src/card/card.less
+++ b/src/card/card.less
@@ -112,7 +112,7 @@
 
 .card-pf-info-status {
   display: flex;
-  margin: 0 10px;
+  margin: 0 10px 15px;
   .card-pf-info-image {
     display: flex;
     align-items: center;
@@ -124,11 +124,15 @@
     }
     .info-img {
       max-height: 50px;
+      &[src*='.svg'] {
+        width: 50px;
+        height: 50px;
+      }
     }
   }
   .card-pf-info-content {
     margin: 10px 0;
-    .card-pf-title{
+    .card-pf-title {
       margin-top: 10px;
       margin-bottom: 15px;
     }

--- a/src/table/tableview/examples/table-view-basic.js
+++ b/src/table/tableview/examples/table-view-basic.js
@@ -20,7 +20,7 @@
   * <ul style='list-style-type: none'>
   *   <li>.header     - (string) Text label for a column header
   *   <li>.itemField    - (string) Item field to associate with a particular column.
-  *   <li>.templateFn - (function) (optional) Template function used to render each cell of the column. Pro: more performant than `htmlTemplate`. Con: doesn't support AngularJS directives in the template, therefore it doesn't support things like ng-click. Example: <pre>templateFn: value => `<span class="text-danger">${value}</span>`</pre>
+  *   <li>.templateFn - (function(value, item)) (optional) Template function used to render each cell of the column. Pro: more performant than `htmlTemplate`. Con: doesn't support AngularJS directives in the template, therefore it doesn't support things like ng-click. Example: <pre>templateFn: (value, item) => `<a href="${item.id}">${value}</a>`</pre>
   *   <li>.htmlTemplate - (string) (optional) id/name of an embedded ng/html template. Pro: supports AngularJS directives in the template. Con: poor performance on large tables. Ex: htmlTemplate="name_template.html".  The template will be used to render each cell of the column.
   *        Use <code>handleColAction(key, value)</code> in the template to call the <code>colActionFn</code> callback function you specify. 'key' is the item attribute name; which should equal the itemFld of a column.
   *       'value' is the item[key] value.
@@ -110,7 +110,7 @@
             { header: "Status", itemField: "status", htmlTemplate: "status_template.html" },
             { header: "Name", itemField: "name", htmlTemplate: "name_template.html", colActionFn: onNameClick },
             { header: "Address", itemField: "address"},
-            { header: "City", itemField: "city", templateFn: function(value) { return '<span class="text-success">' + value + '</span>' } },
+            { header: "City", itemField: "city", templateFn: function(value, item) { return '<a href="#' + item.name + '" title="' + item.address + '">' + value + '</span>' } },
             { header: "State", itemField: "state"}
           ];
 

--- a/src/table/tableview/examples/table-view-with-toolbar.js
+++ b/src/table/tableview/examples/table-view-with-toolbar.js
@@ -28,7 +28,7 @@
  * <ul style='list-style-type: none'>
  *   <li>.header     - (string) Text label for a column header
  *   <li>.itemField    - (string) Item field to associate with a particular column.
- *   <li>.templateFn - (function) (optional) Template function used to render each cell of the column. Pro: more performant than `htmlTemplate`. Con: doesn't support AngularJS directives in the template, therefore it doesn't support things like ng-click. Example: <pre>templateFn: value => `<span class="text-danger">${value}</span>`</pre>
+ *   <li>.templateFn - (function(value, item)) (optional) Template function used to render each cell of the column. Pro: more performant than `htmlTemplate`. Con: doesn't support AngularJS directives in the template, therefore it doesn't support things like ng-click. Example: <pre>templateFn: (value, item) => `<a href="${item.id}">${value}</a>`</pre>
  *   <li>.htmlTemplate - (string) (optional) id/name of an embedded ng/html template. Pro: supports AngularJS directives in the template. Con: poor performance on large tables. Ex: htmlTemplate="name_template.html".  The template will be used to render each cell of the column.
  *        Use <code>handleColAction(key, value)</code> in the template to call the <code>colActionFn</code> callback function you specify. 'key' is the item attribute name; which should equal the itemFld of a column.
  *       'value' is the item[key] value.

--- a/src/table/tableview/table-view.html
+++ b/src/table/tableview/table-view.html
@@ -20,7 +20,7 @@
       <td ng-repeat="col in $ctrl.columns" ng-init="key = col.itemField; value = item[key]">
         <span ng-if="!col.htmlTemplate && !col.templateFn">{{value}}</span>
         <span ng-if="col.htmlTemplate" ng-include="col.htmlTemplate"></span>
-        <span ng-if="col.templateFn" ng-bind-html="$ctrl.trustAsHtml(col.templateFn(value))"></span>
+        <span ng-if="col.templateFn" ng-bind-html="$ctrl.trustAsHtml(col.templateFn(value, item))"></span>
       </td>
 
       <td ng-if="$ctrl.actionButtons && $ctrl.actionButtons.length > 0" class="table-view-pf-actions" ng-repeat="actionButton in $ctrl.actionButtons">

--- a/test/table/tableview/table-view.spec.js
+++ b/test/table/tableview/table-view.spec.js
@@ -33,7 +33,7 @@ describe('Component: pfTableView', function () {
       {itemField: 'uuid', header: 'ID'},
       {itemField: 'name', header: 'Name', htmlTemplate: "name_template.html", colActionFn: onNameClick},
       {itemField: 'size', header: 'Size'},
-      {itemField: 'capacity', header: 'Capacity', templateFn: function(value) { return '<span class="custom-template2">' + value + '</span>' }}
+      {itemField: 'capacity', header: 'Capacity', templateFn: function(value, item) { return '<span id="' + item.uuid + '" class="custom-template2">' + value + '</span>' }}
     ];
 
     $scope.items = [
@@ -154,7 +154,8 @@ describe('Component: pfTableView', function () {
     expect(customSpans.length).toBe(5);
     customSpans.each(function(i) {
       var result = $(this).parent().html();
-      var expected = '<span class="custom-template2">' + $scope.items[i].capacity + '</span>';
+      var item = $scope.items[i];
+      var expected = '<span id="' + item.uuid + '" class="custom-template2">' + item.capacity + '</span>';
       expect(result).toBe(expected);
     });
   });


### PR DESCRIPTION
## Description
During work on [issue-111](https://github.com/patternfly/patternfly-ng/issues/111) in the patternfly-ng repo we noticed there was a styling discrepancy between the info status card examples. After speaking with a member of the design team it was decided to add an additional 15px of bottom margin to this component.

The SVG width/height was added because there was a bug where SVG's with no width/height defined within the xml didn't display at all. This gives them bounds of their own even when not specified.
<img width="407" alt="screen shot 2017-10-31 at 10 40 33 am" src="https://user-images.githubusercontent.com/5942899/32230841-6a55d8f4-be2a-11e7-8a82-fe6626ee0ed1.png">
![screen shot 2017-10-31 at 10 40 43 am](https://user-images.githubusercontent.com/5942899/32230842-6a5e8210-be2a-11e7-97de-902e24b9ab81.png)



## PR Checklist

- [ ] Unit tests are included
- [x] Screenshots are attached (if there are visual changes in the UI)
- [x] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [x] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
