### PR TITLE
fix(pfFilterPanel): Updated filter results at mobile

### DIFF
--- a/src/filters/examples/filter-panel.js
+++ b/src/filters/examples/filter-panel.js
@@ -59,24 +59,24 @@
       <div class="col-md-12">
         <div class="col-md-12 cfme-row-column">
           <div class="row">
-            <div class="col-md-2"><b>ID</b></div>
-            <div class="col-md-2"><b>Keyword</b></div>
-            <div class="col-md-4"><b>Category One</b></div>
-            <div class="col-md-4"><b>Category Two</b></div>
+            <div class="col-xs-3 col-md-2"><b>ID</b></div>
+            <div class="col-xs-3 col-md-2"><b>Keyword</b></div>
+            <div class="col-xs-3 col-md-4"><b>Category One</b></div>
+            <div class="col-sx-3 col-md-4"><b>Category Two</b></div>
           </div>
         </div>
         <div ng-repeat="item in items" class="col-md-12 cfme-row-column">
           <div class="row">
-             <div class="col-md-2">
+             <div class="col-xs-3 col-md-2">
                <span>{{item.id}}</span>
             </div>
-            <div class="col-md-2">
+            <div class="col-xs-3 col-md-2">
               <span>{{item.keyword}}</span>
             </div>
-            <div class="col-md-4">
+            <div class="col-xs-3 col-md-4">
               <span>{{item.categoryOne}}</span>
             </div>
-            <div class="col-md-4">
+            <div class="col-xs-3 col-md-4">
               <span>{{item.categoryTwo}}</span>
             </div>
           </div>

--- a/src/filters/examples/filter.js
+++ b/src/filters/examples/filter.js
@@ -34,57 +34,67 @@
  * @example
 <example module="patternfly.filters">
   <file name="index.html">
-    <div ng-controller="ViewCtrl" class="row example-container">
-      <div class="col-md-12">
-        <pf-filter id="exampleFilter" config="filterConfig"></pf-filter>
-      </div>
-      <hr class="col-md-12">
-      </br></br>
-      <div class="col-sm-4">
-        <form role="form">
-          <div class="form-group">
-            <label class="checkbox-inline">
-              <input type="checkbox" ng-model="filterConfig.inlineResults">Inline results</input>
-            </label>
-          </div>
-        </form>
-      </div>
-      <div class="col-sm-4">
-        <form role="form">
-          <div class="form-group">
-            <label class="checkbox-inline">
-              <input type="checkbox" ng-model="filterConfig.showTotalCountResults">Show total count in results</input>
-            </label>
-          </div>
-        </form>
-      </div>
-      <hr class="col-md-12">
-      <div class="col-md-12">
-        <label class="events-label">Valid Items: </label>
-      </div>
-      <div class="col-md-12">
-        <div ng-repeat="item in items" class="col-md-12 cfme-row-column">
-          <div class="row">
-            <div class="col-md-3">
-              <span>{{item.name}}</span>
-            </div>
-            <div class="col-md-7">
-              <span>{{item.address}}</span>
-            </div>
-            <div class="col-md-2">
-              <span>{{item.birthMonth}}</span>
-            </div>
-            <div class="col-md-4">
-              <span>{{item.car}}</span>
-            </div>
-          </div>
+    <div ng-controller="ViewCtrl" class="example-container">
+      <div class="row">
+        <div class="col-sm-12">
+          <pf-filter id="exampleFilter" config="filterConfig"></pf-filter>
         </div>
       </div>
-      <div class="col-md-12">
-        <label class="events-label">Current Filters: </label>
+      <div class="row">
+        <div class="col-xs-12">
+          <hr>
+        </div>
+        <div class="col-xs-4">
+          <form role="form">
+            <div class="form-group">
+              <label class="checkbox-inline">
+                <input type="checkbox" ng-model="filterConfig.inlineResults">Inline results</input>
+              </label>
+            </div>
+          </form>
+        </div>
+        <div class="col-xs-8">
+          <form role="form">
+            <div class="form-group">
+              <label class="checkbox-inline">
+                <input type="checkbox" ng-model="filterConfig.showTotalCountResults">Show total count in results</input>
+              </label>
+            </div>
+          </form>
+        </div>
       </div>
