### PR TITLE
fix(pfTableView): fix access to invalid array item

### DIFF
--- a/src/table/tableview/table-view.component.js
+++ b/src/table/tableview/table-view.component.js
@@ -378,7 +378,7 @@ angular.module('patternfly.table').component('pfTableView', {
 
       for (i = 0; i < anNodes.length; ++i) {
         rowData = anNodes[i].cells;
-        if (rowData !== null) {
+        if (rowData !== null && rowData.length > ctrl.selectionMatchPropColNum) {
           visibleRows.push(_.trim(rowData[ctrl.selectionMatchPropColNum].innerText));
         }
       }


### PR DESCRIPTION
When there is no data in the array that populates the table, we see a row with just one column saying: "No data available in table". The `getVisibleRows()` function tries to access the row item using the value of `ctrl.selectionMatchPropColNum` as index but that index is invalid because `rowData` has only one item (the "No data available in table" item).
I added another check to the if statement to avoid accessing the array with an invalid index.
Fix #667 