### PR TITLE
pfVerticalNavigation: on mobile, move the masthead utility items to the vertical navigation

### DIFF
--- a/src/navigation/examples/vertical-navigation-basic.js
+++ b/src/navigation/examples/vertical-navigation-basic.js
@@ -35,6 +35,8 @@
  *   <li>.tooltip      - (string) Tooltip to display for the badge
  *   <li>.badgeClass:  - (string) Additional class(es) to add to the badge container
  *   </ul>
+ * <li>.mobileOnly     - (boolean) When set to 'true', menu item will only be displayed when browser is in mobile mode (<768px).
+ * When <code>ignoreMobile</code> flag set to 'true', <code>mobileOnly</code> items are not displayed.
  * </ul>
  * @param {function} navigateCallback function(item) Callback method invoked on a navigation item click (one with no submenus)
  * @param {function} itemClickCallback function(item) Callback method invoked on an item click
@@ -76,7 +78,7 @@
               <span class="caret"></span>
             </a>
             <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
-              <li><a href="#">Preferences</a></li>
+              <li><a href="#">User Preferences</a></li>
               <li><a href="#">Logout</a></li>
             </ul>
           </li>
@@ -392,9 +394,19 @@
            href: "#/adipscing"
         },
         {
-           title: "Lorem",
-           iconClass: "fa fa-gamepad",
-           href: "#/lorem"
+           title: "Help",
+           iconClass: "fa pficon-help",
+           href: "#/help",
+           mobileOnly: true
+        },
+        {
+           title: "User",
+           iconClass: "fa pficon-user",
+           mobileOnly: true,
+           children: [
+              { title: "User Preferences" },
+              { title: "Logout" }
+           ]
         },
         {
            title: "Exit Demo"

--- a/src/navigation/examples/vertical-navigation-router.js
+++ b/src/navigation/examples/vertical-navigation-router.js
@@ -26,6 +26,8 @@
  *   </ul>
  * <li>.uiSref         - (string) Optional Angular UI Router state name. If specified, href must be not defined, and vice versa.
  * <li>.uiSrefOptions  - (object) Optional object to be passed to Angular UI Router $state.go() function
+ * <li>.mobileOnly     - (boolean) When set to 'true', menu item will only be displayed when browser is in mobile mode (<768px).
+ * When <code>ignoreMobile</code> flag set to 'true', <code>mobileOnly</code> items are not displayed.
  * </ul>
  * @param {function} navigateCallback function(item) Callback method invoked on a navigation item click (one with no submenus)
  * @param {function} itemClickCallback function(item) Callback method invoked on an item click
@@ -67,7 +69,7 @@
                 <span class="caret"></span>
               </a>
               <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
-                <li><a href="#">Preferences</a></li>
+                <li><a href="#">User Preferences</a></li>
                 <li><a href="#">Logout</a></li>
               </ul>
             </li>
@@ -125,6 +127,36 @@
                                 </p>\
                               </div>\
                             </div>'
+            })
+            .state('help', {
+                url: '/help',
+                template: '<div class="card-pf card-pf-accented card-pf-aggregate-status" style="height: 89px;">\
+                              <div class="card-pf-body" style="height: 50px;">\
+                                <p class="card-pf-aggregate-status-notifications">\
+                                  State: Help\
+                                </p>\
+                              </div>\
+                            </div>'
+            })
+            .state('user-prefs', {
+                url: '/help',
+                template: '<div class="card-pf card-pf-accented card-pf-aggregate-status" style="height: 89px;">\
+                              <div class="card-pf-body" style="height: 50px;">\
+                                <p class="card-pf-aggregate-status-notifications">\
+                                  State: User Preferences\
+                                </p>\
+                              </div>\
+                            </div>'
+            })
+            .state('logout', {
+                url: '/help',
+                template: '<div class="card-pf card-pf-accented card-pf-aggregate-status" style="height: 89px;">\
+                              <div class="card-pf-body" style="height: 50px;">\
+                                <p class="card-pf-aggregate-status-notifications">\
+                                  State: Logout\
+                                </p>\
+                              </div>\
+                            </div>'
             });
     })
       .controller('vertNavWithRouterController', ['$scope',
@@ -145,6 +177,21 @@
               title: "Ipsum",
               iconClass : "fa fa-space-shuttle",
               uiSref: "ipsum"
+            },
+            {
+               title: "Help",
+               iconClass: "fa pficon-help",
+               uiSref: "help",
+               mobileOnly: true
+            },
+            {
+               title: "User",
+               iconClass: "fa pficon-user",
+               mobileOnly: true,
+               children: [
+                  { title: "User Preferences", uiSref: "user-prefs" },
+                  { title: "Logout", uiSref: "logout" }
+               ]
             },
             {
               title: "Exit Demo"

--- a/src/navigation/vertical-navigation.html
+++ b/src/navigation/vertical-navigation.html
@@ -35,7 +35,8 @@
                        'active': item.isActive,
                        'is-hover': item.isHover,
                        'mobile-nav-item-pf': item.isMobileItem && $ctrl.showMobileSecondary,
-                       'mobile-secondary-item-pf': item.isMobileItem && $ctrl.showMobileTertiary}"
+                       'mobile-secondary-item-pf': item.isMobileItem && $ctrl.showMobileTertiary,
+                       'visible-xs': item.mobileOnly}"
             ng-mouseenter="$ctrl.handlePrimaryHover(item)" ng-mouseleave="$ctrl.handlePrimaryUnHover(item)">
           <a ng-click="$ctrl.handlePrimaryClick(item, $event)">
             <span class="{{item.iconClass}}" ng-if="item.iconClass" ng-class="{hidden: $ctrl.hiddenIcons}"


### PR DESCRIPTION
## Description
Added a `mobileOnly` property to nav. item objects; when 'true' items only display in mobile mode. 
Addresses: #745 

Ex: The **Help** and **User** vert. nav items only appear when in mobile (< 768px) mode, and are hidden when not in mobile mode:
![mobileonly](https://user-images.githubusercontent.com/12733153/41430999-96a34efc-6fdf-11e8-98a9-54bfaa9fc0da.gif)

Note the masthead utility items (Help & User dropdowns) continue to be hidden at mobile; this PR allows app devs to mimic them 'moving' to the vert nav menu.

@alexkieling

## PR Checklist
- [x] Screenshots are attached (if there are visual changes in the UI)
- [x] A Designer (@beanh66) is assigned as a reviewer (if there are visual changes in the UI)
