### PR TITLE
Fix for #740: pfTableView-with-Toolbar: cannot select all rows after clearing filters

### DIFF
--- a/src/table/tableview/examples/table-view-with-toolbar.js
+++ b/src/table/tableview/examples/table-view-with-toolbar.js
@@ -360,6 +360,9 @@
         } else {
           $scope.items = $scope.allItems;
         }
+        if (filters && (filters.length === 0 || filters.length > 1)) {
+          $scope.addNewComponentToDOM();
+        }
       };
 
       var filterChange = function (filters) {


### PR DESCRIPTION
Hi @alexkieling,
The 'Select All' table checkbox seems to lose binding to the controller's 'toggleAll()' method after (a) clearing all or any one filter or (b) applying a second filter.  I spent an entire afternoon trying to figure out why this is happening; trying many suggested solutions such as changing to `ng-click` or using an object for the `ng-model` value.
The only solution I could find is calling `addNewComponentToDOM()` for the usecases mentioned above.  This is not ideal, as the entire table is redrawn in those situations.  However, the controller bindings continue to work after multiple filters are applied or cleared.

As you can see, applying the first filter doesn't cause the table to be redrawn, however adding multiple filters or clearing filters will cause the redraw:

![table-select-all-w-filters](https://user-images.githubusercontent.com/12733153/41001682-aa540a1a-68df-11e8-8355-479b90114bdd.gif)

This is somewhat of a work-around as nothing has changed in the actual TableView component, just in the ngDoc example, so feel free to use the suggested solution if it's acceptable to you.

Fixes #740 ? :-)

Thanks,
- Dave

