### PR TITLE
fix(Sass): datepicker & vertical-navigation were missing

### DIFF
--- a/styles/_angular-patternfly.scss
+++ b/styles/_angular-patternfly.scss
@@ -13,4 +13,6 @@
 @import 'canvas';
 @import 'canvas-editor';
 @import 'pagination';
+@import 'datepicker';
 @import 'modal-overlay';
+@import 'vertical-navigation';


### PR DESCRIPTION
## Description
Fix for issue #772 

`datepicker` and `vertical-navigation` were already in the main Less file `angular-patternfly.less`, but missed out from the Sass file `_angular-patternfly.scss`.
