### PR TITLE
feat(pfCard): Add a loading state to the pfCards

### DIFF
--- a/src/card/aggregate-status/aggregate-status-card.component.js
+++ b/src/card/aggregate-status/aggregate-status-card.component.js
@@ -30,6 +30,9 @@
  *   </ul>
  * </ul>
  * @param {boolean=} show-top-border Show/hide the top border, true shows top border, false (default) hides top border
+ * @param {boolean=} showSpinner Show/Hide the spinner for loading state. True shows the spinner, false (default) hides the spinner
+ * @param {string=} spinnerText Text for the card spinner
+ * @param {string=} spinnerCardHeight Height to set for the card when data is loading and spinner is shown
  * @param {string=} layout Various alternative layouts the aggregate status card may have:<br/>
  * <ul style='list-style-type: none'>
  * <li>'mini' displays a mini aggregate status card.  Note: when using 'mini' layout, only one notification can be specified in the status object
@@ -63,13 +66,19 @@
        <i>(depreciated, use layout = 'tall' instead)</i>
        </br></br>
        <pf-aggregate-status-card status="aggStatusAlt" show-top-border="true" alt-layout="true"></pf-aggregate-status-card>
+       <br/>
+       <label>Loading State</label>
+       <pf-aggregate-status-card status="aggStatusAlt2" spinner-card-height="150" show-top-border="true" show-spinner="dataLoading" spinner-text="Loading" layout="tall"></pf-aggregate-status-card>
      </div>
    </div>
  </file>
 
  <file name="script.js">
-   angular.module( 'patternfly.card' ).controller( 'CardDemoCtrl', function( $scope, $window ) {
+   angular.module( 'patternfly.card' ).controller( 'CardDemoCtrl', function( $scope, $window, $timeout ) {
     var imagePath = $window.IMAGE_PATH || "img";
+
+    $scope.dataLoading = true;
+
     $scope.status = {
       "title":"Nodes",
       "count":793,
@@ -103,28 +112,49 @@
           "href":"#"
         }
       ]
-     };
+    };
 
-     $scope.miniAggStatus = {
+    $timeout(function () {
+      $scope.dataLoading = false;
+
+      $scope.aggStatusAlt2 = {
+        "title":"Providers",
+        "count":3,
+        "notifications":[
+          {
+            "iconImage": imagePath + "/kubernetes.svg",
+            "count":1,
+            "href":"#"
+          },
+          {
+            "iconImage": imagePath + "/OpenShift-logo.svg",
+            "count":2,
+            "href":"#"
+          }
+        ]
+      };
+    }, 6000 );
+
+    $scope.miniAggStatus = {
       "iconClass":"pficon pficon-container-node",
       "title":"Nodes",
       "count":52,
       "href":"#",
       "notification": {
-          "iconClass":"pficon pficon-error-circle-o",
-          "count":3
-        }
-     };
+        "iconClass":"pficon pficon-error-circle-o",
+        "count":3
+      }
+    };
 
-     $scope.miniAggStatus2 = {
+    $scope.miniAggStatus2 = {
       "iconClass":"pficon pficon-cluster",
       "title":"Adipiscing",
       "count":9,
       "href":"#",
       "notification":{
-          "iconClass":"pficon pficon-ok"
-        }
-     };
+        "iconClass":"pficon pficon-ok"
+      }
+    };
    });
  </file>
 
@@ -135,6 +165,9 @@ angular.module( 'patternfly.card' ).component('pfAggregateStatusCard', {
   bindings: {
     status: '=',
     showTopBorder: '@?',
+    showSpinner: '<?',
+    spinnerText: '@?',
+    spinnerCardHeight: '@?',
     altLayout: '@?',
     layout: '@?'
   },
@@ -146,6 +179,11 @@ angular.module( 'patternfly.card' ).component('pfAggregateStatusCard', {
       ctrl.shouldShowTopBorder = (ctrl.showTopBorder === 'true');
       ctrl.isAltLayout = (ctrl.altLayout === 'true' || ctrl.layout === 'tall');
       ctrl.isMiniLayout = (ctrl.layout === 'mini');
+      ctrl.showSpinner = ctrl.showSpinner === true;
+
+      if (ctrl.spinnerCardHeight) {
+        ctrl.spinnerHeight = {'height': ctrl.spinnerCardHeight};
+      }
     };
   }
 });

