### PR TITLE
fix(pfEmptyState): remove period "." after helplink

### DIFF
--- a/src/views/empty-state.html
+++ b/src/views/empty-state.html
@@ -11,7 +11,7 @@
   <p id="blank-state-pf-helpLink-{{$id}}" class="blank-state-pf-helpLink-label" ng-if="$ctrl.config.helpLink">
     {{$ctrl.config.helpLink.label}}
     <a ng-if="$ctrl.config.helpLink.url" class="blank-state-pf-helpLink" ng-click="$ctrl.config.helpLink.urlAction()" href="{{$ctrl.config.helpLink.url}}">{{$ctrl.config.helpLink.urlLabel}}</a>
-    <button ng-if="!$ctrl.config.helpLink.url" class="btn blank-state-pf-helpbutton btn-link" ng-click="$ctrl.config.helpLink.urlAction()">{{$ctrl.config.helpLink.urlLabel}}</button>.
+    <button ng-if="!$ctrl.config.helpLink.url" class="btn blank-state-pf-helpbutton btn-link" ng-click="$ctrl.config.helpLink.urlAction()">{{$ctrl.config.helpLink.urlLabel}}</button>
   </p>
   <div ng-if="$ctrl.hasMainActions()" class="blank-slate-pf-main-action">
     <button class="btn btn-primary btn-lg"


### PR DESCRIPTION
## Description

Removed extra period after helplink:

**Before:**
![image](https://user-images.githubusercontent.com/12733153/35448950-b57bad2e-0289-11e8-95bc-7c48ac84a3d0.png)


**After**
![image](https://user-images.githubusercontent.com/12733153/35448906-92942f5c-0289-11e8-8608-a99771e15ddf.png)

