### PR TITLE
fix(pfTableView): Fixed sort col when show/hiding checkbox col

### DIFF
--- a/src/table/tableview/examples/table-view-basic.js
+++ b/src/table/tableview/examples/table-view-basic.js
@@ -103,7 +103,9 @@
   angular.module('patternfly.tableview.demo').controller('TableCtrl', ['$scope', '$timeout', 'itemsService',
   function ($scope, $timeout, itemsService) {
           $scope.dtOptions = {
-            order: [[2, "asc"]],
+            // order column(s) should NOT account for 1st checkbox column, table component will adjust col. numbers accordingly
+            // Sort by City, then Name
+            order: [[3, "asc"], [1, "desc"]],
           };
 
           $scope.columns = [

--- a/src/table/tableview/table-view.component.js
+++ b/src/table/tableview/table-view.component.js
@@ -14,7 +14,7 @@ angular.module('patternfly.table').component('pfTableView', {
   templateUrl: 'table/tableview/table-view.html',
   controller: function (DTOptionsBuilder, DTColumnDefBuilder, $element, pfUtils, $log, $filter, $timeout, $sce) {
     'use strict';
-    var ctrl = this, prevDtOptions, prevItems, prevPageConfig;
+    var ctrl = this, prevDtOptions, prevItems, prevPageConfig, prevShowCheckboxes;
 
     // Once datatables is out of active development I'll remove log statements
     ctrl.debug = false;
@@ -25,7 +25,7 @@ angular.module('patternfly.table').component('pfTableView', {
     ctrl.defaultDtOptions = {
       autoWidth: false,
       destroy: true,
-      order: [[1, "asc"]],
+      order: [[0, "asc"]],  //default to 1st (col 0) for sorting, updateConfigOptions() will adjust based on showCheckboxes
       dom: "t",
       paging: false,
       select: {
@@ -117,20 +117,23 @@ angular.module('patternfly.table').component('pfTableView', {
         ctrl.dtOptions.displayLength = Number(ctrl.dtOptions.displayLength);
       }
 
+      _.defaults(ctrl.dtOptions, ctrl.defaultDtOptions);
+      _.defaults(ctrl.config, ctrl.defaultConfig);
+
+      if (ctrl.config.showCheckboxes !== prevShowCheckboxes) {
+        // adjust column numbers based on whether or not there is a checkbox column
+        // multi-col order may be used.  Ex:  [[ 0, 'asc' ], [ 1, 'desc' ]]
+        _.each(ctrl.dtOptions.order, function (col) {
+          col[0] = ctrl.config.showCheckboxes ? col[0] + 1 : col[0] - 1;
+          col[0] = col[0] < 0 ? 0 : col[0];  //no negative col numbers
+        });
+      }
+
       // Need to deep watch changes in dtOptions and items
       prevDtOptions = angular.copy(ctrl.dtOptions);
       prevItems = angular.copy(ctrl.items);
       prevPageConfig = angular.copy(ctrl.pageConfig);
-
-      // Setting bound variables to new variables loses it's one way binding
-      //   ctrl.dtOptions = pfUtils.merge(ctrl.defaultDtOptions, ctrl.dtOptions);
-      //   ctrl.config = pfUtils.merge(ctrl.defaultConfig, ctrl.config);
-
-      // Instead, use _.defaults to update the existing variable
-      _.defaults(ctrl.dtOptions, ctrl.defaultDtOptions);
-      _.defaults(ctrl.config, ctrl.defaultConfig);
-      // may need to use _.defaultsDeep, but not currently available in
-      // lodash-amd a-pf is using
+      prevShowCheckboxes = angular.copy(ctrl.config.showCheckboxes);
 
       if (!validSelectionMatchProp()) {
         angular.forEach(ctrl.columns, function (col) {


### PR DESCRIPTION
## Description
Fixes #715  
@akieling

Previously, the sort column was 'hard coded' regardless of whether the first checkbox column was shown or hidden:

**Initial View:**
![image](https://user-images.githubusercontent.com/12733153/36396704-72b31c86-158d-11e8-87d6-da458bc7dff2.png)

**After Turn Off Checkbox Column:**
![image](https://user-images.githubusercontent.com/12733153/36396714-7cdc7d1a-158d-11e8-8b84-65d083f01332.png)

**After Fix, sort column does not change:**

![image](https://user-images.githubusercontent.com/12733153/36396816-f521550c-158d-11e8-8e51-3d2992a606df.png)
![image](https://user-images.githubusercontent.com/12733153/36396823-fa6429b8-158d-11e8-9a63-baf2072012ee.png)

* Tested and Works with multiple column sorts as well.

## PR Checklist

- [ ] Unit tests are included
- [X] Screenshots are attached (if there are visual changes in the UI)
- [ ] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [ ] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
