### PR TITLE
fix(pfTableView): dropdown buttons shorter than table cells

### DIFF
--- a/src/table/table.less
+++ b/src/table/table.less
@@ -44,3 +44,6 @@ table.dataTable {
 .table-view-pf-select {
   width: 13px;
 }
+.table-view-pf-actions .dropup {
+  height: 100%;
+}

--- a/src/table/tableview/table-view.component.js
+++ b/src/table/tableview/table-view.component.js
@@ -21,6 +21,7 @@ angular.module('patternfly.table').component('pfTableView', {
 
     ctrl.selectAll = false;
     ctrl.dtInstance = {};
+    ctrl.dropdownClass = 'dropdown';
 
     ctrl.defaultDtOptions = {
       autoWidth: false,


### PR DESCRIPTION
## Description
Fix issue #762:
* defines height 100% for elements with class `dropup`
* sets default class to `dropdown`