--- a/src/card/aggregate-status/aggregate-status-card.html
+++ b/src/card/aggregate-status/aggregate-status-card.html
@@ -13,8 +13,15 @@
       <span class="card-pf-aggregate-status-title">{{$ctrl.status.title}}</span>
     </span>
   </h2>
-  <div class="card-pf-body">
-    <p class="card-pf-aggregate-status-notifications">
+  <div class="card-pf-body" ng-class="{'show-spinner': $ctrl.showSpinner}" ng-style="$ctrl.showSpinner ? $ctrl.spinnerHeight : {}">
+    <div ng-if="$ctrl.showSpinner" class="spinner-container">
+      <div class="loading-indicator">
+        <span class="spinner spinner-lg" aria-hidden="true"></span>
+        <span ng-if="$ctrl.spinnerText" class="loading-text">{{$ctrl.spinnerText}}</span>
+        <label ng-if="!$ctrl.spinnerText" class="sr-only">Loading</label>
+      </div>
+    </div>
+    <p class="card-pf-aggregate-status-notifications" ng-class="{'hide-for-spinner': $ctrl.showSpinner}">
       <span class="card-pf-aggregate-status-notification" ng-repeat="notification in $ctrl.status.notifications">
         <a href="{{notification.href}}" ng-if="notification.href">
           <image ng-if="notification.iconImage" ng-src="{{notification.iconImage}}" alt="" class="card-pf-icon-image"></image>
@@ -41,7 +48,14 @@
       {{$ctrl.status.title}}
     </span>
   </h2>
-  <div class="card-pf-body">
+  <div class="card-pf-body" ng-class="{'show-spinner': $ctrl.showSpinner}" ng-style="$ctrl.showSpinner ? $ctrl.spinnerHeight : {}">
+    <div ng-if="$ctrl.showSpinner" class="spinner-container">
+      <div class="loading-indicator">
+        <span class="spinner spinner-lg" aria-hidden="true"></span>
+        <span ng-if="$ctrl.spinnerText" class="loading-text">{{$ctrl.spinnerText}}</span>
+        <label ng-if="!$ctrl.spinnerText" class="sr-only">Loading</label>
+      </div>
+    </div>
     <p ng-if="$ctrl.status.notification.iconImage || $ctrl.status.notification.iconClass || $ctrl.status.notification.count" class="card-pf-aggregate-status-notifications">
       <span class="card-pf-aggregate-status-notification">
         <a ng-if="$ctrl.status.notification.href" href="{{$ctrl.status.notification.href}}">

--- a/src/card/card.less
+++ b/src/card/card.less
@@ -64,6 +64,17 @@
   }
 }
 
+.card-pf-aggregate-status-mini {
+  .card-pf-body {
+    &.show-spinner {
+      height: 40px;
+    }
+    .spinner-container {
+      top: -22px;
+    }
+  }
+}
+
 .card-pf-heading-no-bottom {
   margin: 0 -20px 0px;
   padding: 0 20px 0;
@@ -132,5 +143,8 @@
       margin-top: 10px;
       margin-bottom: 15px;
     }
+  }
+  .show-spinner {
+    width: 100%;
   }
 }

--- a/src/card/examples/card-trend.js
+++ b/src/card/examples/card-trend.js
@@ -5,7 +5,9 @@
  *
  * @param {string} headTitle Title for the card
  * @param {string=} subTitle Sub-Title for the card
+ * @param {string=} spinnerText Text for the card spinner
  * @param {boolean=} showTopBorder Show/Hide the blue top border. True shows top border, false (default) hides top border
+ * @param {boolean=} showSpinner Show/Hide the spinner for loading state. True shows the spinner, false (default) hides the spinner
  * @param {boolean=} showTitlesSeparator Show/Hide the grey line between the title and sub-title.
  * True (default) shows the line, false hides the line
  * @param {object=} footer footer configuration properties:<br/>
@@ -38,7 +40,7 @@
      <pf-card head-title="Cluster Utilization" show-top-border="true" footer="footerConfig" filter="filterConfig" style="width: 50%">
        <pf-trends-chart config="configSingle" chart-data="dataSingle"></pf-trends-chart>
      </pf-card>
