### PR TITLE
fix(pfVerticalNavigation): Fixed resizing not hiding/showing the navigation correctly

### DIFF
--- a/src/navigation/vertical-navigation.component.js
+++ b/src/navigation/vertical-navigation.component.js
@@ -15,7 +15,7 @@ angular.module('patternfly.navigation').component('pfVerticalNavigation', {
   //replace: true,
   templateUrl: 'navigation/vertical-navigation.html',
   transclude: true,
-  controller: function ($window, $timeout, $injector, $location, $rootScope) {
+  controller: function ($window, $timeout, $injector, $location, $rootScope, $scope) {
     'use strict';
     var routeChangeListener,
       ctrl = this,
@@ -552,6 +552,8 @@ angular.module('patternfly.navigation').component('pfVerticalNavigation', {
       // Need to bind to resize event
       angular.element($window).on('resize', function () {
         checkNavState();
+        // Trigger a digest to apply any updates done above
+        $scope.$digest();
       });
     };
 

--- a/test/navigation/vertical-navigation.spec.js
+++ b/test/navigation/vertical-navigation.spec.js
@@ -19,7 +19,7 @@ describe('Component:  pfVerticalNavigation', function () {
     $compile(element)(scope);
 
     scope.$digest();
-    isolateScope = element.isolateScope();
+    isolateScope = element.find("pf-vertical-navigation").isolateScope();
   };
 
   beforeEach(function () {
@@ -697,6 +697,13 @@ describe('Component:  pfVerticalNavigation', function () {
       wellDefinedItem.click();
     }).toThrow(new Error("uiSref is defined on item, but no $state has been injected. Did you declare a dependency on \"ui.router\" module in your app?"));
   });
+
+  it('should trigger a $digest when resizing', inject(function($window) {
+    spyOn(isolateScope, '$digest');
+    $window.innerWidth = 767;
+    angular.element($window).triggerHandler('resize');
+    expect(isolateScope.$digest).toHaveBeenCalled();
+  }));
 });
 
 
@@ -749,7 +756,7 @@ describe('Directive:  pfVerticalNavigation with ui.router', function () {
     $compile(element)(scope);
 
     scope.$digest();
-    isolateScope = element.isolateScope();
+    isolateScope = element.find("pf-vertical-navigation").isolateScope();
   };
 
   beforeEach(function () {


### PR DESCRIPTION
Fixes #728

## Description
Fixes an issue with the vertical navigation, where the classes won't be updated when resizing based on the ng-class definition. This was causing the navigation to remain shown when resizing to a smaller window and then remaining hidden when resizing back to a larger screen, until some event in the application caused a $digest to occur. Upon investigating the issue, this is caused by the resize event handler being processed outside of AngularJS's context and therefore won't trigger any watchers and won't update the classes based on the ng-class definition.

Note: This is actually a regression between 3.x -> 4.x, though I've fixed this in a slightly different way to 3.x, so that this only triggers a digest on the isolated component scope, instead of the root scope. This approach means it should be better for performance, as it only needs to evaluate the watchers in the component scope, instead of evaluating all watchers.

## PR Checklist

- [x] Unit tests are included
- [x] Screenshots are attached (if there are visual changes in the UI)
- [ ] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
- [ ] A CSS rep (@cshinn) is assigned as a reviewer (if there are visual changes in the UI)
