### PR TITLE
fix(pfFilterPanel): make filter panel background semi-transparent

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -47,7 +47,7 @@
     "datatables.net": "^1.10.12",
     "datatables.net-select": "~1.2.0",
     "lodash": "4.x",
-    "patternfly": ">=3.27.2"
+    "patternfly": ">=3.36.0"
   },
   "devDependencies": {
     "angular-mocks": "1.5.*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4188,9 +4188,9 @@
       }
     },
     "jasmine-core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
-      "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.9.0.tgz",
+      "integrity": "sha1-v7tW3vzTB4mt7Fo/u6hQQjMonHI=",
       "dev": true
     },
     "jquery": {
@@ -6258,12 +6258,12 @@
       }
     },
     "patternfly": {
-      "version": "3.31.2",
-      "resolved": "https://registry.npmjs.org/patternfly/-/patternfly-3.31.2.tgz",
-      "integrity": "sha1-XqvBVjE/2plQhSuil8vnPdp/U2M=",
+      "version": "3.37.1",
+      "resolved": "https://registry.npmjs.org/patternfly/-/patternfly-3.37.1.tgz",
+      "integrity": "sha1-uYivPWcyyz0O26P347Eb8QFY7Uo=",
       "requires": {
         "bootstrap": "3.3.7",
-        "bootstrap-datepicker": "1.6.4",
+        "bootstrap-datepicker": "1.7.1",
         "bootstrap-sass": "3.3.7",
         "bootstrap-select": "1.12.4",
         "bootstrap-slider": "9.10.0",
@@ -6272,7 +6272,7 @@
         "c3": "0.4.18",
         "d3": "3.5.17",
         "datatables.net": "1.10.16",
-        "datatables.net-colreorder": "1.3.3",
+        "datatables.net-colreorder": "1.4.1",
         "datatables.net-colreorder-bs": "1.3.3",
         "datatables.net-select": "1.2.3",
         "drmonty-datatables-colvis": "1.1.2",
@@ -6282,7 +6282,7 @@
         "google-code-prettify": "1.0.5",
         "jquery": "3.2.1",
         "jquery-match-height": "0.7.2",
-        "moment": "2.14.1",
+        "moment": "2.20.1",
         "moment-timezone": "0.4.1",
         "patternfly-bootstrap-combobox": "1.1.7",
         "patternfly-bootstrap-treeview": "2.1.5"
@@ -6294,9 +6294,9 @@
           "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
         },
         "bootstrap-datepicker": {
-          "version": "1.6.4",
-          "resolved": "https://registry.npmjs.org/bootstrap-datepicker/-/bootstrap-datepicker-1.6.4.tgz",
-          "integrity": "sha1-iJ6+ztjqov8V7B8nPksHUxzEPaA=",
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/bootstrap-datepicker/-/bootstrap-datepicker-1.7.1.tgz",
+          "integrity": "sha1-Tuf680iI2+x4NPv52+fEJ34B3a8=",
           "optional": true,
           "requires": {
             "jquery": "3.2.1"
@@ -6369,9 +6369,9 @@
           }
         },
         "datatables.net-colreorder": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/datatables.net-colreorder/-/datatables.net-colreorder-1.3.3.tgz",
-          "integrity": "sha1-/HYuNQ+UIkyyzUXCuWImGg//73I=",
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/datatables.net-colreorder/-/datatables.net-colreorder-1.4.1.tgz",
+          "integrity": "sha1-OJ5LGidOIDl5o3GNhsWITQoBZrY=",
           "optional": true,
           "requires": {
             "datatables.net": "1.10.16",
@@ -6385,7 +6385,7 @@
           "optional": true,
           "requires": {
             "datatables.net-bs": "1.10.16",
-            "datatables.net-colreorder": "1.3.3",
+            "datatables.net-colreorder": "1.4.1",
             "jquery": "3.2.1"
           }
         },
@@ -6416,7 +6416,7 @@
           "requires": {
             "bootstrap": "3.3.7",
             "jquery": "3.2.1",
-            "moment": "2.14.1",
+            "moment": "2.20.1",
             "moment-timezone": "0.4.1"
           }
         },
@@ -6449,9 +6449,9 @@
           "optional": true
         },
         "moment": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz",
-          "integrity": "sha1-s1snxH5X7S3ccAU9awe+zbKRdBw="
+          "version": "2.20.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
+          "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
         },
         "moment-timezone": {
           "version": "0.4.1",
@@ -6459,7 +6459,7 @@
           "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
           "optional": true,
           "requires": {
-            "moment": "2.14.1"
+            "moment": "2.20.1"
           }
         },
         "patternfly-bootstrap-combobox": {
@@ -6481,9 +6481,9 @@
       }
     },
     "patternfly-eng-release": {
-      "version": "3.26.53",
-      "resolved": "https://registry.npmjs.org/patternfly-eng-release/-/patternfly-eng-release-3.26.53.tgz",
-      "integrity": "sha1-+TOVPaKuopK4e4Jlj/UO4Z2kaLs=",
+      "version": "3.26.54",
+      "resolved": "https://registry.npmjs.org/patternfly-eng-release/-/patternfly-eng-release-3.26.54.tgz",
+      "integrity": "sha1-+CAAmg3ViImpuU+f2JWu+JvlD8w=",
       "dev": true
     },
     "pause": {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "angular": "1.5.*",
     "angular-animate": "1.5.*",
     "angular-sanitize": "1.5.*",
-    "angular-ui-bootstrap": "2.3.x",
     "angular-svg-base-fix": "2.0.0",
+    "angular-ui-bootstrap": "2.3.x",
     "lodash": "4.x",
-    "patternfly": "^3.31.0"
+    "patternfly": "^3.37.1"
   },
   "devDependencies": {
     "angular-dragdrop": "1.0.13",
@@ -48,7 +48,7 @@
     "grunt-remove": "^0.1.0",
     "grunt-sass": "^2.0.0",
     "grunt-string-replace": "^1.3.1",
-    "jasmine-core": "^2.8.0",
+    "jasmine-core": "^2.9.0",
     "karma": "^1.7.1",
     "karma-chrome-launcher": "^2.2.0",
     "karma-firefox-launcher": "^1.0.1",
@@ -58,7 +58,7 @@
     "karma-phantomjs-launcher": "^1.0.4",
     "matchdep": "0.3.0",
     "nsp": "^2.6.1",
-    "patternfly-eng-release": "^3.26.35",
+    "patternfly-eng-release": "^3.26.54",
     "qs": "^1.0.0",
     "semantic-release": "^6.3.6",
     "send": "^0.11.1",

--- a/src/filters/filters.less
+++ b/src/filters/filters.less
@@ -25,6 +25,7 @@
 pf-filter-panel {
   .dropdown > .dropdown-menu, .input-group-btn > .dropdown-menu {
     margin-top: 5px;
+    opacity: .95;
   }
   input {
     &:-moz-placeholder            { font-style: italic; padding-left: 10px; } // Firefox 4-18


### PR DESCRIPTION
## Description
Make the filter panel background semi-transparent to see content under the panel.

Before:
![image](https://user-images.githubusercontent.com/12733153/35051244-cac280e0-fb72-11e7-9cd7-bd2c2705bd4d.png)

After:
![image](https://user-images.githubusercontent.com/12733153/35051252-cf568b38-fb72-11e7-8c02-b6d59a478d3b.png)

Related Issue: https://github.com/openshift/origin-web-catalog/issues/536

## PR Checklist

- [X] Screenshots are attached (if there are visual changes in the UI)
- [X] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [X] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