-      <div class="col-md-12">
-        <textarea rows="5" class="col-md-12">{{filtersText}}</textarea>
+      <div class="row">
+        <div class="col-xs-12">
+          <hr>
+        </div>
+        <div class="col-sm-12">
+          <label class="events-label">Valid Items: </label>
+        </div>
+      </div>
+      <div ng-repeat="item in items" class="row">
+        <div class="col-xs-6 col-sm-3">
+          <span>{{item.name}}</span>
+        </div>
+        <div class="col-xs-6 col-sm-4">
+          <span>{{item.address}}</span>
+        </div>
+        <div class="hidden-xs col-sm-2">
+          <span>{{item.birthMonth}}</span>
+        </div>
+        <div class="hidden-xs col-sm-3">
+          <span>{{item.car}}</span>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
+          <hr>
+        </div>
+        <div class="col-xs-12">
+          <label class="events-label">Current Filters: </label>
+        </div>
+        <div class="col-xs-12">
+          <textarea class="col-xs-12" rows="5">{{filtersText}}</textarea>
+        </div>
       </div>
     </div>
   </file>

--- a/src/filters/filter-panel/filter-panel-results.html
+++ b/src/filters/filter-panel/filter-panel-results.html
@@ -1,29 +1,25 @@
-<span class="filter-pf">
-  <span class="toolbar-pf-results">
+<div class="filter-pf">
+  <div class="toolbar-pf-results">
     <h5>
       {{$ctrl.config.resultsCount}}
       <span ng-if="$ctrl.config.appliedFilters.length"> of {{$ctrl.config.totalCount}}</span>
       {{$ctrl.config.resultsLabel === undefined ? "Results" : $ctrl.config.resultsLabel}}
     </h5>
-    <p ng-if="$ctrl.config.appliedFilters.length">Active filters:</p>
+    <p class="filter-pf-active-label" ng-if="$ctrl.config.appliedFilters.length">Active filters:</p>
     <ul class="list-inline">
-      <li ng-repeat="filter in $ctrl.config.appliedFilters">
-        <span ng-if="filter.values.length === 1" class="active-filter label label-info single-label">
-          <span class="pf-filter-label-category">{{filter.title}}:</span> {{filter.values[0]}}
-          <a><span ng-click="$ctrl.clearFilter(filter, filter.values[0])" class="pficon pficon-close"></span></a>
-        </span>
-        <span ng-if="filter.values.length > 1" class="active-filter label pf-filter-label-category">
-          {{filter.title}}:
-          <ul class="list-inline category-values">
-            <li ng-repeat="value in filter.values">
-              <span class="active-filter label label-info">{{value}}
-                <a><span ng-click="$ctrl.clearFilter(filter, value)" class="pficon pficon-close"></span></a>
-              </span>
-            </li>
-          </ul>
-        </span>
+      <li ng-repeat="filter in $ctrl.config.appliedFilters" class="filter-pf-category-item">
+      <span class="label pf-filter-category-label" ng-class="{'label-info': filter.values.length === 1, 'multiples': filter.values.length > 1}">
+        {{filter.title}}:
+        <ul class="list-inline filter-pf-category-values">
+          <li ng-repeat="value in filter.values">
+            <span class="label label-info">{{value}}
+              <a href="javascript:void(0);"><span ng-click="$ctrl.clearFilter(filter, value)" class="pficon pficon-close"></span></a>
+            </span>
+          </li>
+        </ul>
+      </span>
       </li>
     </ul>
-    <p class="clear-filters"><a href="javascript:void(0);" ng-click="$ctrl.clearAllFilters()" ng-if="$ctrl.config.appliedFilters.length > 0">Clear All Filters</a></p>
-  </span>
-</span>
+    <p><a href="javascript:void(0);" ng-click="$ctrl.clearAllFilters()" ng-if="$ctrl.config.appliedFilters.length > 0">Clear All Filters</a></p>
+  </div>
+</div>

--- a/src/filters/filter-panel/filter-panel-results.html
+++ b/src/filters/filter-panel/filter-panel-results.html
@@ -24,6 +24,6 @@
         </span>
       </li>
     </ul>
