### PR TITLE
chore(pfNotificationDrawer): Updated ngDoc example

### DIFF
--- a/src/notification/examples/notification-drawer.js
+++ b/src/notification/examples/notification-drawer.js
@@ -102,7 +102,7 @@
  </file>
  <file name="notification-body.html">
    <div uib-dropdown class="dropdown pull-right dropdown-kebab-pf" ng-if="notification.actions && notification.actions.length > 0">
-     <button uib-dropdown-toggle class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+     <button uib-dropdown-toggle class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight-{{ notification.uid }}" aria-haspopup="true" aria-expanded="true">
        <span class="fa fa-ellipsis-v"></span>
      </button>
      <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebabRight">


### PR DESCRIPTION
## Description
Fixes #759

In pfNotificationDrawer's ngDoc's `notification-body.html` example:
* Fixed the `dropdownKebabRight` ID in the repeated region to use unique ids.
* Removed the `dropdown-toggle` attribute on the `<button>` because it [conflicts](https://github.com/angular-ui/bootstrap/issues/2156#issuecomment-42399777)  with the JS provided by bootstrap for certain customers.
