### PR TITLE
fix(pfFilterResults): Do not output ul.list-inline when no active fil…

### DIFF
--- a/src/filters/simple-filter/filter-results.html
+++ b/src/filters/simple-filter/filter-results.html
@@ -9,7 +9,7 @@
       <h5 ng-if="$ctrl.config.totalCount !== 1">{{$ctrl.config.resultsCount}} of {{$ctrl.config.totalCount}} {{$ctrl.config.itemsLabelPlural}}</h5>
     </span>
     <p class="filter-pf-active-label" ng-if="$ctrl.config.appliedFilters.length > 0">Active Filters:</p>
-    <ul class="list-inline">
+    <ul class="list-inline" ng-if="$ctrl.config.appliedFilters.length > 0">
       <li ng-repeat="filter in $ctrl.config.appliedFilters">
       <span class="active-filter label label-info">
         {{filter.title}}: {{((filter.value.filterCategory.title || filter.value.filterCategory) + filter.value.filterDelimiter + (filter.value.filterValue.title || filter.value.filterValue)) || filter.value.title || filter.value}}


### PR DESCRIPTION
…ters

## Description
Resolve bug where empty ul.list-inline in .toolbar-pf-results of pf-filter-results directive causes display bug in Firefox.

Fixes #708 

Before:
![screen shot 2018-02-01 at 9 58 04 am](https://user-images.githubusercontent.com/895728/35685004-773cf016-0736-11e8-9138-d865ddb9599b.PNG)

After:
![screen shot 2018-02-01 at 9 58 10 am](https://user-images.githubusercontent.com/895728/35685015-7dbab96e-0736-11e8-839a-58e86dd55d7f.PNG)


