### PR TITLE
fix(pfListView): wrong cursor in expanded area

### DIFF
--- a/src/views/listview/list-view.html
+++ b/src/views/listview/list-view.html
@@ -62,8 +62,8 @@
                ng-dblclick="$ctrl.dblClick($event, item)">
           </div>
         </div>
-        <div class="list-group-item-container container-fluid" ng-transclude="expandedContent" ng-if="$ctrl.config.useExpandingRows && item.isExpanded"></div>
       </div>
+      <div class="list-group-item-container container-fluid" ng-transclude="expandedContent" ng-if="$ctrl.config.useExpandingRows && item.isExpanded"></div>
     </div>
     <pf-pagination ng-if="$ctrl.pageConfig.showPaginationControls && $ctrl.config.itemsAvailable === true"
       page-size="$ctrl.pageConfig.pageSize"


### PR DESCRIPTION
Expanded area is incorrectly a child of the row header. They should be siblings.

fix #694 