### PR TITLE
chore(pfToolbar): updated ngdoc with 'no filter results' empty state instead of 'No Items Available'

### DIFF
--- a/src/toolbars/examples/toolbar.js
+++ b/src/toolbars/examples/toolbar.js
@@ -84,7 +84,7 @@
         <pf-list-view config="listConfig"
                       page-config="pageConfig"
                       items="items"
-                      empty-state-config="emptyStateConfig">
+                      empty-state-config="items.length === 0 && filterConfig.appliedFilters.length > 0 ? noItemsConfig : emptyStateConfig">
           <div class="list-view-pf-description">
             <div class="list-group-item-heading">
               {{item.name}}
@@ -107,7 +107,7 @@
         <pf-card-view config="listConfig"
                       page-config="pageConfig"
                       items="items"
-                      empty-state-config="emptyStateConfig">
+                      empty-state-config="items.length === 0 && filterConfig.appliedFilters.length > 0 ? noItemsConfig : emptyStateConfig">
           <div class="col-md-12">
             <span>{{item.name}}</span>
           </div>
@@ -124,7 +124,7 @@
                        page-config="pageConfig"
                        columns="columns"
                        items="items"
-                       empty-state-config="emptyStateConfig">
+                       empty-state-config="items.length === 0 && filterConfig.appliedFilters.length > 0 ? noItemsConfig : emptyStateConfig">
         </pf-table-view>
       </div>
       <hr class="col-md-12">
@@ -285,6 +285,11 @@
         } else {
           $scope.items = $scope.allItems;
         }
+      };
+
+      var clearFilters = function() {
+        filterChange([]);
+        $scope.filterConfig.appliedFilters = [];
       };
 
       var filterChange = function (filters) {
@@ -485,6 +490,15 @@
            label: 'For more information please see',
            urlLabel: 'pfExample',
            url : '#/api/patternfly.views.component:pfEmptyState'
+        }
+      };
+
+      $scope.noItemsConfig = {
+        title: 'No Results Match the Filter Criteria',
+        info: 'The active filters are hiding all items.',
+        helpLink: {
+          urlLabel: 'Clear All Filters',
+          urlAction: clearFilters
         }
       };
 


### PR DESCRIPTION
## Description
Fix Issue [https://github.com/patternfly/angular-patternfly/issues/693](https://github.com/patternfly/angular-patternfly/issues/693)
Add an empty state div with the messaging for 0 filtered results to differentiate that of an actual empty set based on the patternfly docs listed in the issue.

**Before**:

![before](https://user-images.githubusercontent.com/35978579/36168510-5565024a-10c7-11e8-9057-ec3269988296.png)

**After**:

![after2](https://user-images.githubusercontent.com/35978579/36224252-056c0436-1195-11e8-8268-f6f9efcb42ce.png)


## PR Checklist

- [ ] Unit tests are included
- [x] Screenshots are attached (if there are visual changes in the UI)
- [x] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [ ] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
