### PR TITLE
chore(pfTableView): Fix compile warnings

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -136,7 +136,9 @@ module.exports = function (grunt) {
         }
       },
       lessToSass: {
+        /* eslint-disable */
         convert_within_custom_replacements: {
+          /* eslint-enable */
           files: [
             {
               expand: true,

--- a/src/table/tableview/examples/table-view-basic.js
+++ b/src/table/tableview/examples/table-view-basic.js
@@ -1,10 +1,10 @@
 /**
   * @ngdoc directive
-  * @name patternfly.table.component:pfTableView - Basic
+  * @name patternfly.table.component:pfTableView-Basic
   *
   * @description
   * Component for rendering a simple table view.<br><br>
-  * See {@link patternfly.table.component:pfTableView%20-%20with%20Toolbar pfTableView - with Toolbar} for use with a Toolbar<br>
+  * See {@link patternfly.table.component:pfTableView-with-Toolbar pfTableView - with Toolbar} for use with a Toolbar<br>
   * See {@link patternfly.toolbars.component:pfToolbar pfToolbar} for use in Toolbar View Switcher
   *
   * @param {object} config Optional configuration object

--- a/src/table/tableview/examples/table-view-with-toolbar.js
+++ b/src/table/tableview/examples/table-view-with-toolbar.js
@@ -1,6 +1,6 @@
 /**
  * @ngdoc directive
- * @name patternfly.table.component:pfTableView - with Toolbar
+ * @name patternfly.table.component:pfTableView-with-Toolbar
  *
  * @description
  * Example configuring a table view with a toolbar.<br><br>


### PR DESCRIPTION
1. For ngdoc linking to pfTableView with Toolbar due to spaces. Omit spaces in ngdoc @name so links are not throwing warnings

2. Fix non camel case lint error in Gruntfile.js: Omit the check for camel case function for convert_within_custom_replacements task.

## Description
The goal of this pr is to omit all warnings from the build, and is a fix for:
https://github.com/patternfly/angular-patternfly/issues/713
No coding changes for unit test coverage, no visual changes needing screenshots, a designer or css rep.

## PR Checklist

- [ ] Unit tests are included
- [ ] Screenshots are attached (if there are visual changes in the UI)
- [ ] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [ ] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
