### PR TITLE
fix(pfEmptyState): Do not redirect when no helpLink url specified

### DIFF
--- a/src/views/empty-state.component.js
+++ b/src/views/empty-state.component.js
@@ -107,7 +107,7 @@ angular.module('patternfly.views').component('pfEmptyState', {
   templateUrl: 'views/empty-state.html',
   controller: function ($filter) {
     'use strict';
-    var ctrl = this;
+    var ctrl = this, prevConfig;
 
     ctrl.defaultConfig = {
       title: 'No Items Available'
@@ -121,11 +121,23 @@ angular.module('patternfly.views').component('pfEmptyState', {
     };
 
     ctrl.updateConfig = function () {
+      prevConfig = angular.copy(ctrl.config);
       _.defaults(ctrl.config, ctrl.defaultConfig);
+      if (ctrl.config.helpLink && angular.isUndefined(ctrl.config.helpLink.url)) {
+        // if no url specified, set url to not redirect.  ie. just do urlAction
+        ctrl.config.helpLink.url = "javascript:void(0)";
+      }
     };
 
     ctrl.$onChanges = function (changesObj) {
       if ((changesObj.config && !changesObj.config.isFirstChange()) ) {
+        ctrl.updateConfig();
+      }
+    };
+
+    ctrl.$doCheck = function () {
+      // do a deep compare on config
+      if (!angular.equals(ctrl.config, prevConfig)) {
         ctrl.updateConfig();
       }
     };


### PR DESCRIPTION
## Description
When using the pfEmptyState component and specifying a `helpLink`, the `helpLink` will render a `<a>`.  The `helpLink` can have a `url` and/or a `urlAction`.  Problem was if `url` was not specified, it defaulted to `<a href`  which redirects to root `/`.  
This PR ensures that if no `helpLink.url` specified, that clicking on the `<a>` only executes the `urlAction` (ng-click), and does not redirect and change the browser url.  This is a requirement for OpenShift.

![image](https://user-images.githubusercontent.com/12733153/34725165-156c65bc-f51e-11e7-9997-7feb4aedb56b.png)