-    <p><a class="clear-filters" ng-click="$ctrl.clearAllFilters()" ng-if="$ctrl.config.appliedFilters.length > 0">Clear All Filters</a></p>
+    <p class="clear-filters"><a href="javascript:void(0);" ng-click="$ctrl.clearAllFilters()" ng-if="$ctrl.config.appliedFilters.length > 0">Clear All Filters</a></p>
   </span>
 </span>

--- a/src/filters/filter-panel/filter-panel.html
+++ b/src/filters/filter-panel/filter-panel.html
@@ -1,4 +1,4 @@
-<div class="filter-pf">
+<div class="filter-pf inline-filter-pf">
   <span class="dropdown primary-action" uib-dropdown>
     <button class="btn btn-default dropdown-toggle" uib-dropdown-toggle type="button">
       Filter

--- a/src/filters/filters.less
+++ b/src/filters/filters.less
@@ -1,26 +1,13 @@
 .filter-pf {
-  a {
-    cursor: pointer;
-  }
-  .input-group {
-    .input-group-btn {
-      .dropdown-menu>.selected>a {
-        background-color: @color-pf-blue !important;
-        border-color: #0076b7 !important;
-        color: @color-pf-white !important;
-      }
-    }
-  }
-  .category-select{
+  .category-select {
     display: flex;
   }
-  .category-select-value{
+  .category-select-value {
     border-left-width: 0 !important;
   }
 }
 .filter-pf.filter-fields {
   .form-group {
-    padding-left: 0;
     width: 275px;
   }
 }
@@ -45,6 +32,9 @@ pf-filter-panel {
     &:-ms-input-placeholder       { font-style: italic; padding-left: 10px; } // Internet Explorer 10+
     &::-webkit-input-placeholder  { font-style: italic; padding-left: 10px;} // Safari and Chrome
   }
+  .inline-filter-pf > .dropdown {
+    margin-right: 10px;
+  }
   .filter-panel-container {
     padding: 10px;
     .keyword-filter {
@@ -64,120 +54,56 @@ pf-filter-panel {
       }
     }
   }
-  .list-inline > li {
-    padding-right: 0;
-    padding-left: 0;
-    padding-bottom: 6px;
-    margin-right: 4px;
-    :last-child {
-      margin-right: 0px;
-    }
-    @media (min-width: @screen-md-min) {
-      padding-bottom: 2px;
-      padding-left: 5px;
-      margin-right: 0;
-    }
-  }
-  .toolbar-pf-results {
-    border-top: none;
-    margin-left: 10px;
-    vertical-align: middle;
-    .single-label {
-      padding: 6px;
-      padding-bottom: 6px;
-      @media (min-width: @screen-md-min) {
-        padding-bottom: 8px;
-      }
-      .pf-filter-label-category {
-        background-color: @color-pf-blue-500;
-        font-weight: 700;
-        padding-right: 2px;
-        padding-left: 0;
-        padding-bottom: 6px;
-      }
-      .pficon-close {
-        padding-right: 6px;
-      }
-    }
-    .clear-filters {
-      margin-top: -10px;
-      @media (min-width: @screen-md-min) {
-        margin-top: 0px;
-      }
-    }
-    p {
-      display: block;
-      padding-right: 10px;
-      padding-left: 0px;
-      @media (min-width: @screen-md-min) {
-        display: inline-block;
-        padding-left: 10px;
-      }
-    }
+}
+
+.filter-pf-active-label {
+  margin-right: 5px;
+}
+
+.filter-pf-category-item {
+  margin-bottom: 5px;
+}
+
+.pf-filter-category-label {
+  font-weight: 700;
+  padding: 5px 0 6px 5px;
+  margin-right: 5px;
+
+  &.multiples {
+    background-color: @color-pf-blue-300;
+    padding-right: 5px;
   }
 }
 
-.pf-filter-label-category {
-  background-color: @color-pf-blue-300;
-  font-weight: 700;
-  padding: 6px;
-  padding-bottom: 6px;
-  margin-right: 6px;
-  @media (min-width: @screen-md-min) {
-    margin-right: 2px;
-    padding-bottom: 8px;
-  }
-  .category-values {
-    padding-left: 4px;
+.filter-pf-category-values.list-inline {
+  margin-left: 0;
+  > li {
+    margin-left: 5px;
+    padding: 0;
   }
 }
+
 
 .filter-pf {
   &.inline-filter-pf {
-    flex: 1 1 100%;
-    margin: 15px 15px 7px 0;
-
     pf-filter-fields,
-    pf-filter-results {
+    pf-filter-results,
+    pf-filter-panel-results {
       display: inline-block;
     }
-
-    .form-group {
-      margin-bottom: 0;
-      margin-right: 15px;
+    pf-filter-fields {
+      vertical-align: middle;
     }
 
+    .filter-fields {
+      > .form-group {
+        margin-bottom: 3px;
+        margin-right: 15px;
+      }
+    }
     .toolbar-pf-results {
       border-top: none;
-      margin: 0;
-
-      .col-sm-12 {
-        float: left;
-        padding: 0;
-      }
-
-      h5,
-      p,
-      ul {
-        line-height: 1.43;
-        padding-bottom: 6px;
-        padding-top: 6px;
-      }
-
-      .list-inline {
-        margin-bottom: -5px;
-        padding-right: 5px;
-
-        > li {
-          margin-bottom: 5px;
-        }
-      }
-    }
-  }
-
-  .toolbar-pf-results {
-    .list-inline {
-      margin-left: 0;
+      margin-top: 0;
     }
   }
 }

--- a/src/filters/filters.less
+++ b/src/filters/filters.less
@@ -66,6 +66,17 @@ pf-filter-panel {
   }
   .list-inline > li {
     padding-right: 0;
+    padding-left: 0;
+    padding-bottom: 6px;
+    margin-right: 4px;
+    :last-child {
+      margin-right: 0px;
+    }
+    @media (min-width: @screen-md-min) {
+      padding-bottom: 2px;
+      padding-left: 5px;
+      margin-right: 0;
+    }
   }
   .toolbar-pf-results {
     border-top: none;
@@ -73,19 +84,35 @@ pf-filter-panel {
     vertical-align: middle;
     .single-label {
       padding: 6px;
+      padding-bottom: 6px;
+      @media (min-width: @screen-md-min) {
+        padding-bottom: 8px;
+      }
       .pf-filter-label-category {
         background-color: @color-pf-blue-500;
         font-weight: 700;
         padding-right: 2px;
         padding-left: 0;
+        padding-bottom: 6px;
       }
       .pficon-close {
         padding-right: 6px;
       }
     }
+    .clear-filters {
+      margin-top: -10px;
+      @media (min-width: @screen-md-min) {
+        margin-top: 0px;
+      }
+    }
     p {
+      display: block;
       padding-right: 10px;
-      padding-left: 10px;
+      padding-left: 0px;
+      @media (min-width: @screen-md-min) {
+        display: inline-block;
+        padding-left: 10px;
+      }
     }
   }
 }
@@ -94,6 +121,12 @@ pf-filter-panel {
   background-color: @color-pf-blue-300;
   font-weight: 700;
   padding: 6px;
+  padding-bottom: 6px;
+  margin-right: 6px;
+  @media (min-width: @screen-md-min) {
+    margin-right: 2px;
+    padding-bottom: 8px;
+  }
   .category-values {
     padding-left: 4px;
   }

--- a/src/filters/simple-filter/filter-results.html
+++ b/src/filters/simple-filter/filter-results.html
@@ -1,27 +1,25 @@
 <div class="filter-pf">
-  <div class="row toolbar-pf-results">
-    <div class="col-sm-12">
-      <span ng-if="$ctrl.config.showTotalCountResults !== true || $ctrl.config.totalCount === undefined || $ctrl.config.appliedFilters.length === 0">
-        <h5 ng-if="$ctrl.config.resultsCount === 1">{{$ctrl.config.resultsCount}} {{$ctrl.config.itemsLabel}}</h5>
-        <h5 ng-if="$ctrl.config.resultsCount !== 1">{{$ctrl.config.resultsCount}} {{$ctrl.config.itemsLabelPlural}}</h5>
+  <div class="toolbar-pf-results">
+    <span ng-if="$ctrl.config.showTotalCountResults !== true || $ctrl.config.totalCount === undefined || $ctrl.config.appliedFilters.length === 0">
+      <h5 ng-if="$ctrl.config.resultsCount === 1">{{$ctrl.config.resultsCount}} {{$ctrl.config.itemsLabel}}</h5>
+      <h5 ng-if="$ctrl.config.resultsCount !== 1">{{$ctrl.config.resultsCount}} {{$ctrl.config.itemsLabelPlural}}</h5>
+    </span>
+    <span ng-if="$ctrl.config.showTotalCountResults === true && $ctrl.config.totalCount !== undefined && $ctrl.config.appliedFilters.length > 0">
+      <h5 ng-if="$ctrl.config.totalCount === 1">{{$ctrl.config.resultsCount}} of {{$ctrl.config.totalCount}} {{$ctrl.config.itemsLabel}}</h5>
+      <h5 ng-if="$ctrl.config.totalCount !== 1">{{$ctrl.config.resultsCount}} of {{$ctrl.config.totalCount}} {{$ctrl.config.itemsLabelPlural}}</h5>
+    </span>
+    <p class="filter-pf-active-label" ng-if="$ctrl.config.appliedFilters.length > 0">Active Filters:</p>
+    <ul class="list-inline">
+      <li ng-repeat="filter in $ctrl.config.appliedFilters">
+      <span class="active-filter label label-info">
+        {{filter.title}}: {{((filter.value.filterCategory.title || filter.value.filterCategory) + filter.value.filterDelimiter + (filter.value.filterValue.title || filter.value.filterValue)) || filter.value.title || filter.value}}
+        <a href="javascript:void(0);"><span class="pficon pficon-close" ng-click="$ctrl.clearFilter(filter)"></span></a>
       </span>
-      <span ng-if="$ctrl.config.showTotalCountResults === true && $ctrl.config.totalCount !== undefined && $ctrl.config.appliedFilters.length > 0">
-        <h5 ng-if="$ctrl.config.totalCount === 1">{{$ctrl.config.resultsCount}} of {{$ctrl.config.totalCount}} {{$ctrl.config.itemsLabel}}</h5>
-        <h5 ng-if="$ctrl.config.totalCount !== 1">{{$ctrl.config.resultsCount}} of {{$ctrl.config.totalCount}} {{$ctrl.config.itemsLabelPlural}}</h5>
-      </span>
-      <p ng-if="$ctrl.config.appliedFilters.length > 0">Active Filters:</p>
-      <ul class="list-inline">
-        <li ng-repeat="filter in $ctrl.config.appliedFilters">
-          <span class="active-filter label label-info">
-            {{filter.title}}: {{((filter.value.filterCategory.title || filter.value.filterCategory) + filter.value.filterDelimiter + (filter.value.filterValue.title || filter.value.filterValue)) || filter.value.title || filter.value}}
-            <a><span class="pficon pficon-close" ng-click="$ctrl.clearFilter(filter)"></span></a>
-          </span>
-        </li>
-      </ul>
-      <p><a class="clear-filters" ng-click="$ctrl.clearAllFilters()" ng-if="$ctrl.config.appliedFilters.length > 0">Clear All Filters</a></p>
-      <div ng-if="$ctrl.config.selectedCount !== undefined && $ctrl.config.totalCount !== undefined" class="pf-table-view-selected-label">
-        <strong>{{$ctrl.config.selectedCount}}</strong> of <strong>{{$ctrl.config.totalCount}}</strong> selected
-      </div>
-    </div><!-- /col -->
-  </div><!-- /row -->
+      </li>
+    </ul>
+    <p><a href="javascript:void(0);" class="clear-filters" ng-click="$ctrl.clearAllFilters()" ng-if="$ctrl.config.appliedFilters.length > 0">Clear All Filters</a></p>
+    <div ng-if="$ctrl.config.selectedCount !== undefined && $ctrl.config.totalCount !== undefined" class="pf-table-view-selected-label">
+      <strong>{{$ctrl.config.selectedCount}}</strong> of <strong>{{$ctrl.config.totalCount}}</strong> selected
+    </div>
+  </div>
 </div>

--- a/styles/angular-patternfly.less
+++ b/styles/angular-patternfly.less
@@ -1,4 +1,5 @@
 @import "../node_modules/patternfly/dist/less/color-variables.less";
+@import "../node_modules/bootstrap/less/variables.less";
 @import "misc.less";
 @import "../src/card/card.less";
 @import "../src/charts/charts.less";

--- a/test/filters/filter-panel.spec.js
+++ b/test/filters/filter-panel.spec.js
@@ -152,7 +152,7 @@ describe('Directive:  pfFilterPanel', function () {
     expect(tagOne).toContain("Value 2");
     expect(tagOne).not.toContain("Value 3");
 
-    var clearAll = element.find('.clear-filters');
+    var clearAll = element.find('.clear-filters a');
     expect(clearAll.length).toBe(1);
     eventFire(clearAll[0], 'click');
     $scope.$digest();

--- a/test/filters/filter-panel.spec.js
+++ b/test/filters/filter-panel.spec.js
@@ -92,9 +92,10 @@ describe('Directive:  pfFilterPanel', function () {
     init();
 
     // [cateogry: [value 1 x] [value 2 x] ]
-    var categoryTags = element.find('.pf-filter-label-category');
+    var categoryTags = element.find('.pf-filter-category-label');
     var tagOne = angular.element(categoryTags[0]).text();
-    var tagOneValue = angular.element(element.find('.single-label')).text();
+    var tagValues = element.find('.label.label-info');
+    var tagOneValue = angular.element(tagValues[0]).text();
     var tagTwo = angular.element(categoryTags[1]).text();
     expect(categoryTags.length).toBe(2);
     expect(tagOne).toContain("Keyword");
@@ -125,7 +126,7 @@ describe('Directive:  pfFilterPanel', function () {
     init();
 
     // Filter Tag = [cateogry: [value 1 x] [value 2 x] ...]
-    var categoryTags = element.find('.pf-filter-label-category');
+    var categoryTags = element.find('.pf-filter-category-label');
     expect(categoryTags.length).toBe(2);
 
     var clearFilterLinks =  element.find('.pficon-close');
@@ -135,7 +136,7 @@ describe('Directive:  pfFilterPanel', function () {
     eventFire(clearFilterLinks[0], 'click');
     $scope.$digest();
 
-    categoryTags = element.find('.active-filter.label.pf-filter-label-category');
+    categoryTags = element.find('.label.pf-filter-category-label');
     expect(categoryTags.length).toBe(1);
 
     // Clear one of the Category One filters
@@ -152,9 +153,9 @@ describe('Directive:  pfFilterPanel', function () {
     expect(tagOne).toContain("Value 2");
     expect(tagOne).not.toContain("Value 3");
 
-    var clearAll = element.find('.clear-filters a');
-    expect(clearAll.length).toBe(1);
-    eventFire(clearAll[0], 'click');
+    var clearAll = element.find('.toolbar-pf-results > p');
+    expect(clearAll.length).toBe(2);
+    eventFire(clearAll[1], 'click');
     $scope.$digest();
 
     categoryTags = element.find('.active-filter.label.pf-filter-label-category');


### PR DESCRIPTION
## Description
This fixes #600 

Attempt to fix filter panel results and mobile and accessibility concerns.
Worked with Sarah M. and we determined there is no direct method to know when the 'Clear Filters' and filter results tags are going to wrap onto their own lines.   
Solution is that when screen size is less than medium, 'Apply Filters' and 'Clear Filters' become `block` elements and go to their own lines, and left aligned under Filter dropdown.  When screen size is greater than medium, they become `inline-blocks`:

**Screen size less than medium:**
![image](https://user-images.githubusercontent.com/12733153/32801524-5257d0d2-c94b-11e7-8f06-23f6a2f4a0e4.png)

**Screen size greater than medium:**
![image](https://user-images.githubusercontent.com/12733153/32801497-3e40b186-c94b-11e7-92ad-4e572734424c.png)

- Also added a `href` to the 'Clear Filters' link for accesibility.

## PR Checklist

- [X] Unit tests are included
- [X] Screenshots are attached (if there are visual changes in the UI)
- [X] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [X] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
