### PR TITLE
fix(pfEmptyState): avoid 'unsafe:javascript(void)' for empty helpLink url

### DIFF
--- a/src/views/empty-state.component.js
+++ b/src/views/empty-state.component.js
@@ -123,10 +123,6 @@ angular.module('patternfly.views').component('pfEmptyState', {
     ctrl.updateConfig = function () {
       prevConfig = angular.copy(ctrl.config);
       _.defaults(ctrl.config, ctrl.defaultConfig);
-      if (ctrl.config && ctrl.config.helpLink && angular.isUndefined(ctrl.config.helpLink.url)) {
-        // if no url specified, set url to not redirect.  ie. just do urlAction
-        ctrl.config.helpLink.url = "javascript:void(0)";
-      }
     };
 
     ctrl.$onChanges = function (changesObj) {

--- a/src/views/empty-state.html
+++ b/src/views/empty-state.html
@@ -8,8 +8,10 @@
   <p id="blank-state-pf-info-{{$id}}" class="blank-state-pf-info" ng-if="$ctrl.config.info">
     {{$ctrl.config.info}}
   </p>
-  <p id="blank-state-pf-helpLink-{{$id}}" class="blank-state-pf-helpLink" ng-if="$ctrl.config.helpLink" ng-click="$ctrl.config.helpLink.urlAction()">
-    {{$ctrl.config.helpLink.label}} <a href="{{$ctrl.config.helpLink.url}}">{{$ctrl.config.helpLink.urlLabel}}</a>.
+  <p id="blank-state-pf-helpLink-{{$id}}" class="blank-state-pf-helpLink-label" ng-if="$ctrl.config.helpLink">
+    {{$ctrl.config.helpLink.label}}
+    <a ng-if="$ctrl.config.helpLink.url" class="blank-state-pf-helpLink" ng-click="$ctrl.config.helpLink.urlAction()" href="{{$ctrl.config.helpLink.url}}">{{$ctrl.config.helpLink.urlLabel}}</a>
+    <button ng-if="!$ctrl.config.helpLink.url" class="btn blank-state-pf-helpbutton btn-link" ng-click="$ctrl.config.helpLink.urlAction()">{{$ctrl.config.helpLink.urlLabel}}</button>.
   </p>
   <div ng-if="$ctrl.hasMainActions()" class="blank-slate-pf-main-action">
     <button class="btn btn-primary btn-lg"

--- a/src/views/views.less
+++ b/src/views/views.less
@@ -108,6 +108,11 @@
   button {
     margin-right: 4px;
   }
+  .blank-state-pf-helpbutton {
+    padding-left: 0;
+    padding-right: 0;
+    vertical-align: baseline;
+  }
 }
 /* overriding pf base so that buttons have spaces between them */
 .pf-expand-placeholder {

--- a/test/views/empty-state.spec.js
+++ b/test/views/empty-state.spec.js
@@ -74,7 +74,7 @@ describe('Component:  pfEmptyState', function () {
     expect(element.find('.pficon-add-circle-o').length).toBe(1);
     expect(element.find('.blank-state-pf-title').text()).toContain('Empty State Title');
     expect(element.find('.blank-state-pf-info').text()).toContain('This is the Empty State component');
-    expect(element.find('.blank-state-pf-helpLink').text()).toContain('For more information please see');
+    expect(element.find('.blank-state-pf-helpLink-label').text()).toContain('For more information please see');
     expect(element.find('a').text()).toContain('pfExample');
     expect(element.find('a').prop('href')).toContain('#/api/patternfly.views.component:pfEmptyState');
     element.find('.blank-state-pf-helpLink').click();


### PR DESCRIPTION
## Description
When `config.helplink.url` isn't specified, we were using `javascript:void()` in order to avoid the `<a href` from redirecting.  Unfortunately, angularjs adds a `unsafe:javascript:void()`.   To avoid this, we now use a `button` if `config.helplink.url` isn't specified.
Also moved the `ng-click` from the parent `<p>` to the `<a>` or the `<button>`