-      <pf-card head-title="Cluster Utilization" show-top-border="true" footer="footerConfig" filter="filterConfig" style="width: 50%">
+      <pf-card head-title="Cluster Utilization" show-top-border="true" show-spinner="dataLoading" spinner-text="Loading" footer="footerConfig" filter="filterConfig" style="width: 50%">
         <pf-trends-chart config="configRightLabel" chart-data="dataSingle"></pf-trends-chart>
       </pf-card>
      <label class="label-title">Card with Multiple Trends</label>
@@ -52,7 +54,13 @@
    </div>
  </file>
  <file name="script.js">
- angular.module( 'demo', ['patternfly.charts', 'patternfly.card'] ).controller( 'ChartCtrl', function( $scope ) {
+ angular.module( 'demo', ['patternfly.charts', 'patternfly.card'] ).controller( 'ChartCtrl', function( $scope, $timeout ) {
+
+       $scope.dataLoading = true;
+
+       $timeout(function () {
+         $scope.dataLoading = false;
+       }, 3000 );
 
        $scope.footerConfig = {
          'iconClass' : 'fa fa-flag',

--- a/src/card/info-status/info-status-card.component.js
+++ b/src/card/info-status/info-status-card.component.js
@@ -13,6 +13,9 @@
  * </ul>
  * @param {boolean=} show-top-border Show/hide the top border, true shows top border, false (default) hides top border
  * @param {boolean} htmlContent Flag to allow HTML content within the info options
+ * @param {boolean=} showSpinner Show/Hide the spinner for loading state. True shows the spinner, false (default) hides the spinner
+ * @param {string=} spinnerText Text for the card spinner
+ * @param {string=} spinnerCardHeight Height to set for the card when data is loading and spinner is shown
  *
  * @description
  * Component for easily displaying textual information
@@ -31,13 +34,19 @@
        <br/>
        <label>With HTML</label>
        <pf-info-status-card status="infoStatusAlt" html-content="true"></pf-info-status-card>
+       <br/>
+       <label>Loading State</label>
+       <pf-info-status-card status="infoStatus2" spinner-card-height="200" show-top-border="true" show-spinner="dataLoading" spinner-text="Loading"></pf-info-status-card>
      </div>
    </div>
  </file>
 
  <file name="script.js">
-   angular.module( 'patternfly.card' ).controller( 'CardDemoCtrl', function( $scope, $window ) {
+   angular.module( 'patternfly.card' ).controller( 'CardDemoCtrl', function( $scope, $window, $timeout ) {
     var imagePath = $window.IMAGE_PATH || "img";
+
+    $scope.dataLoading = true;
+
     $scope.infoStatus = {
       "title":"TinyCore-local",
       "href":"#",
@@ -49,6 +58,22 @@
         "Power status: on"
       ]
     };
+
+    $timeout(function () {
+      $scope.dataLoading = false;
+
+      $scope.infoStatus2 = {
+        "title":"TinyCore-local",
+        "href":"#",
+        "iconClass": "fa fa-shield",
+        "info":[
+          "VM Name: aapdemo002",
+          "Host Name: localhost.localdomian",
+          "IP Address: 10.9.62.100",
+          "Power status: on"
+        ]
+      };
+    }, 6000 );
 
     $scope.infoStatusTitless = {
       "iconImage": imagePath + "/OpenShift-logo.svg",
@@ -79,6 +104,9 @@ angular.module( 'patternfly.card' ).component('pfInfoStatusCard', {
   bindings: {
     status: '=',
     showTopBorder: '@?',
+    showSpinner: '<?',
+    spinnerText: '@?',
+    spinnerCardHeight: '@?',
     htmlContent: '@?'
   },
   templateUrl: 'card/info-status/info-status-card.html',
@@ -88,9 +116,14 @@ angular.module( 'patternfly.card' ).component('pfInfoStatusCard', {
     ctrl.$onInit = function () {
       ctrl.shouldShowTopBorder = (ctrl.showTopBorder === 'true');
       ctrl.shouldShowHtmlContent = (ctrl.htmlContent === 'true');
+      ctrl.showSpinner = ctrl.showSpinner === true;
       ctrl.trustAsHtml = function (html) {
         return $sce.trustAsHtml(html);
       };
+
+      if (ctrl.spinnerCardHeight) {
+        ctrl.spinnerHeight = {'height': ctrl.spinnerCardHeight};
+      }
     };
   }
 });

--- a/src/card/info-status/info-status-card.html
+++ b/src/card/info-status/info-status-card.html
@@ -1,11 +1,19 @@
-<div class="card-pf card-pf-info-status"
-     ng-class="{'card-pf-accented': $ctrl.shouldShowTopBorder}">
-  <div class="card-pf-info-image">
+<div class="card-pf card-pf-info-status" ng-class="{'card-pf-accented': $ctrl.shouldShowTopBorder}">
+  <div ng-if="$ctrl.showSpinner" class="card-pf-body show-spinner" ng-style="$ctrl.showSpinner ? $ctrl.spinnerHeight : {}">
+    <div class="spinner-container">
+      <div class="loading-indicator">
+        <span class="spinner spinner-lg" aria-hidden="true"></span>
+        <span ng-if="$ctrl.spinnerText" class="loading-text">{{$ctrl.spinnerText}}</span>
+        <label ng-if="!$ctrl.spinnerText" class="sr-only">Loading</label>
+      </div>
+    </div>
+  </div>
+  <div ng-if="!$ctrl.showSpinner" class="card-pf-info-image">
     <img ng-if="$ctrl.status.iconImage" ng-src="{{$ctrl.status.iconImage}}" alt=""
          class="info-img"/>
     <span class="info-icon {{$ctrl.status.iconClass}}"></span>
   </div>
-  <div class="card-pf-info-content">
+  <div ng-if="!$ctrl.showSpinner" class="card-pf-info-content card-pf-body" ng-class="{'show-spinner': $ctrl.showSpinner}">
     <h2 class="card-pf-title" ng-if="$ctrl.status.title">
       <a href="{{$ctrl.status.href}}" ng-if="$ctrl.status.href">
         <span class="">{{$ctrl.status.title}}</span>

--- a/test/card/aggregate-status/aggregate-status-card.component.spec.js
+++ b/test/card/aggregate-status/aggregate-status-card.component.spec.js
@@ -26,7 +26,7 @@ describe('Component: pfAggregateStatusCard', function () {
         "title":"Nodes",
         "count":793,
         "href":"#",
-        "iconClass": "fa fa-shield",
+        "iconClass": "fa fa-shield"
       };
 
       element = compileCard('<pf-aggregate-status-card status="status"></pf-aggregate-status-card>', $scope);
@@ -115,6 +115,49 @@ describe('Component: pfAggregateStatusCard', function () {
       // showTopBorder set to false, results in not having the .card-pf-accented class
       cardClass = angular.element(element).find('.card-pf').hasClass('card-pf-accented');
       expect(cardClass).toBeFalsy();
+    });
+
+    it("should show and hide the spinner", function() {
+
+      // When data is loaded, spinner should be hidden
+      $scope.dataLoading = false;
+      element = compileCard('<pf-aggregate-status-card status="aggStatusAlt2" show-spinner="dataLoading"></pf-aggregate-status-card>', $scope);
+      cardClass = angular.element(element).find('.spinner-lg');
+      expect(cardClass.length).toBe(0);
+
+      // When data is loading, spinner should be present
+      $scope.dataLoading = true;
+      $scope.$digest();
+      cardClass = angular.element(element).find('.spinner-lg');
+      expect(cardClass.length).toBe(1);
+    });
+
+    it("should show and hide the spinner text", function() {
+
+      // When no spinner text is given, it should be undefined
+      element = compileCard('<pf-aggregate-status-card status="aggStatusAlt2" show-spinner="dataLoading"></pf-aggregate-status-card>', $scope);
+      cardClass = angular.element(element).find('.loading-text');
+      expect(cardClass.html()).toBeUndefined();
+
+      // When data is loading, spinner text should be present
+      $scope.dataLoading = true;
+      element = compileCard('<pf-aggregate-status-card status="aggStatusAlt2" show-spinner="dataLoading" spinner-text="Test Loading Message"></pf-aggregate-status-card>', $scope);
+      cardClass = angular.element(element).find('.loading-text');
+      expect(cardClass.html()).toContain('Test Loading Message');
+    });
+
+    it("should have a loading card height when specified", function() {
+
+      // When a height is specified it should be present
+      $scope.dataLoading = true;
+      element = compileCard('<pf-aggregate-status-card status="aggStatusAlt2" spinner-card-height="150" show-spinner="dataLoading" spinner-text="Test Loading Message"></pf-aggregate-status-card>', $scope);
+      cardClass = angular.element(element).find('.card-pf-body');
+      expect(cardClass.css('height')).toBe('150px');
+
+      // When a height is not specified there should be none
+      element = compileCard('<pf-aggregate-status-card status="aggStatusAlt2" show-spinner="dataLoading" spinner-text="Test Loading Message"></pf-aggregate-status-card>', $scope);
+      cardClass = angular.element(element).find('.card-pf-body');
+      expect(cardClass.css('height')).toBe('0px');
     });
 
     it("should show mini layout", function () {

--- a/test/card/info-status/info-status-card.component.spec.js
+++ b/test/card/info-status/info-status-card.component.spec.js
@@ -98,6 +98,49 @@ describe('Component: pfInfoStatusCard', function () {
       expect(cardClass).toBeFalsy();
     });
 
+    it("should show and hide the spinner", function() {
+
+      // When data is loaded, spinner should be hidden
+      $scope.dataLoading = false;
+      element = compileCard('<pf-info-status-card status="infoStatus2" show-spinner="dataLoading"></pf-info-status-card>', $scope);
+      cardClass = angular.element(element).find('.spinner-lg');
+      expect(cardClass.length).toBe(0);
+
+      // When data is loading, spinner should be present
+      $scope.dataLoading = true;
+      $scope.$digest();
+      cardClass = angular.element(element).find('.spinner-lg');
+      expect(cardClass.length).toBe(1);
+    });
+
+    it("should show and hide the spinner text", function() {
+
+      // When no spinner text is given, it should be undefined
+      element = compileCard('<pf-info-status-card status="infoStatus2" show-spinner="dataLoading"></pf-info-status-card>', $scope);
+      cardClass = angular.element(element).find('.loading-text');
+      expect(cardClass.html()).toBeUndefined();
+
+      // When data is loading, spinner text should be present
+      $scope.dataLoading = true;
+      element = compileCard('<pf-info-status-card status="infoStatus2" show-spinner="dataLoading" spinner-text="Test Loading Message"></pf-info-status-card>', $scope);
+      cardClass = angular.element(element).find('.loading-text');
+      expect(cardClass.html()).toContain('Test Loading Message');
+    });
+
+    it("should have a loading card height when specified", function() {
+
+      // When a height is specified it should be present
+      $scope.dataLoading = true;
+      element = compileCard('<pf-info-status-card status="infoStatus2" spinner-card-height="200px" show-spinner="dataLoading" spinner-text="Test Loading Message"></pf-info-status-card>', $scope);
+      cardClass = angular.element(element).find('.card-pf-body');
+      expect(cardClass.css('height')).toBe('200px');
+
+      // When a height is not specified there should be none
+      element = compileCard('<pf-info-status-card status="infoStatus2" show-spinner="dataLoading" spinner-text="Test Loading Message"></pf-info-status-card>', $scope);
+      cardClass = angular.element(element).find('.card-pf-body');
+      expect(cardClass.css('height')).toBe('0px');
+    });
+
     it('should set of the iconImage value', function () {
 
       $scope.status = {


### PR DESCRIPTION
## Description
Adding a loading state feature to the remaining pfCards as a continuation of PR #661. This would close #662 

[pfAggregateStatusCard](http://rawgit.com/amarie401/angular-patternfly/pf-cards-loading-dist/dist/docs/index.html#/api/patternfly.card.component:pfAggregateStatusCard)
[pfInfoStatusCard](http://rawgit.com/amarie401/angular-patternfly/pf-cards-loading-dist/dist/docs/index.html#/api/patternfly.card.component:pfInfoStatusCard)
[pfCards - Trends](http://rawgit.com/amarie401/angular-patternfly/pf-cards-loading-dist/dist/docs/index.html#/api/patternfly.card.component:pfCard%20-%20Trends) (example)

![loading-info](https://user-images.githubusercontent.com/20052391/32381013-006805ba-c088-11e7-828f-e9a17768148e.gif)

![loading-agg](https://user-images.githubusercontent.com/20052391/32381091-3c94d284-c088-11e7-938e-c1f822ff4d72.gif)

![loading-trends](https://user-images.githubusercontent.com/20052391/32381186-7cb27cc2-c088-11e7-95cd-e225da93e179.gif)


## PR Checklist

- [X] Unit tests are included
- [X] Screenshots are attached (if there are visual changes in the UI)
- [X] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [x] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
