### PR TITLE
Bump version to 4.18.7 in master-dist for npm publication

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-patternfly",
-  "version": "0.0.0-semantically-released",
+  "version": "4.18.7",
   "authors": [
     "Red Hat"
   ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Red Hat",
   "name": "angular-patternfly",
-  "version": "0.0.0-semantically-released",
+  "version": "4.18.7",
   "license": "MIT",
   "description": "Angular extension of the PatternFly project.",
   "keywords": [


### PR DESCRIPTION
Last PR for MIT licensing change didn't get published correctly, failed with:
```
+merge_prereqs
+echo *** This build is running against patternfly/angular-patternfly
*** This build is running against patternfly/angular-patternfly
+cd /home/travis/build/patternfly/angular-patternfly
+[ 767 != false -o -n  ]
+echo *** This build is running against a pull request or tag! Exiting...
*** This build is running against a pull request or tag! Exiting...
+exit 0
+check 0 Publish failure
+[ 0 != 0 ]
+check 0 Semantic release failure
+[ 0 != 0 ]
The command "sh -x ./node_modules/patternfly-eng-release/scripts/_build.sh -a" exited with 0.
```
Manually updating version.
Fixes #769 